### PR TITLE
fix: ultra wide monitor support

### DIFF
--- a/public/css/App.css
+++ b/public/css/App.css
@@ -303,13 +303,34 @@ input[type='number'] {
 }
 
 .coin-wrapper {
-  width: 25%;
+  width: 8.33%;
   -webkit-border-radius: 10px;
   -moz-border-radius: 10px;
   border-radius: 10px;
   padding: 5px;
   margin-bottom: 10px;
-  flex: 25% auto;
+  flex: 8.33% auto;
+}
+
+@media (max-width: 3400px) {
+  .coin-wrapper {
+    width: 16.66%;
+    flex: 16.66% auto;
+  }
+}
+
+@media (max-width: 2300px) {
+  .coin-wrapper {
+    width: 25%;
+    flex: 25% auto;
+  }
+}
+
+@media (max-width: 1800px) {
+  .coin-wrapper {
+    width: 33.33%;
+    flex: 33.33% auto;
+  }
 }
 
 @media (max-width: 1200px) {

--- a/public/js/SymbolTriggerBuyIcon.js
+++ b/public/js/SymbolTriggerBuyIcon.js
@@ -53,7 +53,7 @@ class SymbolTriggerBuyIcon extends React.Component {
           type='button'
           className='btn btn-sm btn-trigger-grid-trade mr-1 btn-manual-buy'
           onClick={this.handleModalShow}>
-          <i className='fas fa-bolt'></i> Trigger
+          <i className='fas fa-bolt'></i>
         </button>
 
         <Modal show={this.state.showModal} onHide={this.handleModalClose}>

--- a/public/js/SymbolTriggerSellIcon.js
+++ b/public/js/SymbolTriggerSellIcon.js
@@ -53,7 +53,7 @@ class SymbolTriggerSellIcon extends React.Component {
           type='button'
           className='btn btn-sm btn-trigger-grid-trade mr-1 btn-manual-sell'
           onClick={this.handleModalShow}>
-          <i className='fas fa-bolt'></i> Trigger
+          <i className='fas fa-bolt'></i>
         </button>
 
         <Modal show={this.state.showModal} onHide={this.handleModalClose}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Will add support to show up to all 12 columns on ultra wide monitors.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#440 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It's annoying to run multiple browser windows to see more than four columns at once on ultra wide monitor.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on UHD display and on wide multi monitor setup.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/37454226/181297147-78d9b102-4b39-4b38-859a-bf9a59d73cf3.png)
