### PR TITLE
fix: closed trade query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.0.76] - 2021-08-17
 
 - Fixed profit calculation. Thanks [@Bajt1](https://github.com/Bajt1) - [#270](https://github.com/chrisleekr/binance-trading-bot/issues/270)
 - Improve Frontend performance with Gzip and compression

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Fix profit calculation. Thanks [@Bajt1](https://github.com/Bajt1) - [#270](https://github.com/chrisleekr/binance-trading-bot/issues/270)
+- Fixed profit calculation. Thanks [@Bajt1](https://github.com/Bajt1) - [#270](https://github.com/chrisleekr/binance-trading-bot/issues/270)
 - Improve Frontend performance with Gzip and compression
 - Disabled saving every single order to MongoDB
+- Fixed closed trade history error `can't $divide by zero`. Thanks [@BramFr](https://github.com/BramFr) - [#276](https://github.com/chrisleekr/binance-trading-bot/issues/276)
+- Clear closed trade history cache when change the period
 
 ## [0.0.75] - 2021-08-13
 

--- a/app/cronjob/trailingTradeIndicator/step/__tests__/get-closed-trades.test.js
+++ b/app/cronjob/trailingTradeIndicator/step/__tests__/get-closed-trades.test.js
@@ -148,10 +148,20 @@ describe('get-closed-trades.js', () => {
                     stopLossQuoteQty: 1,
                     profit: 1,
                     profitPercentage: {
-                      $multiply: [
-                        { $divide: ['$profit', '$totalBuyQuoteQty'] },
-                        100
-                      ]
+                      $cond: {
+                        if: {
+                          $gt: ['$totalBuyQuoteQty', 0]
+                        },
+                        then: {
+                          $multiply: [
+                            {
+                              $divide: ['$profit', '$totalBuyQuoteQty']
+                            },
+                            100
+                          ]
+                        },
+                        else: 0
+                      }
                     },
                     trades: 1
                   }
@@ -261,10 +271,20 @@ describe('get-closed-trades.js', () => {
                 stopLossQuoteQty: 1,
                 profit: 1,
                 profitPercentage: {
-                  $multiply: [
-                    { $divide: ['$profit', '$totalBuyQuoteQty'] },
-                    100
-                  ]
+                  $cond: {
+                    if: {
+                      $gt: ['$totalBuyQuoteQty', 0]
+                    },
+                    then: {
+                      $multiply: [
+                        {
+                          $divide: ['$profit', '$totalBuyQuoteQty']
+                        },
+                        100
+                      ]
+                    },
+                    else: 0
+                  }
                 },
                 trades: 1
               }

--- a/app/cronjob/trailingTradeIndicator/step/get-closed-trades.js
+++ b/app/cronjob/trailingTradeIndicator/step/get-closed-trades.js
@@ -81,7 +81,20 @@ const execute = async (logger, rawData) => {
           stopLossQuoteQty: 1,
           profit: 1,
           profitPercentage: {
-            $multiply: [{ $divide: ['$profit', '$totalBuyQuoteQty'] }, 100]
+            $cond: {
+              if: {
+                $gt: ['$totalBuyQuoteQty', 0]
+              },
+              then: {
+                $multiply: [
+                  {
+                    $divide: ['$profit', '$totalBuyQuoteQty']
+                  },
+                  100
+                ]
+              },
+              else: 0
+            }
           },
           trades: 1
         }

--- a/app/frontend/webserver/handlers/__tests__/closed-trades-set-period.test.js
+++ b/app/frontend/webserver/handlers/__tests__/closed-trades-set-period.test.js
@@ -33,6 +33,8 @@ describe('webserver/handlers/closed-trades-set-period', () => {
 
       cacheMock.hset = jest.fn().mockResolvedValue(true);
 
+      cacheMock.del = jest.fn().mockResolvedValue(true);
+
       postReq = {
         body: {
           authToken: 'some token',
@@ -60,6 +62,12 @@ describe('webserver/handlers/closed-trades-set-period', () => {
         JSON.stringify({
           selectedPeriod: 'd'
         })
+      );
+    });
+
+    it('triggers cache.del', () => {
+      expect(cacheMock.del).toHaveBeenCalledWith(
+        'trailing-trade-closed-trades'
       );
     });
 
@@ -88,6 +96,7 @@ describe('webserver/handlers/closed-trades-set-period', () => {
       );
 
       cacheMock.hset = jest.fn().mockResolvedValue(true);
+      cacheMock.del = jest.fn().mockResolvedValue(true);
 
       postReq = {
         body: {
@@ -117,6 +126,12 @@ describe('webserver/handlers/closed-trades-set-period', () => {
           loadedPeriod: 'a',
           selectedPeriod: 'd'
         })
+      );
+    });
+
+    it('triggers cache.del', () => {
+      expect(cacheMock.del).toHaveBeenCalledWith(
+        'trailing-trade-closed-trades'
       );
     });
 

--- a/app/frontend/webserver/handlers/__tests__/grid-trade-archive-get.test.js
+++ b/app/frontend/webserver/handlers/__tests__/grid-trade-archive-get.test.js
@@ -381,10 +381,20 @@ describe('webserver/handlers/grid-trade-archive-get', () => {
                   stopLossQuoteQty: 1,
                   profit: 1,
                   profitPercentage: {
-                    $multiply: [
-                      { $divide: ['$profit', '$totalBuyQuoteQty'] },
-                      100
-                    ]
+                    $cond: {
+                      if: {
+                        $gt: ['$totalBuyQuoteQty', 0]
+                      },
+                      then: {
+                        $multiply: [
+                          {
+                            $divide: ['$profit', '$totalBuyQuoteQty']
+                          },
+                          100
+                        ]
+                      },
+                      else: 0
+                    }
                   },
                   trades: 1
                 }
@@ -501,10 +511,20 @@ describe('webserver/handlers/grid-trade-archive-get', () => {
                 stopLossQuoteQty: 1,
                 profit: 1,
                 profitPercentage: {
-                  $multiply: [
-                    { $divide: ['$profit', '$totalBuyQuoteQty'] },
-                    100
-                  ]
+                  $cond: {
+                    if: {
+                      $gt: ['$totalBuyQuoteQty', 0]
+                    },
+                    then: {
+                      $multiply: [
+                        {
+                          $divide: ['$profit', '$totalBuyQuoteQty']
+                        },
+                        100
+                      ]
+                    },
+                    else: 0
+                  }
                 },
                 trades: 1
               }

--- a/app/frontend/webserver/handlers/closed-trades-set-period.js
+++ b/app/frontend/webserver/handlers/closed-trades-set-period.js
@@ -22,6 +22,9 @@ const handleClosedTradesSetPeriod = async (funcLogger, app) => {
       })
     );
 
+    // Reset closed trades history
+    await cache.del('trailing-trade-closed-trades');
+
     return res.send({
       success: true,
       status: 200,

--- a/app/frontend/webserver/handlers/grid-trade-archive-get.js
+++ b/app/frontend/webserver/handlers/grid-trade-archive-get.js
@@ -130,7 +130,20 @@ const handleGridTradeArchiveGet = async (funcLogger, app) => {
             stopLossQuoteQty: 1,
             profit: 1,
             profitPercentage: {
-              $multiply: [{ $divide: ['$profit', '$totalBuyQuoteQty'] }, 100]
+              $cond: {
+                if: {
+                  $gt: ['$totalBuyQuoteQty', 0]
+                },
+                then: {
+                  $multiply: [
+                    {
+                      $divide: ['$profit', '$totalBuyQuoteQty']
+                    },
+                    100
+                  ]
+                },
+                else: 0
+              }
             },
             trades: 1
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Fixed closed trade history error `can't $divide by zero`. Thanks [@BramFr](https://github.com/BramFr) - [#276](https://github.com/chrisleekr/binance-trading-bot/issues/276)
- Clear closed trade history cache when change the period


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#276 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
