### PR TITLE
feat: it allows the defining of Redis "db"

### DIFF
--- a/app/helpers/cache.js
+++ b/app/helpers/cache.js
@@ -5,7 +5,8 @@ const Redlock = require('redlock');
 const redis = new Redis({
   host: config.get('redis.host'),
   port: config.get('redis.port'),
-  password: config.get('redis.password')
+  password: config.get('redis.password'),
+  db: config.get('redis.db')
 });
 
 const redlock = new Redlock([redis], {

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -17,7 +17,8 @@
       "__name": "BINANCE_REDIS_PORT",
       "__format": "number"
     },
-    "password": "BINANCE_REDIS_PASSWORD"
+    "password": "BINANCE_REDIS_PASSWORD",
+    "db": "BINANCE_REDIS_DB"
   },
   "mongo": {
     "host": "BINANCE_MONGO_HOST",

--- a/config/default.json
+++ b/config/default.json
@@ -15,7 +15,8 @@
   "redis": {
     "host": "binance-redis",
     "port": 6379,
-    "password": ""
+    "password": "",
+    "db": 0
   },
   "mongo": {
     "host": "binance-mongo",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Introducing new env param "BINANCE_REDIS_DB", this allows the defining of which "db" will be used in Redis Instance.

## Related Issue
#286 

## Motivation and Context
Currently, to run multiple bots in one machine, we also need multiple Redis container. However, the Redis Instance itself has multiple DB which can be utilized by each different bot. This means that we can run multiple bots in only one Redis container by defining which DB should the bot use. 

## How Has This Been Tested?
Tested in my RPi.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/12295737/132005475-94cc832d-476c-45ae-a3f8-78238af13b3d.png)