### PR TITLE
feat: improve UI

### DIFF
--- a/app/cronjob/trailingTrade/step/__tests__/cancel-order.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/cancel-order.test.js
@@ -146,13 +146,14 @@ describe('cancel-order.js', () => {
             sell: {
               openOrders: [
                 {
-                  orderId: 'another-sellorder',
+                  orderId: 'another-sell-order',
                   side: 'sell'
                 }
               ]
             },
             order: {
-              orderId: 'order-123'
+              orderId: 'order-123',
+              side: 'buy'
             }
           };
 
@@ -199,7 +200,7 @@ describe('cancel-order.js', () => {
                   side: 'buy'
                 }
               ],
-              processMessage: 'The order has been cancelled.',
+              processMessage: 'The buy order has been cancelled.',
               updatedAt: expect.any(Object)
             },
             sell: {
@@ -211,7 +212,8 @@ describe('cancel-order.js', () => {
               ]
             },
             order: {
-              orderId: 'order-123'
+              orderId: 'order-123',
+              side: 'buy'
             }
           });
         });
@@ -262,7 +264,8 @@ describe('cancel-order.js', () => {
               ]
             },
             order: {
-              orderId: 'order-123'
+              orderId: 'order-123',
+              side: 'buy'
             }
           };
 
@@ -295,14 +298,15 @@ describe('cancel-order.js', () => {
             openOrders: [],
             buy: {
               openOrders: [],
-              processMessage: 'The order has been cancelled.',
+              processMessage: 'The buy order has been cancelled.',
               updatedAt: expect.any(Object)
             },
             sell: {
               openOrders: []
             },
             order: {
-              orderId: 'order-123'
+              orderId: 'order-123',
+              side: 'buy'
             }
           });
         });

--- a/app/cronjob/trailingTrade/step/cancel-order.js
+++ b/app/cronjob/trailingTrade/step/cancel-order.js
@@ -41,14 +41,18 @@ const execute = async (logger, rawData) => {
     { symbol, apiLimit: getAPILimit(logger) }
   );
 
+  const { side } = order;
   logger.info(
     { function: 'order', orderParams, saveLog: true },
-    'The order will be cancelled.'
+    `The ${side.toLowerCase()} order will be cancelled.`
   );
 
   const orderResult = await binance.client.cancelOrder(orderParams);
 
-  logger.info({ orderResult, saveLog: true }, 'The order has been cancelled.');
+  logger.info(
+    { orderResult, saveLog: true },
+    `The ${side.toLowerCase()} order has been cancelled.`
+  );
 
   await deleteManualOrder(logger, symbol, order.orderId);
 
@@ -68,7 +72,7 @@ const execute = async (logger, rawData) => {
   PubSub.publish('frontend-notification', {
     type: 'success',
     title:
-      `The order for ${symbol} has been cancelled successfully.` +
+      `The ${side.toLowerCase()} order for ${symbol} has been cancelled successfully.` +
       ` If the order still display, it should be removed soon.`
   });
 
@@ -82,7 +86,7 @@ const execute = async (logger, rawData) => {
     { symbol, apiLimit: getAPILimit(logger) }
   );
 
-  data.buy.processMessage = `The order has been cancelled.`;
+  data.buy.processMessage = `The ${side.toLowerCase()} order has been cancelled.`;
   data.buy.updatedAt = moment().utc().toDate();
 
   return data;

--- a/app/cronjob/trailingTradeHelper/__tests__/common.test.js
+++ b/app/cronjob/trailingTradeHelper/__tests__/common.test.js
@@ -3024,7 +3024,9 @@ describe('common.js', () => {
                 }
               },
               profit: { $sum: '$sell.currentProfit' },
-              estimatedBalance: { $sum: '$baseAssetBalance.estimatedValue' }
+              estimatedBalance: { $sum: '$baseAssetBalance.estimatedValue' },
+              free: { $first: '$quoteAssetBalance.free' },
+              locked: { $first: '$quoteAssetBalance.locked' }
             }
           },
           {
@@ -3032,7 +3034,9 @@ describe('common.js', () => {
               asset: '$_id',
               amount: '$amount',
               profit: '$profit',
-              estimatedBalance: '$estimatedBalance'
+              estimatedBalance: '$estimatedBalance',
+              free: '$free',
+              locked: '$locked'
             }
           }
         ]

--- a/app/cronjob/trailingTradeHelper/common.js
+++ b/app/cronjob/trailingTradeHelper/common.js
@@ -1029,7 +1029,9 @@ const getCacheTrailingTradeTotalProfitAndLoss = logger =>
           }
         },
         profit: { $sum: '$sell.currentProfit' },
-        estimatedBalance: { $sum: '$baseAssetBalance.estimatedValue' }
+        estimatedBalance: { $sum: '$baseAssetBalance.estimatedValue' },
+        free: { $first: '$quoteAssetBalance.free' },
+        locked: { $first: '$quoteAssetBalance.locked' }
       }
     },
     {
@@ -1037,7 +1039,9 @@ const getCacheTrailingTradeTotalProfitAndLoss = logger =>
         asset: '$_id',
         amount: '$amount',
         profit: '$profit',
-        estimatedBalance: '$estimatedBalance'
+        estimatedBalance: '$estimatedBalance',
+        free: '$free',
+        locked: '$locked'
       }
     }
   ]);

--- a/app/cronjob/trailingTradeIndicator/step/__tests__/get-closed-trades.test.js
+++ b/app/cronjob/trailingTradeIndicator/step/__tests__/get-closed-trades.test.js
@@ -107,7 +107,10 @@ describe('get-closed-trades.js', () => {
                 stopLossQuoteQty: 70,
                 profit: 80,
                 profitPercentage: 90,
-                trades: 100
+                trades: 100,
+                lastProfit: 110,
+                lastSymbol: 'BTCUSDT',
+                lastArchivedAt: '2022-08-17T21:04:47.017Z'
               }
             ]);
 
@@ -149,7 +152,10 @@ describe('get-closed-trades.js', () => {
                     sellManualQuoteQty: { $sum: '$sellManualQuoteQty' },
                     stopLossQuoteQty: { $sum: '$stopLossQuoteQty' },
                     profit: { $sum: '$profit' },
-                    trades: { $sum: 1 }
+                    trades: { $sum: 1 },
+                    lastProfit: { $last: '$profit' },
+                    lastSymbol: { $last: '$symbol' },
+                    lastArchivedAt: { $last: '$archivedAt' }
                   }
                 },
                 {
@@ -179,7 +185,10 @@ describe('get-closed-trades.js', () => {
                         else: 0
                       }
                     },
-                    trades: 1
+                    trades: 1,
+                    lastProfit: 1,
+                    lastSymbol: 1,
+                    lastArchivedAt: 1
                   }
                 }
               ]
@@ -217,7 +226,10 @@ describe('get-closed-trades.js', () => {
                 stopLossQuoteQty: 70,
                 profit: 80,
                 profitPercentage: 90,
-                trades: 100
+                trades: 100,
+                lastProfit: 110,
+                lastSymbol: 'BTCUSDT',
+                lastArchivedAt: '2022-08-17T21:04:47.017Z'
               }
             });
           });
@@ -276,7 +288,10 @@ describe('get-closed-trades.js', () => {
                 sellManualQuoteQty: { $sum: '$sellManualQuoteQty' },
                 stopLossQuoteQty: { $sum: '$stopLossQuoteQty' },
                 profit: { $sum: '$profit' },
-                trades: { $sum: 1 }
+                trades: { $sum: 1 },
+                lastProfit: { $last: '$profit' },
+                lastSymbol: { $last: '$symbol' },
+                lastArchivedAt: { $last: '$archivedAt' }
               }
             },
             {
@@ -306,7 +321,10 @@ describe('get-closed-trades.js', () => {
                     else: 0
                   }
                 },
-                trades: 1
+                trades: 1,
+                lastProfit: 1,
+                lastSymbol: 1,
+                lastArchivedAt: 1
               }
             }
           ]
@@ -341,7 +359,10 @@ describe('get-closed-trades.js', () => {
             stopLossQuoteQty: 0,
             profit: 0,
             profitPercentage: 0,
-            trades: 0
+            trades: 0,
+            lastProfit: 0,
+            lastSymbol: '',
+            lastArchivedAt: ''
           }
         });
       });

--- a/app/cronjob/trailingTradeIndicator/step/get-closed-trades.js
+++ b/app/cronjob/trailingTradeIndicator/step/get-closed-trades.js
@@ -73,7 +73,10 @@ const execute = async (logger, rawData) => {
           sellManualQuoteQty: { $sum: '$sellManualQuoteQty' },
           stopLossQuoteQty: { $sum: '$stopLossQuoteQty' },
           profit: { $sum: '$profit' },
-          trades: { $sum: 1 }
+          trades: { $sum: 1 },
+          lastProfit: { $last: '$profit' },
+          lastSymbol: { $last: '$symbol' },
+          lastArchivedAt: { $last: '$archivedAt' }
         }
       },
       {
@@ -103,7 +106,10 @@ const execute = async (logger, rawData) => {
               else: 0
             }
           },
-          trades: 1
+          trades: 1,
+          lastProfit: 1,
+          lastSymbol: 1,
+          lastArchivedAt: 1
         }
       }
     ])
@@ -118,7 +124,10 @@ const execute = async (logger, rawData) => {
     stopLossQuoteQty: 0,
     profit: 0,
     profitPercentage: 0,
-    trades: 0
+    trades: 0,
+    lastProfit: 0,
+    lastSymbol: '',
+    lastArchivedAt: ''
   };
 
   data.closedTrades = closedTrades;

--- a/app/frontend/websocket/handlers/__tests__/cancel-order.test.js
+++ b/app/frontend/websocket/handlers/__tests__/cancel-order.test.js
@@ -41,7 +41,8 @@ describe('cancel-order.js', () => {
       data: {
         symbol: 'BTCUSDT',
         order: {
-          some: 'value'
+          some: 'value',
+          side: 'buy'
         }
       }
     });
@@ -53,11 +54,11 @@ describe('cancel-order.js', () => {
       'BTCUSDT',
       {
         action: 'cancel-order',
-        order: { some: 'value' },
+        order: { some: 'value', side: 'buy' },
         actionAt: expect.any(String),
         triggeredBy: 'user'
       },
-      'Cancelling the order action has been received. Wait for cancelling the order.'
+      'Cancelling the buy order action has been received. Wait for cancelling the order.'
     );
   });
 
@@ -70,7 +71,7 @@ describe('cancel-order.js', () => {
       JSON.stringify({
         result: true,
         type: 'cancel-order-result',
-        message: 'Cancelling the order action has been received.'
+        message: 'Cancelling the buy order action has been received.'
       })
     );
   });

--- a/app/frontend/websocket/handlers/cancel-order.js
+++ b/app/frontend/websocket/handlers/cancel-order.js
@@ -11,6 +11,7 @@ const handleCancelOrder = async (logger, ws, payload) => {
     data: { symbol, order }
   } = payload;
 
+  const { side } = order;
   await saveOverrideAction(
     logger,
     symbol,
@@ -20,7 +21,7 @@ const handleCancelOrder = async (logger, ws, payload) => {
       actionAt: moment().toISOString(),
       triggeredBy: 'user'
     },
-    'Cancelling the order action has been received. Wait for cancelling the order.'
+    `Cancelling the ${side.toLowerCase()} order action has been received. Wait for cancelling the order.`
   );
 
   queue.executeFor(logger, symbol);
@@ -29,7 +30,7 @@ const handleCancelOrder = async (logger, ws, payload) => {
     JSON.stringify({
       result: true,
       type: 'cancel-order-result',
-      message: 'Cancelling the order action has been received.'
+      message: `Cancelling the ${side.toLowerCase()} order action has been received.`
     })
   );
 };

--- a/public/css/App.css
+++ b/public/css/App.css
@@ -480,7 +480,7 @@ input[type='number'] {
 }
 
 .coin-info-column-title .coin-info-value {
-  font-style: italic;
+  font-style: bold;
   font-size: 0.8rem;
 }
 
@@ -735,7 +735,7 @@ input[type='number'] {
   width: 50%;
 }
 
-@media (max-width: 550px) {
+@media (max-width: 825px) {
   .profit-loss-container {
     flex-direction: column;
   }
@@ -761,7 +761,8 @@ input[type='number'] {
 }
 
 .profit-loss-wrapper {
-  width: 25%;
+  width: 16.6%;
+  min-width: 12rem;
 }
 
 .profit-loss-wrapper-body {
@@ -776,22 +777,23 @@ input[type='number'] {
 }
 
 .profit-loss-asset {
-  flex: 1 40%;
+  flex: 1 auto;
   font-weight: bold;
 }
 
 .profit-loss-value {
-  flex: 1 60%;
+  flex: 1 auto;
   text-align: right;
+  font-weight: bold;
 }
 
-@media (max-width: 1500px) {
+@media (max-width: 3300px) {
   .profit-loss-wrapper {
     width: 33.3333%;
   }
 }
 
-@media (max-width: 800px) {
+@media (max-width: 1650px) {
   .profit-loss-wrapper {
     width: 50%;
   }

--- a/public/js/AccountWrapper.js
+++ b/public/js/AccountWrapper.js
@@ -3,14 +3,24 @@
 /* eslint-disable no-undef */
 class AccountWrapper extends React.Component {
   render() {
-    const { accountInfo, dustTransfer, sendWebSocket, isAuthenticated } =
-      this.props;
+    const {
+      accountInfo,
+      dustTransfer,
+      sendWebSocket,
+      isAuthenticated,
+      totalProfitAndLoss
+    } = this.props;
 
     const assets = accountInfo.balances.map((balance, index) => {
       return (
         <AccountWrapperAsset
           key={`account-wrapper-` + index}
-          balance={balance}></AccountWrapperAsset>
+          balance={balance}
+          isQuoteAsset={
+            totalProfitAndLoss.find(
+              profitAndLoss => profitAndLoss.asset === balance.asset
+            ) !== undefined
+          }></AccountWrapperAsset>
       );
     });
 

--- a/public/js/AccountWrapperAsset.js
+++ b/public/js/AccountWrapperAsset.js
@@ -3,13 +3,21 @@
 /* eslint-disable no-undef */
 class AccountWrapperAsset extends React.Component {
   render() {
-    const { balance } = this.props;
+    const { balance, isQuoteAsset } = this.props;
 
     return (
       <div className='account-wrapper-assets'>
-        <div className='account-wrapper-body'>
+        <div
+          className={`account-wrapper-body ${
+            isQuoteAsset === false && balance.quote === null ? 'text-muted' : ''
+          }`}>
           <div className='account-asset-coin d-flex justify-content-between align-items-center'>
-            <span>
+            <span
+              className={`${
+                isQuoteAsset === true && balance.quote === null
+                  ? 'text-warning'
+                  : ''
+              }`}>
               {(parseFloat(balance.free) + parseFloat(balance.locked)).toFixed(
                 5
               )}{' '}

--- a/public/js/App.js
+++ b/public/js/App.js
@@ -388,9 +388,12 @@ class App extends React.Component {
       />
     );
     const maxButtons = 8;
-    const buttons = Math.min( maxButtons , ~~totalPages );
+    const buttons = Math.min(maxButtons, ~~totalPages);
     [...Array(buttons).keys()].forEach(x => {
-      const pageNum = Math.min( Math.max( x + 1 , page + x + 1 - Math.ceil( buttons / 2 ) ) , totalPages + x + 1 - buttons );
+      const pageNum = Math.min(
+        Math.max(x + 1, page + x + 1 - Math.ceil(buttons / 2)),
+        totalPages + x + 1 - buttons
+      );
       paginationItems.push(
         <Pagination.Item
           active={pageNum === page}
@@ -439,6 +442,7 @@ class App extends React.Component {
                 accountInfo={accountInfo}
                 dustTransfer={dustTransfer}
                 sendWebSocket={this.sendWebSocket}
+                totalProfitAndLoss={totalProfitAndLoss}
               />
               <ProfitLossWrapper
                 isAuthenticated={isAuthenticated}

--- a/public/js/App.js
+++ b/public/js/App.js
@@ -74,7 +74,37 @@ class App extends React.Component {
       types: [
         {
           type: 'info',
-          background: '#2f96b4',
+          background: '#bf9106',
+          icon: {
+            className: 'fas fa-info-circle fa-lg',
+            tagName: 'i',
+            text: '',
+            color: 'white'
+          }
+        },
+        {
+          type: 'buy',
+          background: '#02c076',
+          icon: {
+            className: 'fas fa-info-circle fa-lg',
+            tagName: 'i',
+            text: '',
+            color: 'white'
+          }
+        },
+        {
+          type: 'sell',
+          background: '#bf374a',
+          icon: {
+            className: 'fas fa-info-circle fa-lg',
+            tagName: 'i',
+            text: '',
+            color: 'white'
+          }
+        },
+        {
+          type: 'success',
+          background: '#17a9bf',
           icon: {
             className: 'fas fa-info-circle fa-lg',
             tagName: 'i',
@@ -84,7 +114,7 @@ class App extends React.Component {
         },
         {
           type: 'warning',
-          background: '#fd7e14',
+          background: '#bf5e0f',
           icon: {
             className: 'fas fa-exclamation-circle fa-lg',
             tagName: 'i',
@@ -93,7 +123,7 @@ class App extends React.Component {
           }
         }
       ],
-      duration: 3000,
+      duration: 8000,
       ripple: true,
       position: { x: 'right', y: 'bottom' },
       dismissible: true
@@ -111,6 +141,14 @@ class App extends React.Component {
 
   toast({ type, title }) {
     // this.notyf.dismissAll();
+    if (type !== 'warning' && type !== 'error') {
+      if (title.toLowerCase().includes('buy ')) {
+        type = 'buy';
+      }
+      if (title.toLowerCase().includes('sell ')) {
+        type = 'sell';
+      }
+    }
     this.notyf.open({
       type,
       message: title

--- a/public/js/CoinWrapperAction.js
+++ b/public/js/CoinWrapperAction.js
@@ -65,7 +65,7 @@ class CoinWrapperAction extends React.Component {
       renderOverrideAction = (
         <div className='coin-info-column coin-info-column-title border-bottom-0 m-0 p-0'>
           <div
-            className='bg-light text-dark w-100 px-1'
+            className='w-100 px-1 text-warning'
             title={overrideData.actionAt}>
             Action <strong>{overrideData.action}</strong> will be executed{' '}
             {moment(overrideData.actionAt).fromNow()}, triggered by{' '}
@@ -124,7 +124,10 @@ class CoinWrapperAction extends React.Component {
           </div>
 
           <div className='d-flex flex-column align-items-end'>
-            <HightlightChange className='action-label'>
+            <HightlightChange
+              className={`action-label ${
+                label.length < 10 ? 'badge-pill badge-dark' : ''
+              }`}>
               {label}
             </HightlightChange>
             {isActionDisabled.isDisabled === true ? (

--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -43,26 +43,40 @@ class CoinWrapperBuySignal extends React.Component {
     let hiddenCount = 0;
 
     const buyGridRows = gridTrade.map((grid, i) => {
-      const modifiedGridTradeIndex = Math.min( Math.max ( currentGridTradeIndex , 5 ) , gridTrade.length - 5 );
+      const modifiedGridTradeIndex = Math.min(
+        Math.max(currentGridTradeIndex, 5),
+        gridTrade.length - 5
+      );
 
       function hiddenRow(i) {
-        return i >= 3 && ( i <= modifiedGridTradeIndex - 3 || i >= modifiedGridTradeIndex + 4 ) && i < gridTrade.length - 1;
+        return (
+          i >= 3 &&
+          (i <= modifiedGridTradeIndex - 3 ||
+            i >= modifiedGridTradeIndex + 4) &&
+          i < gridTrade.length - 1
+        );
       }
 
-      const isNextHidden = hiddenRow( i + 1 );
-      const isHidden = isNextHidden || hiddenRow( i );
+      const isNextHidden = hiddenRow(i + 1);
+      const isHidden = isNextHidden || hiddenRow(i);
 
-      if ( isHidden === true ) {
+      if (isHidden === true) {
         hiddenCount++;
 
-        return isNextHidden === true ? ('') : (
-        <React.Fragment key={'coin-wrapper-buy-grid-row-hidden-' + symbol + '-' + (i - 1)}>
-          <div className='coin-info-column-grid'>
-            <div className='coin-info-column coin-info-column-price'>
-              <div className='coin-info-label text-center'>... {hiddenCount} grid trade{hiddenCount === 1 ? '' : 's'} hidden ...</div>
+        return isNextHidden === true ? (
+          ''
+        ) : (
+          <React.Fragment
+            key={'coin-wrapper-buy-grid-row-hidden-' + symbol + '-' + (i - 1)}>
+            <div className='coin-info-column-grid'>
+              <div className='coin-info-column coin-info-column-price'>
+                <div className='coin-info-label text-center text-muted'>
+                  ... {hiddenCount} grid trade{hiddenCount === 1 ? '' : 's'}{' '}
+                  hidden ...
+                </div>
+              </div>
             </div>
-          </div>
-        </React.Fragment>
+          </React.Fragment>
         );
       } else {
         hiddenCount = 0;
@@ -202,7 +216,14 @@ class CoinWrapperBuySignal extends React.Component {
                     ''
                   )}
                 </div>
-                <HightlightChange className='coin-info-value'>
+                <HightlightChange
+                  className={`coin-info-value ${
+                    symbolConfiguration.buy.athRestriction.enabled &&
+                    parseFloat(buy.triggerPrice) >
+                      parseFloat(buy.athRestrictionPrice)
+                      ? 'text-warning'
+                      : ''
+                  }`}>
                   {parseFloat(buy.triggerPrice).toFixed(precision)}
                 </HightlightChange>
               </div>
@@ -213,7 +234,13 @@ class CoinWrapperBuySignal extends React.Component {
               <div className='coin-info-column coin-info-column-price'>
                 <span className='coin-info-label'>Difference to buy:</span>
                 <HightlightChange
-                  className='coin-info-value'
+                  className={`coin-info-value ${
+                    buy.difference > 0
+                      ? 'text-success'
+                      : buy.difference < 0
+                      ? 'text-danger'
+                      : ''
+                  }`}
                   id='buy-difference'>
                   {parseFloat(buy.difference).toFixed(2)}%
                 </HightlightChange>
@@ -289,7 +316,7 @@ class CoinWrapperBuySignal extends React.Component {
             </span>{' '}
           </div>
           {symbolConfiguration.buy.enabled === false ? (
-            <HightlightChange className='coin-info-message text-muted'>
+            <HightlightChange className='coin-info-message badge-pill badge-danger'>
               Trading is disabled.
             </HightlightChange>
           ) : (
@@ -352,7 +379,14 @@ class CoinWrapperBuySignal extends React.Component {
                     </Button>
                   </OverlayTrigger>
                 </div>
-                <HightlightChange className='coin-info-value'>
+                <HightlightChange
+                  className={`coin-info-value ${
+                    symbolConfiguration.buy.athRestriction.enabled &&
+                    parseFloat(buy.triggerPrice) >
+                      parseFloat(buy.athRestrictionPrice)
+                      ? 'text-warning'
+                      : ''
+                  }`}>
                   {parseFloat(buy.athRestrictionPrice).toFixed(precision)}
                 </HightlightChange>
               </div>
@@ -400,7 +434,7 @@ class CoinWrapperBuySignal extends React.Component {
         {buy.processMessage ? (
           <div className='d-flex flex-column w-100'>
             <div className='coin-info-column coin-info-column-price divider'></div>
-            <div className='coin-info-column coin-info-column-message'>
+            <div className='coin-info-column coin-info-column-message text-warning'>
               <HightlightChange className='coin-info-message'>
                 {buy.processMessage}
               </HightlightChange>

--- a/public/js/CoinWrapperSellSignal.js
+++ b/public/js/CoinWrapperSellSignal.js
@@ -45,26 +45,40 @@ class CoinWrapperSellSignal extends React.Component {
     let hiddenCount = 0;
 
     const sellGridRows = gridTrade.map((grid, i) => {
-      const modifiedGridTradeIndex = Math.min( Math.max ( currentGridTradeIndex , 5 ) , gridTrade.length - 5 );
+      const modifiedGridTradeIndex = Math.min(
+        Math.max(currentGridTradeIndex, 5),
+        gridTrade.length - 5
+      );
 
       function hiddenRow(i) {
-        return i >= 3 && ( i <= modifiedGridTradeIndex - 3 || i >= modifiedGridTradeIndex + 4 ) && i < gridTrade.length - 1;
+        return (
+          i >= 3 &&
+          (i <= modifiedGridTradeIndex - 3 ||
+            i >= modifiedGridTradeIndex + 4) &&
+          i < gridTrade.length - 1
+        );
       }
 
-      const isNextHidden = hiddenRow( i + 1 );
-      const isHidden = isNextHidden || hiddenRow( i );
+      const isNextHidden = hiddenRow(i + 1);
+      const isHidden = isNextHidden || hiddenRow(i);
 
-      if ( isHidden === true ) {
+      if (isHidden === true) {
         hiddenCount++;
 
-        return isNextHidden === true ? ('') : (
-        <React.Fragment key={'coin-wrapper-buy-grid-row-hidden-' + symbol + '-' + (i - 1)}>
-          <div className='coin-info-column-grid'>
-            <div className='coin-info-column coin-info-column-price'>
-              <div className='coin-info-label text-center'>... {hiddenCount} grid trade{hiddenCount === 1 ? '' : 's'} hidden ...</div>
+        return isNextHidden === true ? (
+          ''
+        ) : (
+          <React.Fragment
+            key={'coin-wrapper-buy-grid-row-hidden-' + symbol + '-' + (i - 1)}>
+            <div className='coin-info-column-grid'>
+              <div className='coin-info-column coin-info-column-price'>
+                <div className='coin-info-label text-center text-muted'>
+                  ... {hiddenCount} grid trade{hiddenCount === 1 ? '' : 's'}{' '}
+                  hidden ...
+                </div>
+              </div>
             </div>
-          </div>
-        </React.Fragment>
+          </React.Fragment>
         );
       } else {
         hiddenCount = 0;
@@ -237,7 +251,7 @@ class CoinWrapperSellSignal extends React.Component {
               </span>
             </div>
             {symbolConfiguration.sell.enabled === false ? (
-              <HightlightChange className='coin-info-message text-muted'>
+              <HightlightChange className='coin-info-message badge-pill badge-danger'>
                 Trading is disabled.
               </HightlightChange>
             ) : (
@@ -262,7 +276,10 @@ class CoinWrapperSellSignal extends React.Component {
           {sell.currentProfit ? (
             <div className='coin-info-column coin-info-column-price'>
               <span className='coin-info-label'>Profit/Loss:</span>
-              <HightlightChange className='coin-info-value'>
+              <HightlightChange
+                className={`coin-info-value ${
+                  sell.currentProfit >= 0 ? 'text-success' : 'text-danger'
+                }`}>
                 {parseFloat(sell.currentProfit).toFixed(precision)} {quoteAsset}{' '}
                 ({parseFloat(sell.currentProfitPercentage).toFixed(2)}
                 %)
@@ -305,7 +322,7 @@ class CoinWrapperSellSignal extends React.Component {
             <div className='d-flex flex-column w-100'>
               <div className='coin-info-column coin-info-column-price divider'></div>
               <div className='coin-info-column coin-info-column-message'>
-                <HightlightChange className='coin-info-message'>
+                <HightlightChange className='coin-info-message text-warning'>
                   {sell.processMessage}
                 </HightlightChange>
               </div>
@@ -347,7 +364,7 @@ class CoinWrapperSellSignal extends React.Component {
             </span>
           </div>
           {symbolConfiguration.sell.enabled === false ? (
-            <HightlightChange className='coin-info-message text-muted'>
+            <HightlightChange className='coin-info-message badge-pill badge-danger'>
               Trading is disabled.
             </HightlightChange>
           ) : (

--- a/public/js/CoinWrapperTradingView.js
+++ b/public/js/CoinWrapperTradingView.js
@@ -300,7 +300,7 @@ class CoinWrapperTradingView extends React.Component {
     if (connected && updatedAt.isBefore(currentTime)) {
       updatedWithinAlert = (
         <div className='coin-info-column coin-info-column-title border-bottom-0 m-0 p-0'>
-          <div className='bg-light text-dark w-100 px-1'>
+          <div className='text-warning w-100 px-1'>
             The data is older than {tradingViewUseOnlyWithin} minute(s). This
             data will not be used until it is updated.
           </div>
@@ -361,7 +361,7 @@ class CoinWrapperTradingView extends React.Component {
             </div>
             <HightlightChange
               className={
-                'coin-info-value text-bold ' +
+                'coin-info-value font-weight-bold ' +
                 this.getRecommendationClass(
                   tradingView.result.summary.RECOMMENDATION
                 )

--- a/public/js/ProfitLossWrapper.js
+++ b/public/js/ProfitLossWrapper.js
@@ -148,7 +148,7 @@ class ProfitLossWrapper extends React.Component {
                   } text-truncate`}>
                   {profitAndLoss.estimatedBalance.toFixed(5)}
                 </div>
-                <div class='coin-info-column fs-9'>
+                <div class='fs-9'>
                   {openTradesRatio.toFixed(2) +
                     '% of ' +
                     quoteAssetTotal.toFixed(5) +
@@ -190,36 +190,41 @@ class ProfitLossWrapper extends React.Component {
                   quoteAssetTickSize={5}
                 />
                 ({stat.trades})
-                <div
-                  class='coin-info-column fs-9'
-                  title={
-                    stat.lastArchivedAt
-                      ? moment(stat.lastArchivedAt).format()
-                      : ''
-                  }>
+                <div class='fs-9'>
                   {stat.lastArchivedAt
                     ? stat.lastSymbol +
                       ' ' +
                       (stat.lastProfit > 0 ? '+' : '') +
                       parseFloat(stat.lastProfit).toFixed(5) +
                       ' ' +
-                      stat.quoteAsset +
-                      ' ' +
-                      moment(stat.lastArchivedAt).fromNow()
+                      stat.quoteAsset
                     : 'No closed trades yet'}
                 </div>
               </div>{' '}
-              <div
-                className={`profit-loss-value ${
-                  stat.profit > 0
-                    ? 'text-success'
-                    : stat.profit < 0
-                    ? 'text-danger'
-                    : ''
-                }`}>
-                {stat.profit > 0 ? '+' : ''}
-                {stat.profit.toFixed(5)}
-                <br />({stat.profitPercentage.toFixed(2)}%)
+              <div className='profit-loss-value'>
+                <span
+                  className={`${
+                    stat.profit > 0
+                      ? 'text-success'
+                      : stat.profit < 0
+                      ? 'text-danger'
+                      : ''
+                  }`}>
+                  {stat.profit > 0 ? '+' : ''}
+                  {stat.profit.toFixed(5)}
+                  <br />({stat.profitPercentage.toFixed(2)}%)
+                </span>
+                <div
+                  class='fs-9'
+                  title={
+                    stat.lastArchivedAt
+                      ? moment(stat.lastArchivedAt).format()
+                      : ''
+                  }>
+                  {stat.lastArchivedAt
+                    ? moment(stat.lastArchivedAt).fromNow()
+                    : ''}
+                </div>
               </div>
             </div>
           </div>

--- a/public/js/ProfitLossWrapper.js
+++ b/public/js/ProfitLossWrapper.js
@@ -48,7 +48,8 @@ class ProfitLossWrapper extends React.Component {
     }
 
     const { selectedPeriod, selectedPeriodTZ, selectedPeriodLC } = this.state;
-    const { loadedPeriod, loadedPeriodTZ, loadedPeriodLC } = this.state.closedTradesSetting;
+    const { loadedPeriod, loadedPeriodTZ, loadedPeriodLC } =
+      this.state.closedTradesSetting;
 
     // Set initial selected period
     if (loadedPeriod !== undefined && selectedPeriod === null) {
@@ -94,15 +95,16 @@ class ProfitLossWrapper extends React.Component {
   }
 
   setSelectedPeriod(newSelectedPeriod) {
-    const newSelectedPeriodTZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const newSelectedPeriodTZ =
+      Intl.DateTimeFormat().resolvedOptions().timeZone;
     const newSelectedPeriodLC = Intl.DateTimeFormat().resolvedOptions().locale;
     this.setState(
       {
         selectedPeriod: newSelectedPeriod,
         selectedPeriodTZ: newSelectedPeriodTZ,
         selectedPeriodLC: newSelectedPeriodLC
-      }, () =>
-      this.requestClosedTradesSetPeriod()
+      },
+      () => this.requestClosedTradesSetPeriod()
     );
   }
 
@@ -121,6 +123,13 @@ class ProfitLossWrapper extends React.Component {
           profitAndLoss.amount > 0
             ? ((profitAndLoss.profit / profitAndLoss.amount) * 100).toFixed(2)
             : 0;
+
+        const quoteAssetTotal =
+          profitAndLoss.amount + +profitAndLoss.free + +profitAndLoss.locked;
+        const openTradesRatio = quoteAssetTotal
+          ? (profitAndLoss.amount / quoteAssetTotal) * 100
+          : 0;
+
         return (
           <div
             key={`open-trade-pnl-` + index}
@@ -129,11 +138,32 @@ class ProfitLossWrapper extends React.Component {
               <div className='profit-loss-asset'>
                 {profitAndLoss.asset}
                 <br />
-                <div className='text-success text-truncate'>
+                <div
+                  className={`${
+                    openTradesRatio > 90
+                      ? 'text-danger'
+                      : openTradesRatio > 50
+                      ? 'text-warning'
+                      : 'text-success'
+                  } text-truncate`}>
                   {profitAndLoss.estimatedBalance.toFixed(5)}
                 </div>
+                <div class='coin-info-column fs-9'>
+                  {openTradesRatio.toFixed(2) +
+                    '% of ' +
+                    quoteAssetTotal.toFixed(5) +
+                    ' ' +
+                    profitAndLoss.asset}
+                </div>
               </div>{' '}
-              <div className='profit-loss-value'>
+              <div
+                className={`profit-loss-value ${
+                  profitAndLoss.profit > 0
+                    ? 'text-success'
+                    : profitAndLoss.profit < 0
+                    ? 'text-danger'
+                    : ''
+                }`}>
                 {profitAndLoss.profit > 0 ? '+' : ''}
                 {profitAndLoss.profit.toFixed(5)}
                 <br />({percentage}%)
@@ -160,8 +190,33 @@ class ProfitLossWrapper extends React.Component {
                   quoteAssetTickSize={5}
                 />
                 ({stat.trades})
+                <div
+                  class='coin-info-column fs-9'
+                  title={
+                    stat.lastArchivedAt
+                      ? moment(stat.lastArchivedAt).format()
+                      : ''
+                  }>
+                  {stat.lastArchivedAt
+                    ? stat.lastSymbol +
+                      ' ' +
+                      (stat.lastProfit > 0 ? '+' : '') +
+                      parseFloat(stat.lastProfit).toFixed(5) +
+                      ' ' +
+                      stat.quoteAsset +
+                      ' ' +
+                      moment(stat.lastArchivedAt).fromNow()
+                    : 'No closed trades yet'}
+                </div>
               </div>{' '}
-              <div className='profit-loss-value'>
+              <div
+                className={`profit-loss-value ${
+                  stat.profit > 0
+                    ? 'text-success'
+                    : stat.profit < 0
+                    ? 'text-danger'
+                    : ''
+                }`}>
                 {stat.profit > 0 ? '+' : ''}
                 {stat.profit.toFixed(5)}
                 <br />({stat.profitPercentage.toFixed(2)}%)
@@ -226,7 +281,10 @@ class ProfitLossWrapper extends React.Component {
                   <div className='profit-loss-wrappers profit-loss-open-trades-wrappers'>
                     {_.isEmpty(totalProfitAndLoss) ? (
                       <div className='text-center w-100 m-3'>
-                        <Spinner animation='border' role='status'>
+                        <Spinner
+                          animation='border'
+                          role='status'
+                          style={{ width: '3rem', height: '3rem' }}>
                           <span className='sr-only'>Loading...</span>
                         </Spinner>
                       </div>
@@ -310,7 +368,10 @@ class ProfitLossWrapper extends React.Component {
                   <div className='profit-loss-wrappers profit-loss-open-trades-wrappers'>
                     {closedTradesLoading === true || _.isEmpty(closedTrades) ? (
                       <div className='text-center w-100 m-3'>
-                        <Spinner animation='border' role='status'>
+                        <Spinner
+                          animation='border'
+                          role='status'
+                          style={{ width: '3rem', height: '3rem' }}>
                           <span className='sr-only'>Loading...</span>
                         </Spinner>
                       </div>

--- a/public/js/QuoteAssetGridTradeArchiveIcon.js
+++ b/public/js/QuoteAssetGridTradeArchiveIcon.js
@@ -18,7 +18,7 @@ class QuoteAssetGridTradeArchiveIcon extends React.Component {
       showDeleteAllByQuoteAssetModal: false,
       loading: true,
       page: 1,
-      limit: 5,
+      limit: 20,
       period: 'a',
       start: null,
       end: null,
@@ -171,7 +171,13 @@ class QuoteAssetGridTradeArchiveIcon extends React.Component {
       return (
         <React.Fragment key={'quote-asset-grid-trade-row-' + row.key}>
           <tr>
-            <td className={`text-center align-middle`}>{row.symbol}</td>
+            <td className={`text-center align-middle`}>
+              {row.symbol}
+              <br />
+              <span class='fs-9' title={moment(row.archivedAt).format()}>
+                {'Closed ' + moment(row.archivedAt).fromNow()}
+              </span>
+            </td>
             <td
               title={row.profit}
               className={`text-center align-middle ${
@@ -185,7 +191,15 @@ class QuoteAssetGridTradeArchiveIcon extends React.Component {
               <br />({parseFloat(row.profitPercentage).toFixed(2)}%)
             </td>
             <td
-              title={row.totalBuyQuoteQty}
+              title={
+                'Buy via Grid Trade: ' +
+                parseFloat(row.buyGridTradeQuoteQty).toFixed(
+                  quoteAssetTickSize
+                ) +
+                '\n' +
+                'Buy via Manual Trade: ' +
+                parseFloat(row.buyManualQuoteQty).toFixed(quoteAssetTickSize)
+              }
               className={`text-center align-middle ${
                 row.totalBuyQuoteQty === 0 ? 'text-muted' : ''
               }`}>
@@ -193,73 +207,38 @@ class QuoteAssetGridTradeArchiveIcon extends React.Component {
               {quoteAsset}
             </td>
             <td
-              title={row.totalSellQuoteQty}
+              title={
+                'Sell via Grid Trade: ' +
+                parseFloat(row.sellGridTradeQuoteQty).toFixed(
+                  quoteAssetTickSize
+                ) +
+                '\n' +
+                'Sell via Manual Trade: ' +
+                parseFloat(row.sellManualQuoteQty).toFixed(quoteAssetTickSize) +
+                '\n' +
+                'Sell via Stop Loss: ' +
+                parseFloat(row.stopLossQuoteQty).toFixed(quoteAssetTickSize)
+              }
               className={`text-center align-middle ${
                 row.totalSellQuoteQty === 0 ? 'text-muted' : ''
               }`}>
               {parseFloat(row.totalSellQuoteQty).toFixed(quoteAssetTickSize)}{' '}
               {quoteAsset}
             </td>
-          </tr>
-          <tr>
-            <td colSpan='4' className='px-3'>
-              <div className='d-flex flex-row justify-content-between'>
-                <div className='d-flex flex-column'>
-                  <span>
-                    - Buy via Grid Trade:{' '}
-                    {parseFloat(row.buyGridTradeQuoteQty).toFixed(
-                      quoteAssetTickSize
-                    )}{' '}
-                    {quoteAsset}
-                  </span>
-                  <span>
-                    - Buy via Manual Trade:{' '}
-                    {parseFloat(row.buyManualQuoteQty).toFixed(
-                      quoteAssetTickSize
-                    )}{' '}
-                    {quoteAsset}
-                  </span>
-                  <span>
-                    - Sell via Grid Trade:{' '}
-                    {parseFloat(row.sellGridTradeQuoteQty).toFixed(
-                      quoteAssetTickSize
-                    )}{' '}
-                    {quoteAsset}
-                  </span>
-                  <span>
-                    - Sell via Manual Trade:{' '}
-                    {parseFloat(row.sellManualQuoteQty).toFixed(
-                      quoteAssetTickSize
-                    )}{' '}
-                    {quoteAsset}
-                  </span>
-                  <span>
-                    - Sell via Stop Loss:{' '}
-                    {parseFloat(row.stopLossQuoteQty).toFixed(
-                      quoteAssetTickSize
-                    )}{' '}
-                    {quoteAsset}
-                  </span>
-                  <span title={moment(row.archivedAt).format()}>
-                    - Closed {moment(row.archivedAt).fromNow()}
-                  </span>
-                </div>
-                <div className='d-flex flex-column text-right align-self-center'>
-                  <button
-                    type='button'
-                    className='btn btn-sm btn-danger'
-                    onClick={() => {
-                      this.setState(
-                        {
-                          selectedDeleteByKey: row.key
-                        },
-                        () => this.handleModalShow('deleteByKey')
-                      );
-                    }}>
-                    Delete
-                  </button>
-                </div>
-              </div>
+            <td className='text-center align-middle'>
+              <button
+                type='button'
+                className='btn btn-sm btn-danger'
+                onClick={() => {
+                  this.setState(
+                    {
+                      selectedDeleteByKey: row.key
+                    },
+                    () => this.handleModalShow('deleteByKey')
+                  );
+                }}>
+                Delete
+              </button>
             </td>
           </tr>
         </React.Fragment>
@@ -488,6 +467,7 @@ class QuoteAssetGridTradeArchiveIcon extends React.Component {
                             <th className='text-center'>Profit</th>
                             <th className='text-center'>Buy</th>
                             <th className='text-center'>Sell</th>
+                            <th className='text-center'>Action</th>
                           </tr>
                         </thead>
                         <tbody>{tradeRows}</tbody>

--- a/public/js/SymbolGridTradeArchiveIcon.js
+++ b/public/js/SymbolGridTradeArchiveIcon.js
@@ -18,7 +18,7 @@ class SymbolGridTradeArchiveIcon extends React.Component {
       showDeleteAllBySymbolModal: false,
       loading: true,
       page: 1,
-      limit: 5,
+      limit: 20,
       period: 'a',
       start: null,
       end: null,
@@ -185,7 +185,15 @@ class SymbolGridTradeArchiveIcon extends React.Component {
               <br />({parseFloat(row.profitPercentage).toFixed(2)}%)
             </td>
             <td
-              title={row.totalBuyQuoteQty}
+              title={
+                'Buy via Grid Trade: ' +
+                parseFloat(row.buyGridTradeQuoteQty).toFixed(
+                  quoteAssetTickSize
+                ) +
+                '\n' +
+                'Buy via Manual Trade: ' +
+                parseFloat(row.buyManualQuoteQty).toFixed(quoteAssetTickSize)
+              }
               className={`text-center align-middle ${
                 row.totalBuyQuoteQty === 0 ? 'text-muted' : ''
               }`}>
@@ -193,7 +201,18 @@ class SymbolGridTradeArchiveIcon extends React.Component {
               {quoteAsset}
             </td>
             <td
-              title={row.totalSellQuoteQty}
+              title={
+                'Sell via Grid Trade: ' +
+                parseFloat(row.sellGridTradeQuoteQty).toFixed(
+                  quoteAssetTickSize
+                ) +
+                '\n' +
+                'Sell via Manual Trade: ' +
+                parseFloat(row.sellManualQuoteQty).toFixed(quoteAssetTickSize) +
+                '\n' +
+                'Sell via Stop Loss: ' +
+                parseFloat(row.stopLossQuoteQty).toFixed(quoteAssetTickSize)
+              }
               className={`text-center align-middle ${
                 row.totalSellQuoteQty === 0 ? 'text-muted' : ''
               }`}>
@@ -205,63 +224,20 @@ class SymbolGridTradeArchiveIcon extends React.Component {
               title={moment(row.archivedAt).format()}>
               {moment(row.archivedAt).fromNow()}
             </td>
-          </tr>
-          <tr>
-            <td colSpan='4' className='px-3'>
-              <div className='d-flex flex-row justify-content-between'>
-                <div className='d-flex flex-column'>
-                  <span>
-                    - Buy via Grid Trade:{' '}
-                    {parseFloat(row.buyGridTradeQuoteQty).toFixed(
-                      quoteAssetTickSize
-                    )}{' '}
-                    {quoteAsset}
-                  </span>
-                  <span>
-                    - Buy via Manual Trade:{' '}
-                    {parseFloat(row.buyManualQuoteQty).toFixed(
-                      quoteAssetTickSize
-                    )}{' '}
-                    {quoteAsset}
-                  </span>
-                  <span>
-                    - Sell via Grid Trade:{' '}
-                    {parseFloat(row.sellGridTradeQuoteQty).toFixed(
-                      quoteAssetTickSize
-                    )}{' '}
-                    {quoteAsset}
-                  </span>
-                  <span>
-                    - Sell via Manual Trade:{' '}
-                    {parseFloat(row.sellManualQuoteQty).toFixed(
-                      quoteAssetTickSize
-                    )}{' '}
-                    {quoteAsset}
-                  </span>
-                  <span>
-                    - Sell via Stop Loss:{' '}
-                    {parseFloat(row.stopLossQuoteQty).toFixed(
-                      quoteAssetTickSize
-                    )}{' '}
-                    {quoteAsset}
-                  </span>
-                </div>
-                <div className='d-flex flex-column text-right align-self-center'>
-                  <button
-                    type='button'
-                    className='btn btn-sm btn-danger'
-                    onClick={() => {
-                      this.setState(
-                        {
-                          selectedDeleteByKey: row.key
-                        },
-                        () => this.handleModalShow('deleteByKey')
-                      );
-                    }}>
-                    Delete
-                  </button>
-                </div>
-              </div>
+            <td className='text-center align-middle'>
+              <button
+                type='button'
+                className='btn btn-sm btn-danger'
+                onClick={() => {
+                  this.setState(
+                    {
+                      selectedDeleteByKey: row.key
+                    },
+                    () => this.handleModalShow('deleteByKey')
+                  );
+                }}>
+                Delete
+              </button>
             </td>
           </tr>
         </React.Fragment>
@@ -490,6 +466,7 @@ class SymbolGridTradeArchiveIcon extends React.Component {
                             <th className='text-center'>Buy</th>
                             <th className='text-center'>Sell</th>
                             <th className='text-center'>Closed At</th>
+                            <th className='text-center'>Action</th>
                           </tr>
                         </thead>
                         <tbody>{tradeRows}</tbody>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Closed Trades reports in more compact form allowing 20 rows per page.
- Colorized notifications - info = blue, warning = orange, buy = green, sell = red.
- Longer time to show notifications for better readability.
- Improved texts in notifications to differentiate buy and sell notifications.
- Balances not used by the bot are in grey color, balances of quote assets are in orange color.
- In Open Trades indicator added invested ratio and value of portfolio. Quote asset value in Open trades displayed in green color when less than 50% of portfolio is invested, in orange color when less than 90% of portfolio is invested and in red color when more than 90% of portfolio is invested.
- In Closed Trades indicator added last closed trade info.
- Warnings for symbols united in orange color on black background.
- If ATH limit is triggered the values of Restricted price and Trigger price are displayed in orange color.
- Difference to buy, Profit/Loss, Open trades value and Closed trades value in green color when positive and in red color when negative.
- Round Wait indicator in brighter white color.
- Disabled trading indicator in red color.
- Darkened the hidden grid trades indicator.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#455, #475

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For better user experience.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in all expected states using even full production environment.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/37454226/185289850-3915738f-6158-421f-a6ec-f49c42eca5d5.png)

![image](https://user-images.githubusercontent.com/37454226/185289219-12fd5fd0-f378-4624-9237-6756604a52e0.png)

![image](https://user-images.githubusercontent.com/37454226/185287868-baec022f-a9b8-427d-8589-11a4323756fe.png)

![image](https://user-images.githubusercontent.com/37454226/185288026-9dd268ea-49de-4877-b285-df2fcabab8b6.png)

![image](https://user-images.githubusercontent.com/37454226/185289108-e4725707-c512-4ff9-bf65-149ca5d0e6fe.png)

![image](https://user-images.githubusercontent.com/37454226/185288158-f0a846a0-0248-47ec-aa2c-713b0d9e5641.png)

![image](https://user-images.githubusercontent.com/37454226/185287022-af72000c-2467-42b4-affd-8949a43e73db.png)

![image](https://user-images.githubusercontent.com/37454226/185286797-fde0b400-6053-4dc0-a636-3f11fd0ba760.png)

![image](https://user-images.githubusercontent.com/37454226/185288340-92256dbc-e3ef-4817-82e3-026fcf04b1d5.png)

![image](https://user-images.githubusercontent.com/37454226/185288537-73b05822-a256-4370-9435-b9dc3f9a9be6.png)

![image](https://user-images.githubusercontent.com/37454226/185288623-3f42922a-ab9e-4842-880e-987d46e725c0.png)

![image](https://user-images.githubusercontent.com/37454226/185288786-c17102f1-0985-444d-aee1-1afa08eda772.png)

![image](https://user-images.githubusercontent.com/37454226/185288926-cd93012d-a507-4f43-bcc9-ee28f9cc6e3a.png)

![image](https://user-images.githubusercontent.com/37454226/185392211-1d6018e6-e7f6-4dd6-94ea-669713356c57.png)
