### PR TITLE
Allow usage behind a protected reverse proxy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#191f2c" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta


### PR DESCRIPTION
Hello, great work !

I tried running it behind a proxy, which was checking that the user was correctly authenticated.

Unfortunately, only the `site.webmanifest` file was not loading properly. I found that in order for the browser to attach the credentials to the request when requesting the file, the link markup should contain `crossorigin="use-credentials"` and this `even if the manifest file is in the same origin as the current page.` (quote from documentation below)

With this parameters, it worked.

More informations [https://developer.mozilla.org/en-US/docs/Web/Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest)