### PR TITLE
refactor: moved estimates label to open trades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Clear exchange/symbol info cache in the Redis periodically - [#284](https://github.com/chrisleekr/binance-trading-bot/issues/284)
 - Added minimum required order amount - [#84](https://github.com/chrisleekr/binance-trading-bot/issues/84)
+- Added estimates for quote assets - Thanks [@ilbuonmarcio](https://github.com/ilbuonmarcio) - [#305](https://github.com/chrisleekr/binance-trading-bot/pull/305)
 
 ## [0.0.78] - 2021-09-05
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.77",
+      "version": "0.0.78",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/public/css/App.css
+++ b/public/css/App.css
@@ -740,7 +740,7 @@ input[type='number'] {
   background-color: #272b38;
 
   display: flex;
-  flex-flow: row wrap;
+  flex-flow: row nowrap;
 }
 
 .profit-loss-asset {

--- a/public/js/AccountWrapper.js
+++ b/public/js/AccountWrapper.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-undef */
 class AccountWrapper extends React.Component {
   render() {
-    const { accountInfo, dustTransfer, sendWebSocket, isAuthenticated } =
+    const { accountInfo, dustTransfer, sendWebSocket, isAuthenticated, symbolEstimates } =
       this.props;
 
     const assets = accountInfo.balances.map((balance, index) => {
@@ -13,6 +13,19 @@ class AccountWrapper extends React.Component {
           balance={balance}></AccountWrapperAsset>
       );
     });
+
+    let groupedEstimates = {};
+    symbolEstimates.forEach((symbol) => {
+      if (!Object.keys(groupedEstimates).includes(symbol.quoteAsset)) {
+        groupedEstimates[symbol.quoteAsset] = {};
+        groupedEstimates[symbol.quoteAsset]['value'] = 0;
+        groupedEstimates[symbol.quoteAsset]['quotePrecision'] = parseFloat(symbol.tickSize) === 1 ? 0 : symbol.tickSize.indexOf(1) - 1;
+      }
+
+      groupedEstimates[symbol.quoteAsset]['value'] += symbol.estimatedValue;
+    });
+
+    console.log(groupedEstimates);
 
     return (
       <div className='accordion-wrapper account-wrapper'>
@@ -24,8 +37,12 @@ class AccountWrapper extends React.Component {
               className='px-2 py-1'>
               <button
                 type='button'
-                className='btn btn-sm btn-link btn-account-balance text-uppercase font-weight-bold'>
-                Account Balance
+                className='btn btn-sm btn-link btn-account-balance text-uppercase font-weight-bold text-left'>
+                <span className="pr-2">Account Balance</span>
+                <br className="d-block d-sm-none" />
+                <span className="text-success">
+                  {Object.keys(groupedEstimates).map((key) => `[${key}: ${parseFloat(groupedEstimates[key]['value']).toFixed(groupedEstimates[key]['quotePrecision'])}]`).join(' ')}
+                </span>
               </button>
             </Accordion.Toggle>
             <Accordion.Collapse eventKey='0'>
@@ -44,7 +61,7 @@ class AccountWrapper extends React.Component {
             </Accordion.Collapse>
           </Card>
         </Accordion>
-      </div>
+      </div >
     );
   }
 }

--- a/public/js/AccountWrapper.js
+++ b/public/js/AccountWrapper.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-undef */
 class AccountWrapper extends React.Component {
   render() {
-    const { accountInfo, dustTransfer, sendWebSocket, isAuthenticated, symbolEstimates } =
+    const { accountInfo, dustTransfer, sendWebSocket, isAuthenticated } =
       this.props;
 
     const assets = accountInfo.balances.map((balance, index) => {
@@ -13,19 +13,6 @@ class AccountWrapper extends React.Component {
           balance={balance}></AccountWrapperAsset>
       );
     });
-
-    let groupedEstimates = {};
-    symbolEstimates.forEach((symbol) => {
-      if (!Object.keys(groupedEstimates).includes(symbol.quoteAsset)) {
-        groupedEstimates[symbol.quoteAsset] = {};
-        groupedEstimates[symbol.quoteAsset]['value'] = 0;
-        groupedEstimates[symbol.quoteAsset]['quotePrecision'] = parseFloat(symbol.tickSize) === 1 ? 0 : symbol.tickSize.indexOf(1) - 1;
-      }
-
-      groupedEstimates[symbol.quoteAsset]['value'] += symbol.estimatedValue;
-    });
-
-    console.log(groupedEstimates);
 
     return (
       <div className='accordion-wrapper account-wrapper'>
@@ -39,10 +26,6 @@ class AccountWrapper extends React.Component {
                 type='button'
                 className='btn btn-sm btn-link btn-account-balance text-uppercase font-weight-bold text-left'>
                 <span className="pr-2">Account Balance</span>
-                <br className="d-block d-sm-none" />
-                <span className="text-success">
-                  {Object.keys(groupedEstimates).map((key) => `[${key}: ${parseFloat(groupedEstimates[key]['value']).toFixed(groupedEstimates[key]['quotePrecision'])}]`).join(' ')}
-                </span>
               </button>
             </Accordion.Toggle>
             <Accordion.Collapse eventKey='0'>

--- a/public/js/App.js
+++ b/public/js/App.js
@@ -116,7 +116,7 @@ class App extends React.Component {
       let response = {};
       try {
         response = JSON.parse(evt.data);
-      } catch (_e) {}
+      } catch (_e) { }
 
       if (response.type === 'latest') {
         // Set states
@@ -296,7 +296,6 @@ class App extends React.Component {
                 accountInfo={accountInfo}
                 dustTransfer={dustTransfer}
                 sendWebSocket={this.sendWebSocket}
-                symbolEstimates={symbolEstimates}
               />
               <ProfitLossWrapper
                 isAuthenticated={isAuthenticated}
@@ -304,6 +303,7 @@ class App extends React.Component {
                 closedTradesSetting={closedTradesSetting}
                 closedTrades={closedTrades}
                 sendWebSocket={this.sendWebSocket}
+                symbolEstimates={symbolEstimates}
               />
             </div>
             <div className='coin-wrappers'>{coinWrappers}</div>

--- a/public/js/App.js
+++ b/public/js/App.js
@@ -265,6 +265,15 @@ class App extends React.Component {
       );
     });
 
+    const symbolEstimates = symbols.map((symbol) => {
+      return {
+        'baseAsset': symbol.symbolInfo.baseAsset,
+        'quoteAsset': symbol.symbolInfo.quoteAsset,
+        'estimatedValue': symbol.baseAssetBalance.estimatedValue,
+        'tickSize': symbol.symbolInfo.filterPrice.tickSize
+      };
+    });
+
     return (
       <React.Fragment>
         <Header
@@ -287,6 +296,7 @@ class App extends React.Component {
                 accountInfo={accountInfo}
                 dustTransfer={dustTransfer}
                 sendWebSocket={this.sendWebSocket}
+                symbolEstimates={symbolEstimates}
               />
               <ProfitLossWrapper
                 isAuthenticated={isAuthenticated}

--- a/public/js/ProfitLossWrapper.js
+++ b/public/js/ProfitLossWrapper.js
@@ -112,7 +112,7 @@ class ProfitLossWrapper extends React.Component {
   }
 
   render() {
-    const { sendWebSocket, isAuthenticated, closedTrades } = this.props;
+    const { sendWebSocket, isAuthenticated, closedTrades, symbolEstimates } = this.props;
     const { totalPnL, symbols, selectedPeriod, closedTradesLoading } =
       this.state;
 
@@ -167,6 +167,17 @@ class ProfitLossWrapper extends React.Component {
       }
     );
 
+    let groupedEstimates = {};
+    symbolEstimates.forEach((symbol) => {
+      if (!Object.keys(groupedEstimates).includes(symbol.quoteAsset)) {
+        groupedEstimates[symbol.quoteAsset] = {};
+        groupedEstimates[symbol.quoteAsset]['value'] = 0;
+        groupedEstimates[symbol.quoteAsset]['quotePrecision'] = parseFloat(symbol.tickSize) === 1 ? 0 : symbol.tickSize.indexOf(1) - 1;
+      }
+
+      groupedEstimates[symbol.quoteAsset]['value'] += symbol.estimatedValue;
+    });
+
     return (
       <div className='profit-loss-container'>
         <div className='accordion-wrapper profit-loss-accordion-wrapper profit-loss-open-trades-accordion-wrapper'>
@@ -175,8 +186,8 @@ class ProfitLossWrapper extends React.Component {
               <Card.Header className='px-2 py-1'>
                 <div className='d-flex flex-row justify-content-between'>
                   <div className='flex-column-left'>
-                    <div className='btn-profit-loss text-uppercase font-weight-bold'>
-                      Open Trades{' '}
+                    <div className='btn-profit-loss text-uppercase text-left font-weight-bold'>
+                      <span>Open Trades</span>{' '}
                       <OverlayTrigger
                         trigger='click'
                         key='profit-loss-overlay'
@@ -199,6 +210,11 @@ class ProfitLossWrapper extends React.Component {
                           <i className='fas fa-question-circle fa-sm'></i>
                         </Button>
                       </OverlayTrigger>
+                      {' '}
+                      <br className="d-block d-sm-none" />
+                      <span className="text-success">
+                        {Object.keys(groupedEstimates).map((key) => `[${key}: ${parseFloat(groupedEstimates[key]['value']).toFixed(groupedEstimates[key]['quotePrecision'])}]`).join(' ')}
+                      </span>
                     </div>
                   </div>
                   <div className='flex-column-right pt-2'>
@@ -262,36 +278,32 @@ class ProfitLossWrapper extends React.Component {
                   <div className='flex-column-right pt-2'>
                     <button
                       type='button'
-                      className={`btn btn-period ml-1 btn-sm ${
-                        selectedPeriod === 'd' ? 'btn-info' : 'btn-light'
-                      }`}
+                      className={`btn btn-period ml-1 btn-sm ${selectedPeriod === 'd' ? 'btn-info' : 'btn-light'
+                        }`}
                       onClick={() => this.setSelectedPeriod('d')}
                       title='Day'>
                       D
                     </button>
                     <button
                       type='button'
-                      className={`btn btn-period ml-1 btn-sm ${
-                        selectedPeriod === 'w' ? 'btn-info' : 'btn-light'
-                      }`}
+                      className={`btn btn-period ml-1 btn-sm ${selectedPeriod === 'w' ? 'btn-info' : 'btn-light'
+                        }`}
                       onClick={() => this.setSelectedPeriod('w')}
                       title='Week'>
                       W
                     </button>
                     <button
                       type='button'
-                      className={`btn btn-period ml-1 btn-sm ${
-                        selectedPeriod === 'm' ? 'btn-info' : 'btn-light'
-                      }`}
+                      className={`btn btn-period ml-1 btn-sm ${selectedPeriod === 'm' ? 'btn-info' : 'btn-light'
+                        }`}
                       onClick={() => this.setSelectedPeriod('m')}
                       title='Month'>
                       M
                     </button>
                     <button
                       type='button'
-                      className={`btn btn-period ml-1 btn-sm ${
-                        selectedPeriod === 'a' ? 'btn-info' : 'btn-light'
-                      }`}
+                      className={`btn btn-period ml-1 btn-sm ${selectedPeriod === 'a' ? 'btn-info' : 'btn-light'
+                        }`}
                       onClick={() => this.setSelectedPeriod('a')}
                       title='All'>
                       All
@@ -318,7 +330,7 @@ class ProfitLossWrapper extends React.Component {
             </Card>
           </Accordion>
         </div>
-      </div>
+      </div >
     );
   }
 }

--- a/public/js/ProfitLossWrapper.js
+++ b/public/js/ProfitLossWrapper.js
@@ -112,13 +112,29 @@ class ProfitLossWrapper extends React.Component {
   }
 
   render() {
-    const { sendWebSocket, isAuthenticated, closedTrades, symbolEstimates } = this.props;
+    const { sendWebSocket, isAuthenticated, closedTrades, symbolEstimates } =
+      this.props;
     const { totalPnL, symbols, selectedPeriod, closedTradesLoading } =
       this.state;
 
     if (_.isEmpty(totalPnL)) {
       return '';
     }
+
+    const groupedEstimates = {};
+    symbolEstimates.forEach(symbol => {
+      if (groupedEstimates[symbol.quoteAsset] === undefined) {
+        groupedEstimates[symbol.quoteAsset] = {
+          value: 0,
+          quotePrecision:
+            parseFloat(symbol.tickSize) === 1
+              ? 0
+              : symbol.tickSize.indexOf(1) - 1
+        };
+      }
+
+      groupedEstimates[symbol.quoteAsset].value += symbol.estimatedValue;
+    });
 
     const openTradeWrappers = Object.values(totalPnL).map((pnl, index) => {
       const percentage =
@@ -128,12 +144,20 @@ class ProfitLossWrapper extends React.Component {
           key={`open-trade-pnl-` + index}
           className='profit-loss-wrapper pt-2 pl-2 pr-2 pb-0'>
           <div className='profit-loss-wrapper-body'>
-            <span className='profit-loss-asset'>{pnl.asset}</span>{' '}
-            <span className='profit-loss-value'>
+            <div className='profit-loss-asset'>
+              {pnl.asset}
+              <br />
+              <div className='text-success text-truncate'>
+                {groupedEstimates[pnl.asset].value.toFixed(
+                  groupedEstimates[pnl.asset].quotePrecision
+                )}
+              </div>
+            </div>{' '}
+            <div className='profit-loss-value'>
               {pnl.profit > 0 ? '+' : ''}
               {pnl.profit.toFixed(5)}
               <br />({percentage}%)
-            </span>
+            </div>
           </div>
         </div>
       );
@@ -167,17 +191,6 @@ class ProfitLossWrapper extends React.Component {
       }
     );
 
-    let groupedEstimates = {};
-    symbolEstimates.forEach((symbol) => {
-      if (!Object.keys(groupedEstimates).includes(symbol.quoteAsset)) {
-        groupedEstimates[symbol.quoteAsset] = {};
-        groupedEstimates[symbol.quoteAsset]['value'] = 0;
-        groupedEstimates[symbol.quoteAsset]['quotePrecision'] = parseFloat(symbol.tickSize) === 1 ? 0 : symbol.tickSize.indexOf(1) - 1;
-      }
-
-      groupedEstimates[symbol.quoteAsset]['value'] += symbol.estimatedValue;
-    });
-
     return (
       <div className='profit-loss-container'>
         <div className='accordion-wrapper profit-loss-accordion-wrapper profit-loss-open-trades-accordion-wrapper'>
@@ -210,11 +223,6 @@ class ProfitLossWrapper extends React.Component {
                           <i className='fas fa-question-circle fa-sm'></i>
                         </Button>
                       </OverlayTrigger>
-                      {' '}
-                      <br className="d-block d-sm-none" />
-                      <span className="text-success">
-                        {Object.keys(groupedEstimates).map((key) => `[${key}: ${parseFloat(groupedEstimates[key]['value']).toFixed(groupedEstimates[key]['quotePrecision'])}]`).join(' ')}
-                      </span>
                     </div>
                   </div>
                   <div className='flex-column-right pt-2'>
@@ -278,32 +286,36 @@ class ProfitLossWrapper extends React.Component {
                   <div className='flex-column-right pt-2'>
                     <button
                       type='button'
-                      className={`btn btn-period ml-1 btn-sm ${selectedPeriod === 'd' ? 'btn-info' : 'btn-light'
-                        }`}
+                      className={`btn btn-period ml-1 btn-sm ${
+                        selectedPeriod === 'd' ? 'btn-info' : 'btn-light'
+                      }`}
                       onClick={() => this.setSelectedPeriod('d')}
                       title='Day'>
                       D
                     </button>
                     <button
                       type='button'
-                      className={`btn btn-period ml-1 btn-sm ${selectedPeriod === 'w' ? 'btn-info' : 'btn-light'
-                        }`}
+                      className={`btn btn-period ml-1 btn-sm ${
+                        selectedPeriod === 'w' ? 'btn-info' : 'btn-light'
+                      }`}
                       onClick={() => this.setSelectedPeriod('w')}
                       title='Week'>
                       W
                     </button>
                     <button
                       type='button'
-                      className={`btn btn-period ml-1 btn-sm ${selectedPeriod === 'm' ? 'btn-info' : 'btn-light'
-                        }`}
+                      className={`btn btn-period ml-1 btn-sm ${
+                        selectedPeriod === 'm' ? 'btn-info' : 'btn-light'
+                      }`}
                       onClick={() => this.setSelectedPeriod('m')}
                       title='Month'>
                       M
                     </button>
                     <button
                       type='button'
-                      className={`btn btn-period ml-1 btn-sm ${selectedPeriod === 'a' ? 'btn-info' : 'btn-light'
-                        }`}
+                      className={`btn btn-period ml-1 btn-sm ${
+                        selectedPeriod === 'a' ? 'btn-info' : 'btn-light'
+                      }`}
                       onClick={() => this.setSelectedPeriod('a')}
                       title='All'>
                       All
@@ -330,7 +342,7 @@ class ProfitLossWrapper extends React.Component {
             </Card>
           </Accordion>
         </div>
-      </div >
+      </div>
     );
   }
 }


### PR DESCRIPTION
## Description

Moved estimates label to open trades, follows #305

# Screenshots
![immagine](https://user-images.githubusercontent.com/21985554/132771141-a31a8b63-59e3-4a88-adc1-934821afc0ff.png)
