### PR TITLE
fix: remove symbol-info cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.77] - 2021-08-27
+
+- Support setting minimum logging level. Thanks [ruslan-khalitov](https://github.com/ruslan-khalitov) - [#280](https://github.com/chrisleekr/binance-trading-bot/pull/280)
+- Fixed cached symbol info is not removed when saving the global configuration
+
 ## [0.0.76] - 2021-08-17
 
 - Fixed profit calculation. Thanks [@Bajt1](https://github.com/Bajt1) - [#270](https://github.com/chrisleekr/binance-trading-bot/issues/270)

--- a/app/frontend/websocket/handlers/__tests__/setting-update.test.js
+++ b/app/frontend/websocket/handlers/__tests__/setting-update.test.js
@@ -36,6 +36,7 @@ describe('setting-update.test.js', () => {
       cacheMock = cache;
 
       cacheMock.hdel = jest.fn().mockResolvedValue(true);
+      cacheMock.hgetall = jest.fn().mockResolvedValue({});
 
       mockGetGlobalConfiguration = jest.fn().mockResolvedValue(null);
 
@@ -70,6 +71,12 @@ describe('setting-update.test.js', () => {
         cacheMock = cache;
 
         cacheMock.hdel = jest.fn().mockResolvedValue(true);
+        cacheMock.hgetall = jest.fn().mockResolvedValue({
+          'BTCUSDT-symbol-info': JSON.stringify({ some: 'value' }),
+          'BTCUSDT-data': JSON.stringify({ another: 'value' }),
+          'ETHUSDT-symbol-info': JSON.stringify({ some: 'value' }),
+          'ETHUSDT-latest-candle': JSON.stringify({ another: 'value' })
+        });
 
         mockGetGlobalConfiguration = jest.fn().mockResolvedValue({
           enabled: true,
@@ -145,10 +152,36 @@ describe('setting-update.test.js', () => {
         });
       });
 
-      it('triggers cache.hdel', () => {
+      it('triggers cache.hdel for exchange-symbols', () => {
         expect(cacheMock.hdel).toHaveBeenCalledWith(
           'trailing-trade-common',
           'exchange-symbols'
+        );
+      });
+
+      it('triggers cache.hdel for exchange-info', () => {
+        expect(cacheMock.hdel).toHaveBeenCalledWith(
+          'trailing-trade-common',
+          'exchange-info'
+        );
+      });
+
+      it('triggers cache.hdel for symbols', () => {
+        expect(cacheMock.hdel).toHaveBeenCalledWith(
+          'trailing-trade-symbols',
+          'BTCUSDT-symbol-info'
+        );
+        expect(cacheMock.hdel).toHaveBeenCalledWith(
+          'trailing-trade-symbols',
+          'ETHUSDT-symbol-info'
+        );
+        expect(cacheMock.hdel).not.toHaveBeenCalledWith(
+          'trailing-trade-symbols',
+          'BTCUSDT-data'
+        );
+        expect(cacheMock.hdel).not.toHaveBeenCalledWith(
+          'trailing-trade-symbols',
+          'ETHUSDT-latest-candle'
         );
       });
 
@@ -191,6 +224,12 @@ describe('setting-update.test.js', () => {
         cacheMock = cache;
 
         cacheMock.hdel = jest.fn().mockResolvedValue(true);
+        cacheMock.hgetall = jest.fn().mockResolvedValue({
+          'BTCUSDT-symbol-info': JSON.stringify({ some: 'value' }),
+          'BTCUSDT-data': JSON.stringify({ another: 'value' }),
+          'ETHUSDT-symbol-info': JSON.stringify({ some: 'value' }),
+          'ETHUSDT-latest-candle': JSON.stringify({ another: 'value' })
+        });
 
         mockGetGlobalConfiguration = jest.fn().mockResolvedValue({
           enabled: true,
@@ -277,6 +316,25 @@ describe('setting-update.test.js', () => {
         expect(cacheMock.hdel).toHaveBeenCalledWith(
           'trailing-trade-common',
           'exchange-info'
+        );
+      });
+
+      it('triggers cache.hdel for symbols', () => {
+        expect(cacheMock.hdel).toHaveBeenCalledWith(
+          'trailing-trade-symbols',
+          'BTCUSDT-symbol-info'
+        );
+        expect(cacheMock.hdel).toHaveBeenCalledWith(
+          'trailing-trade-symbols',
+          'ETHUSDT-symbol-info'
+        );
+        expect(cacheMock.hdel).not.toHaveBeenCalledWith(
+          'trailing-trade-symbols',
+          'BTCUSDT-data'
+        );
+        expect(cacheMock.hdel).not.toHaveBeenCalledWith(
+          'trailing-trade-symbols',
+          'ETHUSDT-latest-candle'
         );
       });
 

--- a/app/helpers/__tests__/logger.test.js
+++ b/app/helpers/__tests__/logger.test.js
@@ -1,33 +1,64 @@
 /* eslint-disable global-require */
 describe('logger', () => {
-  let bunyan;
   let logger;
   let mockCreateLogger;
   const packageJson = require('../../../package.json');
 
-  beforeEach(() => {
-    jest.clearAllMocks().resetModules();
+  describe('when BINANCE_LOG_LEVEL is defined', () => {
+    beforeEach(() => {
+      jest.clearAllMocks().resetModules();
 
-    mockCreateLogger = jest.fn(() => ({
-      info: jest.fn()
-    }));
+      process.env.BINANCE_LOG_LEVEL = 'ERROR';
 
-    jest.mock('bunyan', () => ({
-      createLogger: mockCreateLogger
-    }));
-    bunyan = require('bunyan');
-    logger = require('../logger');
-  });
+      mockCreateLogger = jest.fn(() => ({
+        info: jest.fn()
+      }));
 
-  it('triggers createLogger', () => {
-    expect(mockCreateLogger).toHaveBeenCalledWith({
-      name: 'binance-api',
-      version: packageJson.version,
-      streams: [{ stream: process.stdout, level: bunyan.TRACE }]
+      jest.mock('bunyan', () => ({
+        createLogger: mockCreateLogger
+      }));
+      logger = require('../logger');
+    });
+
+    it('triggers createLogger', () => {
+      expect(mockCreateLogger).toHaveBeenCalledWith({
+        name: 'binance-api',
+        version: packageJson.version,
+        streams: [{ stream: process.stdout, level: 'ERROR' }]
+      });
+    });
+
+    it('returns expected', () => {
+      expect(logger.info).toBeDefined();
     });
   });
 
-  it('returns expected', () => {
-    expect(logger.info).toBeDefined();
+  describe('when BINANCE_LOG_LEVEL is not defined', () => {
+    beforeEach(() => {
+      jest.clearAllMocks().resetModules();
+
+      delete process.env.BINANCE_LOG_LEVEL;
+
+      mockCreateLogger = jest.fn(() => ({
+        info: jest.fn()
+      }));
+
+      jest.mock('bunyan', () => ({
+        createLogger: mockCreateLogger
+      }));
+      logger = require('../logger');
+    });
+
+    it('triggers createLogger', () => {
+      expect(mockCreateLogger).toHaveBeenCalledWith({
+        name: 'binance-api',
+        version: packageJson.version,
+        streams: [{ stream: process.stdout, level: 'TRACE' }]
+      });
+    });
+
+    it('returns expected', () => {
+      expect(logger.info).toBeDefined();
+    });
   });
 });

--- a/app/helpers/logger.js
+++ b/app/helpers/logger.js
@@ -5,7 +5,12 @@ const logger = bunyan.createLogger({
   name: 'binance-api',
   version: packageJson.version,
   serializers: bunyan.stdSerializers,
-  streams: [{ stream: process.stdout, level: process.env.BINANCE_LOG_LEVEL || 'TRACE' }]
+  streams: [
+    {
+      stream: process.stdout,
+      level: process.env.BINANCE_LOG_LEVEL || 'TRACE'
+    }
+  ]
 });
 logger.info({ NODE_ENV: process.env.NODE_ENV }, 'API logger loaded');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fixed cached symbol info is not removed when saving the global configuration

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#284 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
