### PR TITLE
fix: prevent unnecessary text wrapping

### DIFF
--- a/public/css/App.css
+++ b/public/css/App.css
@@ -447,11 +447,11 @@ input[type='number'] {
 }
 
 .coin-info-label {
-  width: 65%;
+  width: auto;
 }
 
 .coin-info-value {
-  width: 35%;
+  width: auto;
 }
 
 .coin-info-column-title .coin-info-label {

--- a/public/js/CoinWrapperAction.js
+++ b/public/js/CoinWrapperAction.js
@@ -81,7 +81,7 @@ class CoinWrapperAction extends React.Component {
     return (
       <div className='coin-info-sub-wrapper'>
         <div className='coin-info-column coin-info-column-title border-bottom-0 mb-0 pb-0'>
-          <div className='coin-info-label w-40'>
+          <div className='coin-info-label'>
             Action -{' '}
             <span className='coin-info-value'>
               {updatedAt.format('HH:mm:ss')}
@@ -121,7 +121,7 @@ class CoinWrapperAction extends React.Component {
             )}
           </div>
 
-          <div className='d-flex flex-column align-items-end w-60'>
+          <div className='d-flex flex-column align-items-end'>
             <HightlightChange className='action-label'>
               {label}
             </HightlightChange>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fix unnecessary text wrapping if there is enough space to print a text.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#446

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Text wrapping is affecting a height of columns and rows alignment which is causing visual disruptions while watching changes in the grid trade view.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on various data sets with long texts.

## Screenshots (if appropriate):

Even a very wide texts are no longer wrapped after the fix is applied.

![image](https://user-images.githubusercontent.com/37454226/181386541-c0cd497e-48ff-422c-b7f6-1dd42d041660.png)

Columns are consistent after the fix is applied.

![image](https://user-images.githubusercontent.com/37454226/181387044-5a8d9366-0840-4416-a16a-accf88924137.png)
