### PR TITLE
feat: Reset global configuration to initial configuration

### DIFF
--- a/app/frontend/websocket/configure.js
+++ b/app/frontend/websocket/configure.js
@@ -6,6 +6,7 @@ const {
   handleSettingUpdate,
   handleSymbolUpdateLastBuyPrice,
   handleSymbolDelete,
+  handleResetFactorySettings,
   handleSymbolSettingUpdate,
   handleSymbolSettingDelete,
   handleSymbolEnableAction,
@@ -62,6 +63,9 @@ const configureWebSocket = async (server, funcLogger) => {
           break;
         case 'symbol-delete':
           await handleSymbolDelete(commandLogger, ws, payload);
+          break;
+        case 'reset-factory-settings':
+          await handleResetFactorySettings(commandLogger, ws, payload);
           break;
         case 'symbol-setting-update':
           await handleSymbolSettingUpdate(commandLogger, ws, payload);

--- a/app/frontend/websocket/handlers/index.js
+++ b/app/frontend/websocket/handlers/index.js
@@ -4,6 +4,7 @@ const {
   handleSymbolUpdateLastBuyPrice
 } = require('./symbol-update-last-buy-price');
 const { handleSymbolDelete } = require('./symbol-delete');
+const { handleResetFactorySettings } = require('./reset-factory-settings');
 const { handleSymbolSettingUpdate } = require('./symbol-setting-update');
 const { handleSymbolSettingDelete } = require('./symbol-setting-delete');
 const { handleSymbolEnableAction } = require('./symbol-enable-action');
@@ -19,6 +20,7 @@ module.exports = {
   handleSymbolUpdateLastBuyPrice,
   handleSymbolDelete,
   handleSymbolSettingUpdate,
+  handleResetFactorySettings,
   handleSymbolSettingDelete,
   handleSymbolEnableAction,
   handleManualTrade,

--- a/app/frontend/websocket/handlers/reset-factory-settings.js
+++ b/app/frontend/websocket/handlers/reset-factory-settings.js
@@ -1,0 +1,34 @@
+
+const { PubSub } = require('../../../helpers');
+const {
+  resetToFactorySettings,
+  resetToFactorySettingsWithSymbols,
+  getGlobalConfiguration
+} = require('../../../cronjob/trailingTradeHelper/configuration');
+
+const handleResetFactorySettings = async (logger, ws, payload) => {
+  logger.info({ payload }, 'Start resetting to factory settings');
+
+  const { data: newConfiguration } = payload;
+
+  const { action } = newConfiguration;
+
+  const config = await getGlobalConfiguration(logger);
+
+  if (action == 'reset-factory-settings-minus-symbols') {
+    await resetToFactorySettingsWithSymbols(logger, config.symbols);
+  } else {
+    await resetToFactorySettings(logger, config.symbols);
+  }
+
+  PubSub.publish('frontend-notification', {
+    type: 'success',
+    title: `Bot is now resetting to default's configuration.
+            Wait for the symbols to appear.`
+  });
+
+  ws.send(JSON.stringify({ result: true, type: 'reset-successful' }));
+
+};
+
+module.exports = { handleResetFactorySettings };

--- a/public/js/SettingIcon.js
+++ b/public/js/SettingIcon.js
@@ -836,6 +836,54 @@ class SettingIcon extends React.Component {
         </Modal>
 
         <Modal
+          show={this.state.showResetModal}
+          onHide={() => this.handleModalClose('reset')}
+          size='md'>
+          <Modal.Header className='pt-1 pb-1'>
+            <Modal.Title>
+              <span className='text-danger'>⚠ Delete ALL saved configuration</span>
+            </Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            This will delete all your data from database.
+            <br />
+            <br />
+            Your settings will be like the first time you started the bot.
+            <br />
+            <br />
+            If there's a symbol with open trade, it will delete it right away, even before trade finishes.
+            <br />
+            <br />
+            Please, don't use this with open trades.
+          </Modal.Body>
+
+          <Modal.Footer>
+            <Button
+              variant='secondary'
+              size='sm'
+              onClick={() => this.handleModalClose('reset')}>
+              Cancel
+            </Button>
+            <Button
+              variant='primary'
+              size='sm'
+              onClick={() => this.handleResetSettings({
+                action: 'reset-factory-settings'
+              })}>
+              Reset All
+            </Button>
+            <Button
+              variant='primary'
+              size='sm'
+              onClick={() => this.handleResetSettings({
+                action: 'reset-factory-settings-minus-symbols'
+              })}>
+              Reset but keep symbols
+            </Button>
+          </Modal.Footer>
+        </Modal>
+
+        <Modal
           show={this.state.showConfirmModal}
           onHide={() => this.handleModalClose('confirm')}
           size='md'>

--- a/public/js/SettingIcon.js
+++ b/public/js/SettingIcon.js
@@ -7,12 +7,14 @@ class SettingIcon extends React.Component {
 
     this.modalToStateMap = {
       setting: 'showSettingModal',
-      confirm: 'showConfirmModal'
+      confirm: 'showConfirmModal',
+      reset: 'showResetModal'
     };
 
     this.state = {
       showSettingModal: false,
       showConfirmModal: false,
+      showResetModal: false,
       availableSymbols: [],
       quoteAssets: [],
       configuration: {}
@@ -25,6 +27,8 @@ class SettingIcon extends React.Component {
     this.handleInputChange = this.handleInputChange.bind(this);
     this.handleMaxPurchaeAmountChange =
       this.handleMaxPurchaeAmountChange.bind(this);
+
+    this.handleResetSettings = this.handleResetSettings.bind(this);
   }
 
   getQuoteAssets(exchangeSymbols, selectedSymbols, maxPurchaseAmounts) {
@@ -96,6 +100,15 @@ class SettingIcon extends React.Component {
     });
   }
 
+  handleResetSettings(extraConfiguration = {}) {
+    this.handleModalClose('reset');
+    this.handleModalClose('setting');
+    this.props.sendWebSocket('reset-factory-settings', {
+      ...this.state.configuration,
+      ...extraConfiguration
+    });
+  }
+
   handleModalShow(modal) {
     this.setState({
       [this.modalToStateMap[modal]]: true
@@ -114,8 +127,8 @@ class SettingIcon extends React.Component {
       target.type === 'checkbox'
         ? target.checked
         : target.type === 'number'
-        ? +target.value
-        : target.value;
+          ? +target.value
+          : target.value;
     const stateKey = target.getAttribute('data-state-key');
 
     const { configuration } = this.state;
@@ -798,6 +811,14 @@ class SettingIcon extends React.Component {
                 Note that the changes will be displayed in the frontend in the
                 next tick.
               </div>
+              <Button
+                variant='danger'
+                size='sm'
+                onClick={() =>
+                  this.handleModalShow('reset')
+                }>
+                Reset to factory default.
+              </Button>
               <Button
                 variant='secondary'
                 size='sm'


### PR DESCRIPTION
Reset to factory settings with the option to choose to keep current monitored symbols or not.

<!--- Provide a general summary of your changes in the Title above -->

## Description

A button that reset everything to default. You can choose to keep current monitored symbols.



## Related Issue

Reset global configuration to initial configuration - [#97]

## Motivation and Context

I had some problems with configuration and liked to rollback everything. Now everyone can :)

## How Has This Been Tested?

Keeping the current symbols, then everything is deleted successfully. 

Deleting all, all is deleted, even current symbols.

NOTE: Every cache/database data about the old symbols and trades is ERASED when you reset to factory settings.

## Screenshots:

![Captura de Tela (152)](https://user-images.githubusercontent.com/59580251/124664178-73360680-de81-11eb-8eb9-be410cd780ef.png)
