### PR TITLE
feat: added status basic endpoint

### DIFF
--- a/app/frontend/webserver/handlers/index.js
+++ b/app/frontend/webserver/handlers/index.js
@@ -3,12 +3,14 @@ const { handleGridTradeArchiveGet } = require('./grid-trade-archive-get');
 const { handleGridTradeArchiveDelete } = require('./grid-trade-archive-delete');
 const { handleClosedTradesSetPeriod } = require('./closed-trades-set-period');
 const { handle404 } = require('./404');
+const { handleStatus } = require('./status');
 
 const setHandlers = async (logger, app, { loginLimiter }) => {
   await handleAuth(logger, app, { loginLimiter });
   await handleGridTradeArchiveGet(logger, app);
   await handleGridTradeArchiveDelete(logger, app);
   await handleClosedTradesSetPeriod(logger, app);
+  await handleStatus(logger, app);
   await handle404(logger, app);
 };
 

--- a/app/frontend/webserver/handlers/status.js
+++ b/app/frontend/webserver/handlers/status.js
@@ -1,0 +1,24 @@
+const requestIp = require('request-ip');
+
+const handleStatus = async (funcLogger, app) => {
+  const logger = funcLogger.child({ endpoint: '/status' });
+
+  app.route('/status').get(async (req, res) => {
+    const clientIp = requestIp.getClientIp(req);
+
+    logger.info(
+      {
+        clientIp
+      },
+      'handle status monitoring endpoint'
+    );
+
+    return res.send({
+      success: true,
+      status: 200,
+      message: 'OK'
+    });
+  });
+};
+
+module.exports = { handleStatus };


### PR DESCRIPTION
## Description

Added `/status` basic endpoint for monitoring using Grafana/Prometheus/UptimeKuma.
I just added a `/status` endpoint, which replies (fast) with an HTTP 200 and a basic json object if the body.

This implementation right now doesn't check for `mongodb` or `redis` availability, yet it's still pretty useful in itself to make sure the bot is at least up.

## Related Issue

#341

## Motivation and Context

Monitoring the bot is a good thing, and this is an easy way to help with that!

## How Has This Been Tested?

Tested on TEST environment, should be ok even in production environment aswell.