### PR TITLE
feat: hide unexecuted grid trades in big lists

### DIFF
--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -41,7 +41,7 @@ class CoinWrapperBuySignal extends React.Component {
     } = symbolConfiguration;
 
     const buyGridRows = gridTrade.map((grid, i) => {
-      return (
+      return i >= 10 && !grid.executed && currentGridTradeIndex !== i && currentGridTradeIndex + 1 !== i && gridTrade.length - 1 !== i ? ('') : (
         <React.Fragment key={'coin-wrapper-buy-grid-row-' + symbol + '-' + i}>
           <div className='coin-info-column-grid'>
             <div className='coin-info-column coin-info-column-price'>

--- a/public/js/CoinWrapperSellSignal.js
+++ b/public/js/CoinWrapperSellSignal.js
@@ -43,7 +43,7 @@ class CoinWrapperSellSignal extends React.Component {
     } = symbolConfiguration;
 
     const sellGridRows = gridTrade.map((grid, i) => {
-      return (
+      return i >= 10 && !grid.executed && currentGridTradeIndex !== i && currentGridTradeIndex + 1 !== i && gridTrade.length - 1 !== i ? ('') : (
         <React.Fragment key={'coin-wrapper-sell-grid-row-' + symbol + '-' + i}>
           <div className='coin-info-column-grid'>
             <div className='coin-info-column coin-info-column-price'>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To save the space and make scrolling thru symbols more comfortable an unexecuted grid trade will be compacted in lists with more than 10 items.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#442 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I had to scroll down for too long everytime I wanted to see sell orders or other symbols listed on another rows if there were multiple grid trades defined.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I created up to 100 grid trades to test the solution with low and high amount of grid trades and with various amount of executed grid trades.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/37454226/181305015-c02594c8-773d-43e6-b524-f8f0a89f6c42.png)
