### PR TITLE
fix: update last buy removal threshold min/step

### DIFF
--- a/public/js/SettingIconLastBuyPriceRemoveThreshold.js
+++ b/public/js/SettingIconLastBuyPriceRemoveThreshold.js
@@ -104,8 +104,8 @@ class SettingIconLastBuyPriceRemoveThreshold extends React.Component {
               type='number'
               placeholder={'Enter last buy threshold for ' + quoteAsset}
               required
-              min='0.0001'
-              step='0.0001'
+              min='0.00000001'
+              step='0.00000001'
               data-state-key={quoteAsset}
               value={lastBuyPriceRemoveThresholds[quoteAsset]}
               onChange={this.handleInputChange}

--- a/public/js/SymbolSettingIcon.js
+++ b/public/js/SymbolSettingIcon.js
@@ -390,8 +390,8 @@ class SymbolSettingIcon extends React.Component {
                                       type='number'
                                       placeholder='Enter last buy threshold'
                                       required
-                                      min='0.0001'
-                                      step='0.0001'
+                                      min='0.00000001'
+                                      step='0.00000001'
                                       data-state-key='buy.lastBuyPriceRemoveThreshold'
                                       value={
                                         symbolConfiguration.buy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

@Rayn0r has reported XRPBTC/SHIBBUSD are removing the coin due to the last buy removal threshold cannot be set under the minimum notional.

This PR is rectifying the issue.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#372 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/5715919/139531402-0a7c0243-b72c-4bb8-b3cb-3a30af57943b.png)
