### PR TITLE
Add npm task for building docker image on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint ./app --fix",
     "test": "cross-env NODE_ENV=test jest --coverage --detectOpenHandles",
     "docker:build": "docker build . --build-arg PACKAGE_VERSION=$(node -p \"require('./package.json').version\") --build-arg GIT_HASH=$(git rev-parse --short HEAD) --build-arg NODE_ENV=production --target production-stage -t chrisleekr/binance-trading-bot:latest",
-    "docker:build:dev": "docker build . --build-arg PACKAGE_VERSION=$(node -p \"require('./package.json').version\") --build-arg GIT_HASH=$(git rev-parse --short HEAD) --build-arg NODE_ENV=development --target dev-stage -t chrisleekr/binance-trading-bot:latest"
+    "docker:build:dev": "docker build . --build-arg PACKAGE_VERSION=$(node -p \"require('./package.json').version\") --build-arg GIT_HASH=$(git rev-parse --short HEAD) --build-arg NODE_ENV=development --target dev-stage -t chrisleekr/binance-trading-bot:latest",
+    "docker:build:win": "powershell -NoProfile -ExecutionPolicy Unrestricted -Command ./scripts/docker-build.ps1"
   },
   "repository": {
     "type": "git",

--- a/scripts/docker-build.ps1
+++ b/scripts/docker-build.ps1
@@ -8,12 +8,16 @@ param (
 
 $packageVersion = $(node -p "require('./package.json').version")
 $gitHash = $(git rev-parse --short HEAD)
-$nodeEnv = "production"
-$target = "production-stage"
 
-if ($env -eq "dev") {
-  $nodeEnv = "development"
-  $target = "dev-stage"
+switch ($env) {
+  "prod" {
+    $nodeEnv = "production"
+    $target = "production-stage"
+  }
+  "dev" {
+    $nodeEnv = "development"
+    $target = "dev-stage"
+  }
 }
 
 docker build . --build-arg PACKAGE_VERSION=$packageVersion --build-arg GIT_HASH=$gitHash --build-arg NODE_ENV=$nodeEnv --target $target -t chrisleekr/binance-trading-bot:latest

--- a/scripts/docker-build.ps1
+++ b/scripts/docker-build.ps1
@@ -1,0 +1,19 @@
+[CmdletBinding()]
+param (
+  [Parameter(Position = 0)]
+  [ValidateSet("prod", "dev")]
+  [string]
+  $env = "prod"
+)
+
+$packageVersion = $(node -p "require('./package.json').version")
+$gitHash = $(git rev-parse --short HEAD)
+$nodeEnv = "production"
+$target = "production-stage"
+
+if ($env -eq "dev") {
+  $nodeEnv = "development"
+  $target = "dev-stage"
+}
+
+docker build . --build-arg PACKAGE_VERSION=$packageVersion --build-arg GIT_HASH=$gitHash --build-arg NODE_ENV=$nodeEnv --target $target -t chrisleekr/binance-trading-bot:latest


### PR DESCRIPTION
## Description

Added a new npm task for building the docker image under Windows using PowerShell. To run,
```
npm run docker:build:win
```

By default it will do the `production` build, to use `development` build, run:
```
npm run docker:build:win -- -env dev
```

## Related Issue

#77

## Motivation and Context

## How Has This Been Tested?
I checked the built image with `docker inspect`:
```
npm run docker:build:win
```
![image](https://user-images.githubusercontent.com/4453664/118263922-84017600-b4e9-11eb-9261-fe7ec59f7550.png)
```
npm run docker:build:win -- -env dev
```
![image](https://user-images.githubusercontent.com/4453664/118263751-43a1f800-b4e9-11eb-8fe9-967c1f4bfe3c.png)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4453664/118263241-98913e80-b4e8-11eb-880d-75bae28780bd.png)
