### PR TITLE
fix: order status update

### DIFF
--- a/app/__tests__/server.test.js
+++ b/app/__tests__/server.test.js
@@ -49,4 +49,12 @@ describe('server', () => {
   it('triggers runBinance', () => {
     expect(mockRunBinance).toHaveBeenCalled();
   });
+
+  it('triggers runCronjob', () => {
+    expect(mockRunCronJob).toHaveBeenCalled();
+  });
+
+  it('triggers runFrontend', () => {
+    expect(mockRunFrontend).toHaveBeenCalled();
+  });
 });

--- a/app/binance/__tests__/user.test.js
+++ b/app/binance/__tests__/user.test.js
@@ -10,6 +10,7 @@ describe('user.js', () => {
   let mockUpdateGridTradeLastOrder;
   let mockGetManualOrder;
   let mockSaveManualOrder;
+  let mockExecuteTrailingTrade;
 
   let mockUserClean;
 
@@ -137,6 +138,14 @@ describe('user.js', () => {
     });
 
     describe('when executionReport event received', () => {
+      beforeEach(() => {
+        mockExecuteTrailingTrade = jest.fn().mockResolvedValue(true);
+
+        jest.mock('../../cronjob', () => ({
+          executeTrailingTrade: mockExecuteTrailingTrade
+        }));
+      });
+
       describe('when last order not found', () => {
         beforeEach(async () => {
           mockUserClean = jest.fn().mockResolvedValue(true);
@@ -225,10 +234,15 @@ describe('user.js', () => {
           expect(mockUpdateGridTradeLastOrder).not.toHaveBeenCalled();
         });
 
+        it('does not trigger executeTrailingTrade', () => {
+          expect(mockExecuteTrailingTrade).not.toHaveBeenCalled();
+        });
+
         it('does not trigger userClean', () => {
           expect(mockUserClean).not.toHaveBeenCalled();
         });
       });
+
       describe('when last order found', () => {
         beforeEach(async () => {
           mockUserClean = jest.fn().mockResolvedValue(true);
@@ -336,6 +350,13 @@ describe('user.js', () => {
           );
         });
 
+        it('triggers executeTrailingTrade', () => {
+          expect(mockExecuteTrailingTrade).toHaveBeenCalledWith(
+            loggerMock,
+            'ETHUSDT'
+          );
+        });
+
         it('does not trigger userClean', () => {
           expect(mockUserClean).not.toHaveBeenCalled();
         });
@@ -427,6 +448,10 @@ describe('user.js', () => {
 
         it('does not trigger saveManualOrder', () => {
           expect(mockSaveManualOrder).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger executeTrailingTrade', () => {
+          expect(mockExecuteTrailingTrade).not.toHaveBeenCalled();
         });
 
         it('does not trigger userClean', () => {
@@ -537,6 +562,13 @@ describe('user.js', () => {
               type: 'STOP_LOSS_LIMIT',
               updateTime: 1642713283562
             }
+          );
+        });
+
+        it('triggers executeTrailingTrade', () => {
+          expect(mockExecuteTrailingTrade).toHaveBeenCalledWith(
+            loggerMock,
+            'ETHUSDT'
           );
         });
 

--- a/app/binance/user.js
+++ b/app/binance/user.js
@@ -52,9 +52,10 @@ const setupUserWebsocket = async logger => {
         totalQuoteTradeQuantity,
         totalTradeQuantity
       } = evt;
+      // eventTime is added to prevent last log message check.
       logger.info(
         { symbol, evt, saveLog: true },
-        `Received new report - ${eventTime}` // to prevent last log message check.
+        `There is a new update in order. - ${side} - ${orderStatus} - ${eventTime}`
       );
 
       const checkLastOrder = async () => {

--- a/app/binance/user.js
+++ b/app/binance/user.js
@@ -52,10 +52,9 @@ const setupUserWebsocket = async logger => {
         totalQuoteTradeQuantity,
         totalTradeQuantity
       } = evt;
-      // eventTime is added to prevent last log message check.
       logger.info(
         { symbol, evt, saveLog: true },
-        `There is a new update in order. - ${side} - ${orderStatus} - ${eventTime}`
+        `There is a new update in order. - ${side} - ${orderStatus}`
       );
 
       const checkLastOrder = async () => {

--- a/app/binance/user.js
+++ b/app/binance/user.js
@@ -51,7 +51,10 @@ const setupUserWebsocket = async logger => {
         totalQuoteTradeQuantity,
         totalTradeQuantity
       } = evt;
-      logger.info({ evt }, 'Received new report');
+      logger.info(
+        { symbol, evt, saveLog: true },
+        `Received new report - ${eventTime}` // to prevent last log message check.
+      );
 
       const checkLastOrder = async () => {
         const lastOrder = await getGridTradeLastOrder(
@@ -74,6 +77,10 @@ const setupUserWebsocket = async logger => {
             isWorking: isOrderWorking,
             updateTime: eventTime
           });
+          logger.info(
+            { symbol, lastOrder, saveLog: true },
+            'The last order has been updated.'
+          );
         }
       };
 
@@ -96,6 +103,11 @@ const setupUserWebsocket = async logger => {
             isWorking: isOrderWorking,
             updateTime: eventTime
           });
+
+          logger.info(
+            { symbol, manualOrder, saveLog: true },
+            'The manual order has been updated.'
+          );
         }
       };
 

--- a/app/binance/user.js
+++ b/app/binance/user.js
@@ -54,7 +54,7 @@ const setupUserWebsocket = async logger => {
       } = evt;
       logger.info(
         { symbol, evt, saveLog: true },
-        `There is a new update in order. - ${side} - ${orderStatus}`
+        `There is a new update in order. ${orderId} - ${side} - ${orderStatus}`
       );
 
       const checkLastOrder = async () => {

--- a/app/binance/user.js
+++ b/app/binance/user.js
@@ -13,6 +13,7 @@ const {
   getManualOrder,
   saveManualOrder
 } = require('../cronjob/trailingTradeHelper/order');
+const { executeTrailingTrade } = require('../cronjob');
 
 let userClean;
 
@@ -81,6 +82,8 @@ const setupUserWebsocket = async logger => {
             { symbol, lastOrder, saveLog: true },
             'The last order has been updated.'
           );
+
+          executeTrailingTrade(logger, symbol);
         }
       };
 
@@ -108,6 +111,8 @@ const setupUserWebsocket = async logger => {
             { symbol, manualOrder, saveLog: true },
             'The manual order has been updated.'
           );
+
+          executeTrailingTrade(logger, symbol);
         }
       };
 

--- a/app/cronjob/trailingTrade/step/ensure-grid-trade-order-executed.js
+++ b/app/cronjob/trailingTrade/step/ensure-grid-trade-order-executed.js
@@ -222,7 +222,7 @@ const execute = async (logger, rawData) => {
     if (lastBuyOrder.status === 'FILLED') {
       logger.info(
         { lastBuyOrder, saveLog: true },
-        'The grid trade order has already filled. Calculating last buy price...'
+        'The grid trade order has filled. Calculating last buy price...'
       );
 
       // Calculate last buy price

--- a/app/cronjob/trailingTrade/step/get-indicators.js
+++ b/app/cronjob/trailingTrade/step/get-indicators.js
@@ -104,7 +104,6 @@ const execute = async (logger, rawData) => {
   if (buyATHRestrictionEnabled) {
     logger.info(
       {
-        debug: true,
         function: 'athCandles',
         buyATHRestrictionEnabled,
         buyATHRestrictionCandlesInterval,

--- a/app/cronjob/trailingTrade/step/handle-open-orders.js
+++ b/app/cronjob/trailingTrade/step/handle-open-orders.js
@@ -89,7 +89,7 @@ const execute = async (logger, rawData) => {
     if (order.side.toLowerCase() === 'buy') {
       if (parseFloat(order.stopPrice) >= buyLimitPrice) {
         logger.info(
-          { stopPrice: order.stopPrice, buyLimitPrice },
+          { stopPrice: order.stopPrice, buyLimitPrice, saveLog: true },
           'Stop price is higher than buy limit price, cancel current buy order'
         );
 
@@ -170,7 +170,7 @@ const execute = async (logger, rawData) => {
     if (order.side.toLowerCase() === 'sell') {
       if (parseFloat(order.stopPrice) <= sellLimitPrice) {
         logger.info(
-          { stopPrice: order.stopPrice, sellLimitPrice },
+          { stopPrice: order.stopPrice, sellLimitPrice, saveLog: true },
           'Stop price is less than sell limit price, cancel current sell order'
         );
 

--- a/app/cronjob/trailingTrade/step/handle-open-orders.js
+++ b/app/cronjob/trailingTrade/step/handle-open-orders.js
@@ -18,9 +18,10 @@ const {
  * @param {*} order
  */
 const cancelOrder = async (logger, symbol, order) => {
+  const { side } = order;
   logger.info(
     { function: 'cancelOrder', order, saveLog: true },
-    'The order will be cancelled.'
+    `The ${side} order will be cancelled.`
   );
   // Cancel open orders first to make sure it does not have unsettled orders.
   let result = false;

--- a/app/server.js
+++ b/app/server.js
@@ -13,9 +13,9 @@ const { runErrorHandler } = require('./error-handler');
 
   await mongo.connect(logger);
 
-  await runBinance(logger);
-
-  await runCronjob(logger);
-
-  await runFrontend(logger);
+  await Promise.all([
+    runBinance(logger),
+    runCronjob(logger),
+    runFrontend(logger)
+  ]);
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9895,9 +9895,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001344",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
-      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
+      "version": "1.0.30001374",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
+      "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
       "dev": true
     },
     "chalk": {

--- a/public/js/SymbolLogsIcon.js
+++ b/public/js/SymbolLogsIcon.js
@@ -189,9 +189,12 @@ class SymbolLogsIcon extends React.Component {
       );
     }
     const maxButtons = 8;
-    const buttons = Math.min( maxButtons , ~~totalPages );
+    const buttons = Math.min(maxButtons, ~~totalPages);
     [...Array(buttons).keys()].forEach(x => {
-      const pageNum = Math.min( Math.max( x + 1 , page + x + 1 - Math.ceil( buttons / 2 ) ) , totalPages + x + 1 - buttons );
+      const pageNum = Math.min(
+        Math.max(x + 1, page + x + 1 - Math.ceil(buttons / 2)),
+        totalPages + x + 1 - buttons
+      );
       paginationItems.push(
         <Pagination.Item
           active={pageNum === page}
@@ -224,15 +227,31 @@ class SymbolLogsIcon extends React.Component {
     );
 
     const logRows = rows.map((row, _index) => {
+      const uuid = _.get(row, ['data', 'correlationId'], '').split('-').pop();
+      const step = _.get(row, ['data', 'stepName'], 'Unknown');
+      let uuidBlock = '';
+      if (uuid) {
+        uuidBlock = (
+          <div>
+            <code>
+              {uuid} - {step}
+            </code>
+          </div>
+        );
+      }
+
       return (
         <React.Fragment key={'symbol-grid-trade-log-' + row._id}>
           <tr>
             <td
-              className='text-center align-middle'
+              className='text-center align-top'
               title={moment(row.loggedAt).format()}>
-              {moment(row.loggedAt).format('HH:mm:ss')}
+              {moment(row.loggedAt).format('HH:mm:ss.SSS')}
             </td>
-            <td>{row.msg}</td>
+            <td>
+              {uuidBlock}
+              {row.msg}
+            </td>
             <td className='text-center'>
               <button
                 type='button'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
After receiving the order status via WebSocket, the trailing trade process was not executed unless the tick is received.
However, the symbol should be processed after the order status is updated to determine what to do with the updated order.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#451

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
