### PR TITLE
fix: incorrect symbol in reset-symbol-websockets

### DIFF
--- a/app/server-binance.js
+++ b/app/server-binance.js
@@ -142,7 +142,7 @@ const setupBinance = async logger => {
   PubSub.subscribe('reset-symbol-websockets', async (message, data) => {
     logger.info(`Message: ${message}, Data: ${data}`);
 
-    const symbol = message;
+    const symbol = data;
 
     PubSub.publish('frontend-notification', {
       type: 'info',


### PR DESCRIPTION
## Description

When customizing a setting for a specific symbol, it will trigger the `reset-symbol-websockets` channel but unfortunately with an incorrect symbol which will cause the other stuff not to work as expected.
This PR is solving this issue by getting the symbol correctly to do the reset stuff.

## Related Issue
## Motivation and Context
## How Has This Been Tested?

- Write tests
- Customizing a setting for a specific symbol will call `reset-symbol-websockets` correctly.

## Screenshots (if appropriate):
