### PR TITLE
bug: Fixed order not found issue

### DIFF
--- a/app/cronjob/trailingTrade/step/__tests__/ensure-manual-buy-order.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/ensure-manual-buy-order.test.js
@@ -4,7 +4,6 @@ const moment = require('moment');
 describe('ensure-manual-buy-order.js', () => {
   let result;
   let rawData;
-  let error;
 
   let binanceMock;
   let slackMock;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The bot sends unexpected messages to Slack when the API didn't return the order because API is busy.
This PR is fixing the step `ensure-manual-buy-order.js` to not throw an error when the order was not found. The order must be found if the order was successfully placed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#100 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
