### PR TITLE
feat: Show badge for the customised symbol configuration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -104,6 +104,7 @@
         Modal,
         ButtonGroup,
         Button,
+        Badge,
         Form,
         Spinner,
         Accordion,

--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -220,7 +220,7 @@ class CoinWrapperBuySignal extends React.Component {
                 </div>
               </div>
               <div className='coin-info-column coin-info-column-order'>
-                <span className='coin-info-label'>- Max purchase anmount:</span>
+                <span className='coin-info-label'>- Max purchase amount:</span>
                 <div className='coin-info-value'>
                   {grid.maxPurchaseAmount} {quoteAsset}
                 </div>

--- a/public/js/CoinWrapperSetting.js
+++ b/public/js/CoinWrapperSetting.js
@@ -17,6 +17,9 @@ class CoinWrapperSetting extends React.Component {
     });
   }
 
+  isCustomised = configurationKeyName =>
+      configurationKeyName !== 'configuration';
+
   render() {
     const { collapsed } = this.state;
     const { symbolInfo } = this.props;
@@ -28,6 +31,7 @@ class CoinWrapperSetting extends React.Component {
     } = symbolInfo;
 
     const {
+      key: configurationKeyName,
       buy: { gridTrade: buyGridTrade },
       sell: { gridTrade: sellGridTrade }
     } = symbolConfiguration;
@@ -116,7 +120,18 @@ class CoinWrapperSetting extends React.Component {
       <div className='coin-info-sub-wrapper coin-info-sub-wrapper-setting'>
         <div className='coin-info-column coin-info-column-title coin-info-column-title-setting'>
           <div className='coin-info-label'>
-            <div className='mr-1'>Setting</div>
+            <div className='mr-1'>
+              Setting -{' '}
+              {this.isCustomised(configurationKeyName) ? (
+                  <Badge pill variant='warning'>
+                    Customised
+                  </Badge>
+              ) : (
+                  <Badge pill variant='light'>
+                    Global
+                  </Badge>
+              )}
+            </div>
           </div>
 
           <button

--- a/public/js/CoinWrapperSetting.js
+++ b/public/js/CoinWrapperSetting.js
@@ -39,7 +39,7 @@ class CoinWrapperSetting extends React.Component {
     const buyGridRows = buyGridTrade.map((grid, i) => {
       return (
         <React.Fragment
-          key={'coin-wrapper-seting-buy-grid-row-' + symbol + '-' + i}>
+          key={'coin-wrapper-setting-buy-grid-row-' + symbol + '-' + i}>
           <div className='coin-info-column-grid'>
             <div className='coin-info-column coin-info-column-order'>
               <span className='coin-info-label'>Grid Trade #{i + 1}</span>
@@ -82,7 +82,7 @@ class CoinWrapperSetting extends React.Component {
     const sellGridRows = sellGridTrade.map((grid, i) => {
       return (
         <React.Fragment
-          key={'coin-wrapper-seting-sell-grid-row-' + symbol + '-' + i}>
+          key={'coin-wrapper-setting-sell-grid-row-' + symbol + '-' + i}>
           <div className='coin-info-column-grid'>
             <div className='coin-info-column coin-info-column-order'>
               <span className='coin-info-label'>Grid Trade #{i + 1}</span>

--- a/public/js/ManualTradeIcon.js
+++ b/public/js/ManualTradeIcon.js
@@ -412,7 +412,7 @@ class ManualTradeIcon extends React.Component {
                   <br />
                   <br />
                   If you click the button to sell 100% of the remaining balance,
-                  it will automatically caluclate 0.1% commission.
+                  it will automatically calculate 0.1% commission.
                 </React.Fragment>
               ) : (
                 ''

--- a/public/js/SymbolManualTradeIcon.js
+++ b/public/js/SymbolManualTradeIcon.js
@@ -773,7 +773,7 @@ class SymbolManualTradeIcon extends React.Component {
                 </div>
                 <div className='manual-trade-row d-flex flex-row justify-content-between'>
                   <div className='manual-trade-label'>Balance</div>
-                  <span className='manual-trade-base-sset'>
+                  <span className='manual-trade-base-asset'>
                     {parseFloat(baseAssetBalance.free).toFixed(
                       baseAssetStepSize
                     )}{' '}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just a small enhancement for the UI to show a badge when a symbol configuration is customised. It was added by @chrisleekr but it is removed in current releases while developing the bot and we are just bringing it back.

## Related Issue

#170 

## Motivation and Context

Sometimes we don't know which symbol is customised and which is not. This feature solves the issue.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

| Customised Symbol | Not Customised Symbol |
| ---------------------- | -------------------------- |
| ![image](https://user-images.githubusercontent.com/31035020/127746742-3d90d184-3a0f-4d1e-89f9-644271342f7c.png) | ![image](https://user-images.githubusercontent.com/31035020/127746760-4b727bb9-882d-453d-8d7f-216775ebaf56.png) |

