### PR TITLE
feat: added estimates for quote handled by bot

### DIFF
--- a/public/js/AccountWrapper.js
+++ b/public/js/AccountWrapper.js
@@ -37,10 +37,11 @@ class AccountWrapper extends React.Component {
               className='px-2 py-1'>
               <button
                 type='button'
-                className='btn btn-sm btn-link btn-account-balance text-uppercase font-weight-bold'>
+                className='btn btn-sm btn-link btn-account-balance text-uppercase font-weight-bold text-left'>
                 <span className="pr-2">Account Balance</span>
+                <br className="d-block d-sm-none" />
                 <span className="text-success">
-                  (Managed by bot: {Object.keys(groupedEstimates).map((key) => `[${key}: ${parseFloat(groupedEstimates[key]['value']).toFixed(groupedEstimates[key]['quotePrecision'])}]`).join(' ')})
+                  {Object.keys(groupedEstimates).map((key) => `[${key}: ${parseFloat(groupedEstimates[key]['value']).toFixed(groupedEstimates[key]['quotePrecision'])}]`).join(' ')}
                 </span>
               </button>
             </Accordion.Toggle>

--- a/public/js/AccountWrapper.js
+++ b/public/js/AccountWrapper.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-undef */
 class AccountWrapper extends React.Component {
   render() {
-    const { accountInfo, dustTransfer, sendWebSocket, isAuthenticated } =
+    const { accountInfo, dustTransfer, sendWebSocket, isAuthenticated, symbolEstimates } =
       this.props;
 
     const assets = accountInfo.balances.map((balance, index) => {
@@ -13,6 +13,19 @@ class AccountWrapper extends React.Component {
           balance={balance}></AccountWrapperAsset>
       );
     });
+
+    let groupedEstimates = {};
+    symbolEstimates.forEach((symbol) => {
+      if (!Object.keys(groupedEstimates).includes(symbol.quoteAsset)) {
+        groupedEstimates[symbol.quoteAsset] = {};
+        groupedEstimates[symbol.quoteAsset]['value'] = 0;
+        groupedEstimates[symbol.quoteAsset]['quotePrecision'] = parseFloat(symbol.tickSize) === 1 ? 0 : symbol.tickSize.indexOf(1) - 1;
+      }
+
+      groupedEstimates[symbol.quoteAsset]['value'] += symbol.estimatedValue;
+    });
+
+    console.log(groupedEstimates);
 
     return (
       <div className='accordion-wrapper account-wrapper'>
@@ -25,7 +38,10 @@ class AccountWrapper extends React.Component {
               <button
                 type='button'
                 className='btn btn-sm btn-link btn-account-balance text-uppercase font-weight-bold'>
-                Account Balance
+                <span className="pr-2">Account Balance</span>
+                <span className="text-success">
+                  (Managed by bot: {Object.keys(groupedEstimates).map((key) => `[${key}: ${parseFloat(groupedEstimates[key]['value']).toFixed(groupedEstimates[key]['quotePrecision'])}]`).join(' ')})
+                </span>
               </button>
             </Accordion.Toggle>
             <Accordion.Collapse eventKey='0'>
@@ -44,7 +60,7 @@ class AccountWrapper extends React.Component {
             </Accordion.Collapse>
           </Card>
         </Accordion>
-      </div>
+      </div >
     );
   }
 }

--- a/public/js/App.js
+++ b/public/js/App.js
@@ -265,6 +265,15 @@ class App extends React.Component {
       );
     });
 
+    const symbolEstimates = symbols.map((symbol) => {
+      return {
+        'baseAsset': symbol.symbolInfo.baseAsset,
+        'quoteAsset': symbol.symbolInfo.quoteAsset,
+        'estimatedValue': symbol.baseAssetBalance.estimatedValue,
+        'tickSize': symbol.symbolInfo.filterPrice.tickSize
+      };
+    });
+
     return (
       <React.Fragment>
         <Header
@@ -287,6 +296,7 @@ class App extends React.Component {
                 accountInfo={accountInfo}
                 dustTransfer={dustTransfer}
                 sendWebSocket={this.sendWebSocket}
+                symbolEstimates={symbolEstimates}
               />
               <ProfitLossWrapper
                 isAuthenticated={isAuthenticated}


### PR DESCRIPTION
## Description

Added estimates for quote handled by bot in the Account Balance tab, similar to Issue #303, but for every coin pair handled by the bot currently.

It recycles estimates shown in the frontend cards and simply sums it up in the title.
It supports not only USDT, but all pairs currently analyzed by the bot at the current time.

## How Has This Been Tested?

It has been tested on both the dev and production APIs.

## Screenshots (if appropriate):

![immagine](https://user-images.githubusercontent.com/21985554/132756242-b76403d3-1622-4e6a-9913-d3f8f7f4e71f.png)

## Special thanks to

@sentientmachin3