### PR TITLE
fix: updated small bnb btc max value as per updated docs

### DIFF
--- a/app/cronjob/trailingTradeHelper/common.js
+++ b/app/cronjob/trailingTradeHelper/common.js
@@ -116,14 +116,14 @@ const extendBalancesWithDustTransfer = async (_logger, rawAccountInfo) => {
       }
 
       // https://academy.binance.com/en/articles/converting-dust-on-binance
-      // In order to qualify the dust must have a value less than 0.0003BTC
+      // In order to qualify the dust must have a value less than 0.001BTC
 
       balance.estimatedBTC = Number(
         parseFloat(cachedLatestCandle.close) * parseFloat(balance.free)
       ).toFixed(8);
 
-      // If the estimated BTC is less than 0.0003, then set dust transfer
-      if (balance.estimatedBTC <= 0.0003) {
+      // If the estimated BTC is less than 0.001, then set dust transfer
+      if (balance.estimatedBTC <= 0.001) {
         balance.canDustTransfer = true;
       }
 

--- a/public/js/DustTransferIcon.js
+++ b/public/js/DustTransferIcon.js
@@ -121,7 +121,7 @@ class DustTransferIcon extends React.Component {
           </Modal.Header>
           <Modal.Body>
             <p className='d-block text-muted mb-2'>
-              You can convert balances with a valuation below 0.0003 BTC to BNB
+              You can convert balances with a valuation below 0.001 BTC to BNB
               once every 6 hours. It is not currently possible to convert
               delisted coins.
             </p>


### PR DESCRIPTION
Updated small dust transfer for BNB's BTC threshold to new 0.001 BTC maximum value.

## Related Issue

#344 