### PR TITLE
feat: account balance quote estimates for bot's currently handling assets

### DIFF
--- a/app/frontend/webserver/handlers/__tests__/index.test.js
+++ b/app/frontend/webserver/handlers/__tests__/index.test.js
@@ -7,6 +7,7 @@ describe('index', () => {
   let mockHandleGridTradeArchiveDelete;
   let mockHandleClosedTradesSetPeriod;
   let mockHandle404;
+  let mockHandleStatus;
 
   let mockLoginLimiter;
 
@@ -18,6 +19,7 @@ describe('index', () => {
     mockHandleGridTradeArchiveDelete = jest.fn().mockResolvedValue(true);
     mockHandleClosedTradesSetPeriod = jest.fn().mockResolvedValue(true);
     mockHandle404 = jest.fn().mockResolvedValue(true);
+    mockHandleStatus = jest.fn().mockResolvedValue(true);
 
     mockLoginLimiter = jest.fn().mockReturnValue(true);
 
@@ -39,6 +41,10 @@ describe('index', () => {
 
     jest.mock('../404', () => ({
       handle404: mockHandle404
+    }));
+
+    jest.mock('../status', () => ({
+      handleStatus: mockHandleStatus
     }));
 
     index = require('../index');
@@ -69,6 +75,10 @@ describe('index', () => {
       'logger',
       'app'
     );
+  });
+
+  it('triggers handleStatus', () => {
+    expect(mockHandleStatus).toHaveBeenCalledWith('logger', 'app');
   });
 
   it('triggers handle404', () => {

--- a/app/frontend/webserver/handlers/__tests__/status.test.js
+++ b/app/frontend/webserver/handlers/__tests__/status.test.js
@@ -1,0 +1,26 @@
+/* eslint-disable global-require */
+describe('webserver/handlers/status', () => {
+  const appMock = {};
+
+  let resSendMock;
+
+  beforeEach(async () => {
+    resSendMock = jest.fn().mockResolvedValue(true);
+    appMock.get = jest.fn().mockImplementation((_path, func) => {
+      func(null, { send: resSendMock });
+    });
+    const loggerMock = require('../../../../helpers/logger');
+
+    const { handleStatus } = require('../status');
+
+    await handleStatus(loggerMock, appMock);
+  });
+
+  it('triggers res.send', () => {
+    expect(resSendMock).toHaveBeenCalledWith({
+      success: true,
+      status: 200,
+      message: 'OK'
+    });
+  });
+});

--- a/app/frontend/webserver/handlers/status.js
+++ b/app/frontend/webserver/handlers/status.js
@@ -1,24 +1,11 @@
-const requestIp = require('request-ip');
-
 const handleStatus = async (funcLogger, app) => {
-  const logger = funcLogger.child({ endpoint: '/status' });
-
-  app.route('/status').get(async (req, res) => {
-    const clientIp = requestIp.getClientIp(req);
-
-    logger.info(
-      {
-        clientIp
-      },
-      'handle status monitoring endpoint'
-    );
-
-    return res.send({
+  app.get('/status', (req, res) =>
+    res.send({
       success: true,
       status: 200,
       message: 'OK'
-    });
-  });
+    })
+  );
 };
 
 module.exports = { handleStatus };

--- a/public/css/App.css
+++ b/public/css/App.css
@@ -280,6 +280,9 @@ input[type='number'] {
   display: flex;
   flex-flow: row wrap;
 }
+.account-asset-row-valignfix {
+  opacity: 0;
+}
 
 .account-asset-label {
   flex: 1 40%;

--- a/public/js/AccountWrapper.js
+++ b/public/js/AccountWrapper.js
@@ -3,14 +3,33 @@
 /* eslint-disable no-undef */
 class AccountWrapper extends React.Component {
   render() {
-    const { accountInfo, dustTransfer, sendWebSocket, isAuthenticated } =
-      this.props;
+    const {
+      accountInfo,
+      dustTransfer,
+      sendWebSocket,
+      isAuthenticated,
+      quoteEstimates
+    } = this.props;
 
     const assets = accountInfo.balances.map((balance, index) => {
+      let quoteEstimate = quoteEstimates.filter(
+        elem => elem.baseAsset === balance.asset
+      );
+
+      if (quoteEstimate.length == 1) {
+        quoteEstimate = {
+          quote: quoteEstimate[0]['quoteAsset'],
+          estimate: quoteEstimate[0]['estimatedValue']
+        };
+      } else {
+        quoteEstimate = null;
+      }
+
       return (
         <AccountWrapperAsset
           key={`account-wrapper-` + index}
-          balance={balance}></AccountWrapperAsset>
+          balance={balance}
+          quoteEstimate={quoteEstimate}></AccountWrapperAsset>
       );
     });
 

--- a/public/js/AccountWrapperAsset.js
+++ b/public/js/AccountWrapperAsset.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-undef */
 class AccountWrapperAsset extends React.Component {
   render() {
-    const { balance } = this.props;
+    const { balance, quoteEstimate } = this.props;
 
     return (
       <div className='account-wrapper-asset pt-2 pl-2 pr-2 pb-0'>
@@ -29,6 +29,20 @@ class AccountWrapperAsset extends React.Component {
               {parseFloat(balance.locked).toFixed(5)}
             </span>
           </div>
+          {quoteEstimate !== null ? (
+            <div className='account-asset-row'>
+              <span className='account-asset-label text-success font-weight-bold'>
+                In {quoteEstimate.quote}:
+              </span>
+              <span className='account-asset-value text-success font-weight-bold'>
+                {parseFloat(quoteEstimate.estimate).toFixed(5)}
+              </span>
+            </div>
+          ) : (
+            <div className='account-asset-row account-asset-row-valignfix'>
+              <span className='account-asset-label'>placeholder</span>
+            </div>
+          )}
         </div>
       </div>
     );

--- a/public/js/App.js
+++ b/public/js/App.js
@@ -299,6 +299,7 @@ class App extends React.Component {
                 accountInfo={accountInfo}
                 dustTransfer={dustTransfer}
                 sendWebSocket={this.sendWebSocket}
+                quoteEstimates={symbolEstimates}
               />
               <ProfitLossWrapper
                 isAuthenticated={isAuthenticated}


### PR DESCRIPTION
## Description

Shows up detailed assets value as quote current value.
See screenshot attached.

It supports multiple quote asset at the same time, e.g. ETHUSDT and DOGEBTC and AVAXBUSD, showing data properly.

## Related Issue

It also fixes testing on #347, which currently fails tests due to missing test file implementation.

## Motivation and Context

Having this info grouped up on the top panel is better than scrolling for all coins, and that gives you a quick look at your asset portfolio and how much is invested in quote amount for each asset.

## How Has This Been Tested?

Tested on testnet, should be good also for live mode for sure.

## Screenshots (if appropriate):

![Capture](https://user-images.githubusercontent.com/21985554/136697018-bb5ef07a-5fc4-4325-afa6-ab7e73729335.PNG)


