### PR TITLE
feat(auth): support rate limiter to prevent brute force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.0.78] - 2021-09-04
 
 - Added indexes for MongoDB
 - Updated configuration to use cache as well to improve performance
@@ -11,10 +11,11 @@ All notable changes to this project will be documented in this file.
 - Updated MongoDB to not acknowledge insert/update/delete
 - Updated Slack message for authentication. Thanks [@caebwallace](https://github.com/caebwallace) - [#287](https://github.com/chrisleekr/binance-trading-bot/pull/287)
 - Support Redis DB. Thanks [@azorpax](https://github.com/azorpax) - [#292](https://github.com/chrisleekr/binance-trading-bot/pull/292)
+- Support Rate Limiter to prevent brute force. Thanks [@caebwallace](https://github.com/caebwallace) - [#287](https://github.com/chrisleekr/binance-trading-bot/pull/287)
 
 ## [0.0.77] - 2021-08-27
 
-- Support setting minimum logging level. Thanks [ruslan-khalitov](https://github.com/ruslan-khalitov) - [#280](https://github.com/chrisleekr/binance-trading-bot/pull/280)
+- Support setting minimum logging level. Thanks [@ruslan-khalitov](https://github.com/ruslan-khalitov) - [#280](https://github.com/chrisleekr/binance-trading-bot/pull/280)
 - Fixed cached symbol info is not removed when saving the global configuration
 
 ## [0.0.76] - 2021-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Moved grid/manual orders to MongoDB from Redis since Redis is not persistent anymore
 - Updated MongoDB to not acknowledge insert/update/delete
 - Updated Slack message for authentication. Thanks [@caebwallace](https://github.com/caebwallace) - [#287](https://github.com/chrisleekr/binance-trading-bot/pull/287)
+- Support Redis DB. Thanks [@azorpax](https://github.com/azorpax) - [#292](https://github.com/chrisleekr/binance-trading-bot/pull/292)
 
 ## [0.0.77] - 2021-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.78] - 2021-09-04
+## [0.0.78] - 2021-09-05
 
 - Added indexes for MongoDB
 - Updated configuration to use cache as well to improve performance

--- a/README.ko.md
+++ b/README.ko.md
@@ -324,7 +324,7 @@
 
 | Password Protected | Frontend Mobile |
 | ------------------ | --------------- |
-| ![Password Protected](https://user-images.githubusercontent.com/5715919/127773484-51d01881-4933-454e-9052-9965b222e716.png) | ![Frontend Mobile](https://user-images.githubusercontent.com/5715919/131497627-3c637c9a-f0b8-4e8f-a8d7-6002f1602944.png) |
+| ![Password Protected](https://user-images.githubusercontent.com/5715919/127773484-51d01881-4933-454e-9052-9965b222e716.png) | ![Frontend Mobile](https://user-images.githubusercontent.com/5715919/132074850-e5caf676-a385-4cca-b1dc-4fbe538a28c4.png) |
 
 | Setting | Manual Trade |
 | ------- | ------------ |
@@ -332,7 +332,7 @@
 
 | Frontend Desktop  | Closed Trades |
 | ----------------- | ------------- |
-| ![Frontend Desktop](https://user-images.githubusercontent.com/5715919/131497813-03cef79b-7b43-4e61-90d9-a4b6d7f1a91b.png) | ![Closed Trades](https://user-images.githubusercontent.com/5715919/131497856-28ec42b7-1290-4b74-8644-d74516758a5b.png) |
+| ![Frontend Desktop](https://user-images.githubusercontent.com/5715919/132074902-da9cf959-7533-409e-806d-8be20db2e57e.png) | ![Closed Trades](https://user-images.githubusercontent.com/5715919/132074927-d6739de0-910f-496a-b71d-508905c6adc1.png) |
 
 ### 샘플 거래
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Or use the frontend to adjust configurations after launching the application.
 
 | Password Protected | Frontend Mobile |
 | ------------------ | --------------- |
-| ![Password Protected](https://user-images.githubusercontent.com/5715919/127773484-51d01881-4933-454e-9052-9965b222e716.png) | ![Frontend Mobile](https://user-images.githubusercontent.com/5715919/131497627-3c637c9a-f0b8-4e8f-a8d7-6002f1602944.png) |
+| ![Password Protected](https://user-images.githubusercontent.com/5715919/127773484-51d01881-4933-454e-9052-9965b222e716.png) | ![Frontend Mobile](https://user-images.githubusercontent.com/5715919/132074850-e5caf676-a385-4cca-b1dc-4fbe538a28c4.png) |
 
 | Setting | Manual Trade |
 | ------- | ------------ |
@@ -356,7 +356,7 @@ Or use the frontend to adjust configurations after launching the application.
 
 | Frontend Desktop  | Closed Trades |
 | ----------------- | ------------- |
-| ![Frontend Desktop](https://user-images.githubusercontent.com/5715919/131497813-03cef79b-7b43-4e61-90d9-a4b6d7f1a91b.png) | ![Closed Trades](https://user-images.githubusercontent.com/5715919/131497856-28ec42b7-1290-4b74-8644-d74516758a5b.png) |
+| ![Frontend Desktop](https://user-images.githubusercontent.com/5715919/132074902-da9cf959-7533-409e-806d-8be20db2e57e.png) | ![Closed Trades](https://user-images.githubusercontent.com/5715919/132074927-d6739de0-910f-496a-b71d-508905c6adc1.png) |
 
 ### Sample Trade
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -318,7 +318,7 @@ The final profit would be
 
 | Password Protected | Frontend Mobile |
 | ------------------ | --------------- |
-| ![Password Protected](https://user-images.githubusercontent.com/5715919/127773484-51d01881-4933-454e-9052-9965b222e716.png) | ![Frontend Mobile](https://user-images.githubusercontent.com/5715919/131497627-3c637c9a-f0b8-4e8f-a8d7-6002f1602944.png) |
+| ![Password Protected](https://user-images.githubusercontent.com/5715919/127773484-51d01881-4933-454e-9052-9965b222e716.png) | ![Frontend Mobile](https://user-images.githubusercontent.com/5715919/132074850-e5caf676-a385-4cca-b1dc-4fbe538a28c4.png) |
 
 | Setting | Manual Trade |
 | ------- | ------------ |
@@ -326,7 +326,7 @@ The final profit would be
 
 | Frontend Desktop  | Closed Trades |
 | ----------------- | ------------- |
-| ![Frontend Desktop](https://user-images.githubusercontent.com/5715919/131497813-03cef79b-7b43-4e61-90d9-a4b6d7f1a91b.png) | ![Closed Trades](https://user-images.githubusercontent.com/5715919/131497856-28ec42b7-1290-4b74-8644-d74516758a5b.png) |
+| ![Frontend Desktop](https://user-images.githubusercontent.com/5715919/132074902-da9cf959-7533-409e-806d-8be20db2e57e.png) | ![Closed Trades](https://user-images.githubusercontent.com/5715919/132074927-d6739de0-910f-496a-b71d-508905c6adc1.png) |
 
 ### Sample Trade
 

--- a/app/__tests__/server-frontend.test.js
+++ b/app/__tests__/server-frontend.test.js
@@ -7,12 +7,29 @@ describe('server-frontend', () => {
   let mockExpressServerOn;
   let mockExpressUrlEncoded;
   let mockExpressJson;
+  let mockExpress;
+
+  let mockCompression;
+  let mockCors;
 
   let mockConfigureWebServer;
   let mockConfigureWebSocket;
   let mockConfigureLocalTunnel;
 
+  let mockRateLimiterRedisGet;
+  let mockRateLimiterRedis;
+
+  let mockRequestIpGetClientIp;
+
+  let mockRateLimiterMiddlewareReq;
+  let mockRateLimiterMiddlewareResSend;
+  let mockRateLimiterMiddlewareResStatus;
+  let mockRateLimiterMiddlewareRes;
+  let mockRateLimiterMiddlewareNext;
+
   let config;
+  let cacheMock;
+  let loggerMock;
 
   beforeEach(() => {
     jest.clearAllMocks().resetModules();
@@ -22,21 +39,63 @@ describe('server-frontend', () => {
     jest.mock('ws');
     jest.mock('config');
 
-    mockConfigureWebServer = jest.fn().mockResolvedValue(true);
-    mockConfigureWebSocket = jest.fn().mockResolvedValue(true);
-    mockConfigureLocalTunnel = jest.fn().mockResolvedValue(true);
+    mockCompression = jest.fn().mockReturnValue(true);
+    mockCors = jest.fn().mockReturnValue(true);
 
-    mockExpressStatic = jest.fn().mockResolvedValue(true);
-    mockExpressUse = jest.fn().mockResolvedValue(true);
-    mockExpressUrlEncoded = jest.fn().mockResolvedValue(true);
-    mockExpressJson = jest.fn().mockResolvedValue(true);
+    mockRateLimiterRedisGet = jest.fn().mockReturnValue({ remainingPoints: 5 });
+    mockRateLimiterRedis = jest.fn().mockImplementation(() => ({
+      get: mockRateLimiterRedisGet
+    }));
+
+    jest.mock('rate-limiter-flexible', () => ({
+      RateLimiterRedis: mockRateLimiterRedis
+    }));
+
+    mockRequestIpGetClientIp = jest.fn().mockReturnValue('127.0.0.1');
+    jest.mock('request-ip', () => ({
+      getClientIp: mockRequestIpGetClientIp
+    }));
+
+    mockConfigureWebServer = jest.fn().mockReturnValue(true);
+    mockConfigureWebSocket = jest.fn().mockReturnValue(true);
+    mockConfigureLocalTunnel = jest.fn().mockReturnValue(true);
+
+    mockExpressStatic = jest.fn().mockReturnValue(true);
+
+    mockRateLimiterMiddlewareReq = 'req';
+
+    mockRateLimiterMiddlewareResSend = jest.fn().mockReturnValue(true);
+    mockRateLimiterMiddlewareResStatus = jest.fn().mockImplementation(() => ({
+      send: mockRateLimiterMiddlewareResSend
+    }));
+    mockRateLimiterMiddlewareRes = {
+      status: mockRateLimiterMiddlewareResStatus
+    };
+
+    mockRateLimiterMiddlewareNext = jest.fn().mockReturnValue(true);
+
+    mockExpressUse = jest.fn().mockImplementation(async fn => {
+      if (fn.name === 'compression') {
+        mockCompression();
+      } else if (fn.name === 'corsMiddleware') {
+        mockCors();
+      } else if (fn.name === 'rateLimiterMiddleware') {
+        await fn(
+          mockRateLimiterMiddlewareReq,
+          mockRateLimiterMiddlewareRes,
+          mockRateLimiterMiddlewareNext
+        );
+      }
+    });
+    mockExpressUrlEncoded = jest.fn().mockReturnValue(true);
+    mockExpressJson = jest.fn().mockReturnValue(true);
 
     mockExpressListen = jest.fn().mockReturnValue({
       on: mockExpressServerOn
     });
 
     jest.mock('express', () => {
-      const mockExpress = () => ({
+      mockExpress = () => ({
         use: mockExpressUse,
         listen: mockExpressListen
       });
@@ -56,15 +115,6 @@ describe('server-frontend', () => {
       return mockExpress;
     });
 
-    config.get = jest.fn(key => {
-      switch (key) {
-        case 'mode':
-          return 'test';
-        default:
-          return `value-${key}`;
-      }
-    });
-
     jest.mock('../frontend/webserver/configure', () => ({
       configureWebServer: mockConfigureWebServer
     }));
@@ -78,27 +128,180 @@ describe('server-frontend', () => {
     }));
   });
 
-  describe('check web server', () => {
-    beforeEach(() => {
-      const { logger } = require('../helpers');
-      const { runFrontend } = require('../server-frontend');
-      runFrontend(logger);
+  describe('web server', () => {
+    describe('authentication is disabled', () => {
+      beforeEach(() => {
+        config.get = jest.fn(key => {
+          switch (key) {
+            case 'mode':
+              return 'test';
+            case 'authentication.enabled':
+              return false;
+            case 'authentication.loginLimiter.maxConsecutiveFails':
+              return 5;
+            case 'authentication.loginLimiter.duration':
+              return 10800;
+            case 'authentication.loginLimiter.blockDuration':
+              return 900;
+            default:
+              return `value-${key}`;
+          }
+        });
+
+        const { cache, logger } = require('../helpers');
+
+        cacheMock = cache;
+        cacheMock.redis = 'redis client';
+
+        loggerMock = logger;
+
+        const { runFrontend } = require('../server-frontend');
+        runFrontend(logger);
+      });
+
+      it('initiates mockRateLimiterRedis', () => {
+        expect(mockRateLimiterRedis).toHaveBeenCalledWith({
+          redis: 'redis client',
+          keyPrefix: 'login',
+          points: 5,
+          duration: 10800,
+          blockDuration: 900
+        });
+      });
+
+      it('triggers server.listen', () => {
+        expect(mockExpressListen).toHaveBeenCalledWith(80);
+      });
+
+      it('triggers configureWebServer', () => {
+        expect(mockConfigureWebServer).toHaveBeenCalledWith(
+          expect.any(Object),
+          loggerMock,
+          { loginLimiter: expect.any(Object) }
+        );
+      });
+
+      it('triggers configureWebSocket', () => {
+        expect(mockConfigureWebSocket).toHaveBeenCalledWith(
+          expect.any(Object),
+          loggerMock,
+          { loginLimiter: expect.any(Object) }
+        );
+      });
+
+      it('does not trigger requestIp.getClientIp', () => {
+        expect(mockRequestIpGetClientIp).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger loginLimiter.get', () => {
+        expect(mockRateLimiterRedisGet).not.toHaveBeenCalled();
+      });
+
+      it('triggers configureLocalTunnel', () => {
+        expect(mockConfigureLocalTunnel).toHaveBeenCalled();
+      });
     });
 
-    it('triggers server.listen', () => {
-      expect(mockExpressListen).toHaveBeenCalledWith(80);
-    });
+    describe('authentication is enabled', () => {
+      beforeEach(() => {
+        config.get = jest.fn(key => {
+          switch (key) {
+            case 'mode':
+              return 'test';
+            case 'authentication.enabled':
+              return true;
+            case 'authentication.loginLimiter.maxConsecutiveFails':
+              return 5;
+            case 'authentication.loginLimiter.duration':
+              return 10800;
+            case 'authentication.loginLimiter.blockDuration':
+              return 900;
+            default:
+              return `value-${key}`;
+          }
+        });
 
-    it('triggers configureWebServer', () => {
-      expect(mockConfigureWebServer).toHaveBeenCalled();
-    });
+        const { cache, logger } = require('../helpers');
 
-    it('triggers configureWebSocket', () => {
-      expect(mockConfigureWebSocket).toHaveBeenCalled();
-    });
+        cacheMock = cache;
+        cacheMock.redis = 'redis client';
 
-    it('triggers configureLocalTunnel', () => {
-      expect(mockConfigureLocalTunnel).toHaveBeenCalled();
+        loggerMock = logger;
+      });
+
+      describe('remaining points are more than 0', () => {
+        beforeEach(() => {
+          mockRateLimiterRedisGet = jest
+            .fn()
+            .mockReturnValue({ remainingPoints: 5 });
+          mockRateLimiterRedis = jest.fn().mockImplementation(() => ({
+            get: mockRateLimiterRedisGet
+          }));
+
+          jest.mock('rate-limiter-flexible', () => ({
+            RateLimiterRedis: mockRateLimiterRedis
+          }));
+
+          const { runFrontend } = require('../server-frontend');
+          runFrontend(loggerMock);
+        });
+
+        it('triggers requestIp.getClientIp', () => {
+          expect(mockRequestIpGetClientIp).toHaveBeenCalled();
+        });
+
+        it('triggers loginLimiter.get', () => {
+          expect(mockRateLimiterRedisGet).toHaveBeenCalledWith('127.0.0.1');
+        });
+
+        it('does not trigger status', () => {
+          expect(mockRateLimiterMiddlewareResStatus).not.toHaveBeenCalled();
+        });
+
+        it('triggers next', () => {
+          expect(mockRateLimiterMiddlewareNext).toHaveBeenCalled();
+        });
+      });
+
+      describe('remaining point is less or equal than 0', () => {
+        beforeEach(() => {
+          mockRateLimiterRedisGet = jest
+            .fn()
+            .mockReturnValue({ remainingPoints: 0 });
+          mockRateLimiterRedis = jest.fn().mockImplementation(() => ({
+            get: mockRateLimiterRedisGet
+          }));
+
+          jest.mock('rate-limiter-flexible', () => ({
+            RateLimiterRedis: mockRateLimiterRedis
+          }));
+
+          const { runFrontend } = require('../server-frontend');
+          runFrontend(loggerMock);
+        });
+
+        it('triggers requestIp.getClientIp', () => {
+          expect(mockRequestIpGetClientIp).toHaveBeenCalled();
+        });
+
+        it('triggers loginLimiter.get', () => {
+          expect(mockRateLimiterRedisGet).toHaveBeenCalledWith('127.0.0.1');
+        });
+
+        it('triggers status', () => {
+          expect(mockRateLimiterMiddlewareResStatus).toHaveBeenCalledWith(403);
+        });
+
+        it('triggers send', () => {
+          expect(mockRateLimiterMiddlewareResSend).toHaveBeenCalledWith(
+            expect.stringContaining(`You are blocked`)
+          );
+        });
+
+        it('does not trigger next', () => {
+          expect(mockRateLimiterMiddlewareNext).not.toHaveBeenCalled();
+        });
+      });
     });
   });
 });

--- a/app/frontend/webserver/__tests__/configure.test.js
+++ b/app/frontend/webserver/__tests__/configure.test.js
@@ -3,6 +3,8 @@
 describe('webserver/configure.js', () => {
   let mockSetHandlers;
 
+  let mockLoginLimiter;
+
   let cacheMock;
   let loggerMock;
 
@@ -10,6 +12,8 @@ describe('webserver/configure.js', () => {
     jest.clearAllMocks().resetModules();
 
     mockSetHandlers = jest.fn().mockResolvedValue(true);
+
+    mockLoginLimiter = jest.fn().mockReturnValue(true);
 
     jest.mock('../handlers', () => ({
       setHandlers: mockSetHandlers
@@ -26,7 +30,9 @@ describe('webserver/configure.js', () => {
       cacheMock.set = jest.fn().mockReturnValue(true);
 
       const { configureWebServer } = require('../configure');
-      await configureWebServer('app', loggerMock);
+      await configureWebServer('app', loggerMock, {
+        loginLimiter: mockLoginLimiter
+      });
     });
 
     it('triggers cache.get', () => {
@@ -41,7 +47,9 @@ describe('webserver/configure.js', () => {
     });
 
     it(`triggers setHandlers`, () => {
-      expect(mockSetHandlers).toHaveBeenCalledWith(loggerMock, 'app');
+      expect(mockSetHandlers).toHaveBeenCalledWith(loggerMock, 'app', {
+        loginLimiter: mockLoginLimiter
+      });
     });
   });
 
@@ -55,7 +63,9 @@ describe('webserver/configure.js', () => {
       cacheMock.set = jest.fn().mockReturnValue(true);
 
       const { configureWebServer } = require('../configure');
-      await configureWebServer('app', loggerMock);
+      await configureWebServer('app', loggerMock, {
+        loginLimiter: mockLoginLimiter
+      });
     });
 
     it('triggers cache.get', () => {

--- a/app/frontend/webserver/configure.js
+++ b/app/frontend/webserver/configure.js
@@ -15,13 +15,13 @@ const configureJWTToken = async () => {
   return jwtSecret;
 };
 
-const configureWebServer = async (app, funcLogger) => {
+const configureWebServer = async (app, funcLogger, { loginLimiter }) => {
   const logger = funcLogger.child({ server: 'webserver' });
 
   // Firstly get(or set) JWT secret
   await configureJWTToken();
 
-  await setHandlers(logger, app);
+  await setHandlers(logger, app, { loginLimiter });
 };
 
 module.exports = { configureWebServer };

--- a/app/frontend/webserver/handlers/__tests__/index.test.js
+++ b/app/frontend/webserver/handlers/__tests__/index.test.js
@@ -7,6 +7,9 @@ describe('index', () => {
   let mockHandleGridTradeArchiveDelete;
   let mockHandleClosedTradesSetPeriod;
   let mockHandle404;
+
+  let mockLoginLimiter;
+
   beforeEach(async () => {
     jest.clearAllMocks().resetModules();
 
@@ -15,6 +18,8 @@ describe('index', () => {
     mockHandleGridTradeArchiveDelete = jest.fn().mockResolvedValue(true);
     mockHandleClosedTradesSetPeriod = jest.fn().mockResolvedValue(true);
     mockHandle404 = jest.fn().mockResolvedValue(true);
+
+    mockLoginLimiter = jest.fn().mockReturnValue(true);
 
     jest.mock('../auth', () => ({
       handleAuth: mockHandleAuth
@@ -37,11 +42,15 @@ describe('index', () => {
     }));
 
     index = require('../index');
-    await index.setHandlers('logger', 'app');
+    await index.setHandlers('logger', 'app', {
+      loginLimiter: mockLoginLimiter
+    });
   });
 
   it('triggers handleAuth', () => {
-    expect(mockHandle404).toHaveBeenCalledWith('logger', 'app');
+    expect(mockHandleAuth).toHaveBeenCalledWith('logger', 'app', {
+      loginLimiter: mockLoginLimiter
+    });
   });
 
   it('triggers handleGridTradeArchiveGet', () => {

--- a/app/frontend/webserver/handlers/index.js
+++ b/app/frontend/webserver/handlers/index.js
@@ -4,8 +4,8 @@ const { handleGridTradeArchiveDelete } = require('./grid-trade-archive-delete');
 const { handleClosedTradesSetPeriod } = require('./closed-trades-set-period');
 const { handle404 } = require('./404');
 
-const setHandlers = async (logger, app) => {
-  await handleAuth(logger, app);
+const setHandlers = async (logger, app, { loginLimiter }) => {
+  await handleAuth(logger, app, { loginLimiter });
   await handleGridTradeArchiveGet(logger, app);
   await handleGridTradeArchiveDelete(logger, app);
   await handleClosedTradesSetPeriod(logger, app);

--- a/app/helpers/cache.js
+++ b/app/helpers/cache.js
@@ -147,6 +147,7 @@ const hdel = async (key, field) => {
 };
 
 module.exports = {
+  redis,
   keys,
   set,
   get,

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -67,7 +67,24 @@
       "__description": "Set a boolean to enable authentication on the bot.",
       "__format": "boolean"
     },
-    "password": "BINANCE_AUTHENTICATION_PASSWORD"
+    "password": "BINANCE_AUTHENTICATION_PASSWORD",
+    "loginLimiter": {
+      "maxConsecutiveFails": {
+        "__name": "BINANCE_AUTHENTICATION_LOGIN_LIMITER_MAX_CONSECUTIVE_FAILS",
+        "__description": "Set number of allowed login failures. If failed maximum consecutive fails, the bot will block the request based on the block duration (seconds).",
+        "__format": "number"
+      },
+      "duration": {
+        "__name": "BINANCE_AUTHENTICATION_LOGIN_LIMITER_DURATION",
+        "__description": "Set seconds for storing points since the first login failure.",
+        "__format": "number"
+      },
+      "blockDuration": {
+        "__name": "BINANCE_AUTHENTICATION_LOGIN_LIMITER_BLOCK_DURATION",
+        "__description": "Set seconds for blocking the request after reaching maximum consecutive login failures.",
+        "__format": "number"
+      }
+    }
   },
   "jobs": {
     "alive": {

--- a/config/default.json
+++ b/config/default.json
@@ -40,7 +40,12 @@
   },
   "authentication": {
     "enabled": true,
-    "password": "123456"
+    "password": "123456",
+    "loginLimiter": {
+      "maxConsecutiveFails": 5,
+      "duration": 10800,
+      "blockDuration": 900
+    }
   },
   "jobs": {
     "alive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "moment-timezone": "^0.5.33",
         "mongodb": "4.1.0",
         "pubsub-js": "^1.9.3",
+        "rate-limiter-flexible": "^2.2.4",
         "redlock": "^4.2.0",
         "request-ip": "^2.1.3",
         "uuid": "^8.3.2",
@@ -5866,9 +5867,9 @@
       }
     },
     "node_modules/binance-api-node": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/binance-api-node/-/binance-api-node-0.11.11.tgz",
-      "integrity": "sha512-qxIesf6TR7W9+aWnA97OicpTZAbtuKDBrRyEcXAjvxSQmfVzLqHI/bBfkGK8LnkVYyp0yxvcQ7mkccS7nAJ04w==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/binance-api-node/-/binance-api-node-0.11.13.tgz",
+      "integrity": "sha512-721cGhm0Sa+4Uy5bPqeQswJLf6MxHKk1YbjGtiB7aR+N7Q58sUgnJ+jCfAhT7Rghgn3Yn8nzND2zF5YKGSjdIg==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1",
         "isomorphic-ws": "^4.0.1",
@@ -23395,6 +23396,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/rate-limiter-flexible": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.2.4.tgz",
+      "integrity": "sha512-8u4k5b1afuBcfydX0L0l3J2PNjgcuo3zua8plhvIisyDqOBldrCwfSFut/Fj00LAB1nxJYVM9jeszr2rZyDhQw=="
+    },
     "node_modules/raw-body": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
@@ -31052,9 +31058,9 @@
       "dev": true
     },
     "binance-api-node": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/binance-api-node/-/binance-api-node-0.11.11.tgz",
-      "integrity": "sha512-qxIesf6TR7W9+aWnA97OicpTZAbtuKDBrRyEcXAjvxSQmfVzLqHI/bBfkGK8LnkVYyp0yxvcQ7mkccS7nAJ04w==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/binance-api-node/-/binance-api-node-0.11.13.tgz",
+      "integrity": "sha512-721cGhm0Sa+4Uy5bPqeQswJLf6MxHKk1YbjGtiB7aR+N7Q58sUgnJ+jCfAhT7Rghgn3Yn8nzND2zF5YKGSjdIg==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "isomorphic-ws": "^4.0.1",
@@ -44247,6 +44253,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "rate-limiter-flexible": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.2.4.tgz",
+      "integrity": "sha512-8u4k5b1afuBcfydX0L0l3J2PNjgcuo3zua8plhvIisyDqOBldrCwfSFut/Fj00LAB1nxJYVM9jeszr2rZyDhQw=="
     },
     "raw-body": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "moment-timezone": "^0.5.33",
     "mongodb": "4.1.0",
     "pubsub-js": "^1.9.3",
+    "rate-limiter-flexible": "^2.2.4",
     "redlock": "^4.2.0",
     "request-ip": "^2.1.3",
     "uuid": "^8.3.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR will allow the bot to prevent brute force attacks for login. 

It will utilise the rate limit requests for consecutive login failures. 

The rate limit will prevent the user requests once the user failed configured amount of login failures. 

The issue was raised by @caebwallace. Initially, it was suggested using fail2ban. However, it is now alternatively to use the rate limiter inside of the bot due to there are Windows users who do not have fail2ban in the system.

The rate limiter can be configured using the environment parameters.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#293 #281 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To remove the block, go to Redis and remove the login key.

```bash
$ docker exec -it binance-redis /bin/bash
$ redis-cli
> AUTH <redis password>
> KEYS *
> DEL login:::ffff:<IP address>
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in my server. 
Test code has been written.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/5715919/132074486-dc47f0f4-d6cc-4f98-b527-abf766783dd3.png)

Slack message:
![image](https://user-images.githubusercontent.com/5715919/132074523-2052879c-0f96-41b0-ad83-6b2214aeabd0.png)

After failed 5 times:
![image](https://user-images.githubusercontent.com/5715919/132074557-b9baf099-0d6a-4e76-bace-66e0c83a77ba.png)

