### PR TITLE
fix: archive grid order if all sell orders are executed

### DIFF
--- a/app/cronjob/trailingTrade/step/__tests__/remove-last-buy-price.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/remove-last-buy-price.test.js
@@ -6,6 +6,7 @@ describe('remove-last-buy-price.js', () => {
 
   let PubSubMock;
   let slackMock;
+  let binanceMock;
   let loggerMock;
 
   let mockGetAPILimit;
@@ -27,14 +28,16 @@ describe('remove-last-buy-price.js', () => {
     });
 
     beforeEach(async () => {
-      const { PubSub, slack, logger } = require('../../../../helpers');
+      const { PubSub, slack, binance, logger } = require('../../../../helpers');
 
       PubSubMock = PubSub;
       slackMock = slack;
       loggerMock = logger;
+      binanceMock = binance;
 
       PubSubMock.publish = jest.fn().mockResolvedValue(true);
       slackMock.sendMessage = jest.fn().mockResolvedValue(true);
+      binanceMock.client.cancelOrder = jest.fn().mockResolvedValue(true);
 
       mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
       mockGetAPILimit = jest.fn().mockResolvedValue(10);
@@ -200,162 +203,6 @@ describe('remove-last-buy-price.js', () => {
       });
     });
 
-    describe('when grid trade last buy order exists', () => {
-      beforeEach(async () => {
-        jest.mock('../../../trailingTradeHelper/common', () => ({
-          isActionDisabled: mockIsActionDisabled,
-          getAPILimit: mockGetAPILimit,
-          removeLastBuyPrice: mockRemoveLastBuyPrice,
-          saveOrderStats: mockSaveOrderStats,
-          saveOverrideAction: mockSaveOverrideAction,
-          getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
-        }));
-
-        jest.mock('../../../trailingTradeHelper/configuration', () => ({
-          archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
-          getSymbolGridTrade: mockGetSymbolGridTrade
-        }));
-
-        mockGetGridTradeOrder = jest.fn().mockImplementation((_logger, key) => {
-          if (key === 'BTCUPUSDT-grid-trade-last-buy-order') {
-            return { orderId: 123 };
-          }
-          return null;
-        });
-
-        jest.mock('../../../trailingTradeHelper/order', () => ({
-          getGridTradeOrder: mockGetGridTradeOrder
-        }));
-
-        const step = require('../remove-last-buy-price');
-
-        rawData = {
-          action: 'not-determined',
-          isLocked: false,
-          symbol: 'BTCUPUSDT',
-          symbolConfiguration: {
-            symbols: ['BTCUPUSDT', 'BTCUSDT', 'BNBUSDT'],
-            buy: { lastBuyPriceRemoveThreshold: 10 }
-          },
-          symbolInfo: {
-            filterLotSize: {
-              stepSize: '0.01000000',
-              minQty: '0.01000000'
-            },
-            filterMinNotional: {
-              minNotional: '10.00000000'
-            }
-          },
-          openOrders: [],
-          baseAssetBalance: {
-            free: 0,
-            locked: 0
-          },
-          sell: {
-            currentPrice: 200,
-            lastBuyPrice: null
-          }
-        };
-
-        result = await step.execute(loggerMock, rawData);
-      });
-
-      it('does not trigger archiveSymbolGridTrade', () => {
-        expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
-      });
-
-      it('does not trigger deleteSymbolGridTrade', () => {
-        expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
-      });
-
-      it('does not trigger saveOrderStats', () => {
-        expect(mockSaveOrderStats).not.toHaveBeenCalled();
-      });
-
-      it('returns expected data', () => {
-        expect(result).toStrictEqual(rawData);
-      });
-    });
-
-    describe('when grid trade last sell order exists', () => {
-      beforeEach(async () => {
-        jest.mock('../../../trailingTradeHelper/common', () => ({
-          isActionDisabled: mockIsActionDisabled,
-          getAPILimit: mockGetAPILimit,
-          removeLastBuyPrice: mockRemoveLastBuyPrice,
-          saveOrderStats: mockSaveOrderStats,
-          saveOverrideAction: mockSaveOverrideAction,
-          getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
-        }));
-
-        jest.mock('../../../trailingTradeHelper/configuration', () => ({
-          archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
-          getSymbolGridTrade: mockGetSymbolGridTrade
-        }));
-
-        mockGetGridTradeOrder = jest.fn().mockImplementation((_logger, key) => {
-          if (key === 'BTCUPUSDT-grid-trade-last-sell-order') {
-            return { orderId: 123 };
-          }
-          return null;
-        });
-
-        jest.mock('../../../trailingTradeHelper/order', () => ({
-          getGridTradeOrder: mockGetGridTradeOrder
-        }));
-
-        const step = require('../remove-last-buy-price');
-
-        rawData = {
-          action: 'not-determined',
-          isLocked: false,
-          symbol: 'BTCUPUSDT',
-          symbolConfiguration: {
-            symbols: ['BTCUPUSDT', 'BTCUSDT', 'BNBUSDT'],
-            buy: { lastBuyPriceRemoveThreshold: 10 }
-          },
-          symbolInfo: {
-            filterLotSize: {
-              stepSize: '0.01000000',
-              minQty: '0.01000000'
-            },
-            filterMinNotional: {
-              minNotional: '10.00000000'
-            }
-          },
-          openOrders: [],
-          baseAssetBalance: {
-            free: 0,
-            locked: 0
-          },
-          sell: {
-            currentPrice: 200,
-            lastBuyPrice: null
-          }
-        };
-
-        result = await step.execute(loggerMock, rawData);
-      });
-
-      it('does not trigger archiveSymbolGridTrade', () => {
-        expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
-      });
-
-      it('does not trigger deleteSymbolGridTrade', () => {
-        expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
-      });
-
-      it('does not trigger saveOrderStats', () => {
-        expect(mockSaveOrderStats).not.toHaveBeenCalled();
-      });
-
-      it('returns expected data', () => {
-        expect(result).toStrictEqual(rawData);
-      });
-    });
-
     describe('when last buy price is not set', () => {
       beforeEach(async () => {
         jest.mock('../../../trailingTradeHelper/common', () => ({
@@ -406,90 +253,6 @@ describe('remove-last-buy-price.js', () => {
           sell: {
             currentPrice: 200,
             lastBuyPrice: null
-          }
-        };
-
-        result = await step.execute(loggerMock, rawData);
-      });
-
-      it('does not trigger archiveSymbolGridTrade', () => {
-        expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
-      });
-
-      it('does not trigger deleteSymbolGridTrade', () => {
-        expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
-      });
-
-      it('does not trigger saveOrderStats', () => {
-        expect(mockSaveOrderStats).not.toHaveBeenCalled();
-      });
-
-      it('returns expected data', () => {
-        expect(result).toStrictEqual(rawData);
-      });
-    });
-
-    describe('when open orders exist', () => {
-      beforeEach(async () => {
-        jest.mock('../../../trailingTradeHelper/common', () => ({
-          isActionDisabled: mockIsActionDisabled,
-          getAPILimit: mockGetAPILimit,
-          removeLastBuyPrice: mockRemoveLastBuyPrice,
-          saveOrderStats: mockSaveOrderStats,
-          saveOverrideAction: mockSaveOverrideAction,
-          getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
-        }));
-
-        jest.mock('../../../trailingTradeHelper/configuration', () => ({
-          archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
-          getSymbolGridTrade: mockGetSymbolGridTrade
-        }));
-
-        mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
-
-        jest.mock('../../../trailingTradeHelper/order', () => ({
-          getGridTradeOrder: mockGetGridTradeOrder
-        }));
-
-        const step = require('../remove-last-buy-price');
-
-        rawData = {
-          action: 'not-determined',
-          isLocked: false,
-          symbol: 'BTCUPUSDT',
-          symbolConfiguration: {
-            symbols: ['BTCUPUSDT', 'BTCUSDT', 'BNBUSDT'],
-            buy: { lastBuyPriceRemoveThreshold: 10 }
-          },
-          symbolInfo: {
-            filterLotSize: {
-              stepSize: '0.01000000',
-              minQty: '0.01000000'
-            },
-            filterMinNotional: {
-              minNotional: '10.00000000'
-            }
-          },
-          openOrders: [
-            {
-              orderId: 123,
-              price: 197.8,
-              quantity: 0.09,
-              side: 'sell',
-              stopPrice: 198,
-              symbol: 'BTCUPUSDT',
-              timeInForce: 'GTC',
-              type: 'STOP_LOSS_LIMIT'
-            }
-          ],
-          baseAssetBalance: {
-            free: 0,
-            locked: 0
-          },
-          sell: {
-            currentPrice: 200,
-            lastBuyPrice: 190
           }
         };
 
@@ -591,576 +354,92 @@ describe('remove-last-buy-price.js', () => {
       });
     });
 
-    describe('when quantity is not enough to sell', () => {
-      describe('when found open orders at this point', () => {
-        beforeEach(async () => {
-          mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([
-            {
-              orderId: '123123123'
-            }
-          ]);
+    describe('when grid trade last sell order exists', () => {
+      beforeEach(async () => {
+        jest.mock('../../../trailingTradeHelper/common', () => ({
+          isActionDisabled: mockIsActionDisabled,
+          getAPILimit: mockGetAPILimit,
+          removeLastBuyPrice: mockRemoveLastBuyPrice,
+          saveOrderStats: mockSaveOrderStats,
+          saveOverrideAction: mockSaveOverrideAction,
+          getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
+        }));
 
-          jest.mock('../../../trailingTradeHelper/common', () => ({
-            isActionDisabled: mockIsActionDisabled,
-            getAPILimit: mockGetAPILimit,
-            removeLastBuyPrice: mockRemoveLastBuyPrice,
-            saveOrderStats: mockSaveOrderStats,
-            saveOverrideAction: mockSaveOverrideAction,
-            getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
-          }));
+        jest.mock('../../../trailingTradeHelper/configuration', () => ({
+          archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
+          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+          getSymbolGridTrade: mockGetSymbolGridTrade
+        }));
 
-          jest.mock('../../../trailingTradeHelper/configuration', () => ({
-            archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-            deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
-            getSymbolGridTrade: mockGetSymbolGridTrade
-          }));
+        mockGetGridTradeOrder = jest.fn().mockImplementation((_logger, key) => {
+          if (key === 'BTCUPUSDT-grid-trade-last-sell-order') {
+            return { orderId: 123 };
+          }
+          return null;
+        });
 
-          mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
+        jest.mock('../../../trailingTradeHelper/order', () => ({
+          getGridTradeOrder: mockGetGridTradeOrder
+        }));
 
-          jest.mock('../../../trailingTradeHelper/order', () => ({
-            getGridTradeOrder: mockGetGridTradeOrder
-          }));
+        const step = require('../remove-last-buy-price');
 
-          const step = require('../remove-last-buy-price');
-
-          rawData = {
-            action: 'not-determined',
-            isLocked: false,
-            symbol: 'BTCUPUSDT',
-            symbolConfiguration: {
-              symbols: ['BTCUPUSDT', 'BTCUSDT', 'BNBUSDT'],
-              buy: { lastBuyPriceRemoveThreshold: 10 }
+        rawData = {
+          action: 'not-determined',
+          isLocked: false,
+          symbol: 'BTCUPUSDT',
+          symbolConfiguration: {
+            symbols: ['BTCUPUSDT', 'BTCUSDT', 'BNBUSDT'],
+            buy: { lastBuyPriceRemoveThreshold: 10 }
+          },
+          symbolInfo: {
+            filterLotSize: {
+              stepSize: '0.01000000',
+              minQty: '0.01000000'
             },
-            symbolInfo: {
-              filterLotSize: {
-                stepSize: '0.01000000',
-                minQty: '0.01000000'
-              },
-              filterMinNotional: {
-                minNotional: '10.00000000'
-              }
-            },
-            openOrders: [],
-            baseAssetBalance: {
-              free: 0,
-              locked: 0
-            },
-            sell: {
-              currentPrice: 200,
-              lastBuyPrice: 160
-            }
-          };
-
-          result = await step.execute(loggerMock, rawData);
-        });
-
-        it('does not trigger archiveSymbolGridTrade', () => {
-          expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
-        });
-
-        it('does not trigger deleteSymbolGridTrade', () => {
-          expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
-        });
-
-        it('does not trigger saveOrderStats', () => {
-          expect(mockSaveOrderStats).not.toHaveBeenCalled();
-        });
-
-        it('returns expected data', () => {
-          expect(result).toStrictEqual(rawData);
-        });
-      });
-
-      describe('when cannot find open orders', () => {
-        beforeEach(() => {
-          jest.mock('../../../trailingTradeHelper/common', () => ({
-            isActionDisabled: mockIsActionDisabled,
-            getAPILimit: mockGetAPILimit,
-            removeLastBuyPrice: mockRemoveLastBuyPrice,
-            saveOrderStats: mockSaveOrderStats,
-            saveOverrideAction: mockSaveOverrideAction,
-            getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
-          }));
-
-          mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
-
-          jest.mock('../../../trailingTradeHelper/order', () => ({
-            getGridTradeOrder: mockGetGridTradeOrder
-          }));
-        });
-
-        [
-          {
-            symbol: 'ALPHABTC',
-            archivedSymbolGridTradeResult: {
-              profit: 10,
-              profitPercentage: 0.1,
-              totalBuyQuoteBuy: 100,
-              totalSellQuoteQty: 110
-            },
-            rawData: {
-              action: 'not-determined',
-              isLocked: false,
-              symbol: 'ALPHABTC',
-              symbolConfiguration: {
-                symbols: ['BTCUSDT', 'BNBUSDT', 'ALPHABTC'],
-                buy: { lastBuyPriceRemoveThreshold: 0.0001 },
-                botOptions: {
-                  autoTriggerBuy: {
-                    enabled: true,
-                    triggerAfter: 20
-                  }
-                }
-              },
-              symbolInfo: {
-                filterLotSize: {
-                  stepSize: '1.00000000',
-                  minQty: '1.00000000'
-                },
-                filterMinNotional: {
-                  minNotional: '0.00010000'
-                }
-              },
-              openOrders: [],
-              baseAssetBalance: {
-                free: 1,
-                locked: 0
-              },
-              sell: {
-                currentPrice: 0.000038,
-                lastBuyPrice: 0.00003179
-              }
+            filterMinNotional: {
+              minNotional: '10.00000000'
             }
           },
-          {
-            symbol: 'BTCUPUSDT',
-            archivedSymbolGridTradeResult: {},
-            rawData: {
-              action: 'not-determined',
-              isLocked: false,
-              symbol: 'BTCUPUSDT',
-              symbolConfiguration: {
-                symbols: ['BTCUSDT', 'BNBUSDT', 'BTCUPUSDT'],
-                buy: { lastBuyPriceRemoveThreshold: 10 },
-                botOptions: {
-                  autoTriggerBuy: {
-                    enabled: false,
-                    triggerAfter: 20
-                  }
-                }
-              },
-              symbolInfo: {
-                filterLotSize: {
-                  stepSize: '0.01000000',
-                  minQty: '0.01000000'
-                },
-                filterMinNotional: {
-                  minNotional: '10.00000000'
-                }
-              },
-              openOrders: [],
-              baseAssetBalance: {
-                free: 0,
-                locked: 0
-              },
-              sell: {
-                currentPrice: 200,
-                lastBuyPrice: 160
-              }
-            }
+          openOrders: [],
+          baseAssetBalance: {
+            free: 0,
+            locked: 0
+          },
+          sell: {
+            currentPrice: 200,
+            lastBuyPrice: 160
           }
-        ].forEach(test => {
-          describe(`${test.symbol}`, () => {
-            beforeEach(async () => {
-              mockArchiveSymbolGridTrade = jest
-                .fn()
-                .mockResolvedValue(test.archivedSymbolGridTradeResult);
+        };
 
-              jest.mock('../../../trailingTradeHelper/configuration', () => ({
-                archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-                deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
-                getSymbolGridTrade: mockGetSymbolGridTrade
-              }));
+        result = await step.execute(loggerMock, rawData);
+      });
 
-              const step = require('../remove-last-buy-price');
+      it('does not trigger archiveSymbolGridTrade', () => {
+        expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
+      });
 
-              result = await step.execute(loggerMock, test.rawData);
-            });
+      it('does not trigger deleteSymbolGridTrade', () => {
+        expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
+      });
 
-            it('triggers removeLastBuyPrice', () => {
-              expect(mockRemoveLastBuyPrice).toHaveBeenCalledWith(
-                loggerMock,
-                test.symbol
-              );
-            });
+      it('does not trigger saveOrderStats', () => {
+        expect(mockSaveOrderStats).not.toHaveBeenCalled();
+      });
 
-            it('triggers archiveSymbolGridTrade', () => {
-              expect(mockArchiveSymbolGridTrade).toHaveBeenCalledWith(
-                loggerMock,
-                test.symbol
-              );
-            });
-
-            it('triggers deleteSymbolGridTrade', () => {
-              expect(mockDeleteSymbolGridTrade).toHaveBeenCalledWith(
-                loggerMock,
-                test.symbol
-              );
-            });
-
-            if (
-              test.rawData.symbolConfiguration.botOptions.autoTriggerBuy.enabled
-            ) {
-              it('triggers saveOverrideAction', () => {
-                expect(mockSaveOverrideAction).toHaveBeenCalledWith(
-                  loggerMock,
-                  test.symbol,
-                  {
-                    action: 'buy',
-                    actionAt: expect.any(String),
-                    triggeredBy: 'auto-trigger',
-                    notify: true,
-                    checkTradingView: true
-                  },
-                  `The bot queued the action to trigger the grid trade for buying after` +
-                    ` ${test.rawData.symbolConfiguration.botOptions.autoTriggerBuy.triggerAfter} minutes later.`
-                );
-              });
-            } else {
-              it('does not trigger saveOverrideAction', () => {
-                expect(mockSaveOverrideAction).not.toHaveBeenCalled();
-              });
-            }
-
-            it('triggers saveOrderStats', () => {
-              expect(mockSaveOrderStats).toHaveBeenCalledWith(
-                loggerMock,
-                test.rawData.symbolConfiguration.symbols
-              );
-            });
-
-            it('returns expected data', () => {
-              expect(result).toMatchObject({
-                sell: {
-                  processMessage:
-                    'Balance is not enough to sell. Delete last buy price.',
-                  updatedAt: expect.any(Object)
-                }
-              });
-            });
-          });
-        });
+      it('returns expected data', () => {
+        expect(result).toStrictEqual(rawData);
       });
     });
 
-    describe('when balance is less than minimum notional', () => {
-      describe('when found open orders at this point', () => {
-        beforeEach(async () => {
-          mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([
-            {
-              orderId: '123123123'
-            }
-          ]);
-
-          jest.mock('../../../trailingTradeHelper/common', () => ({
-            isActionDisabled: mockIsActionDisabled,
-            getAPILimit: mockGetAPILimit,
-            removeLastBuyPrice: mockRemoveLastBuyPrice,
-            saveOrderStats: mockSaveOrderStats,
-            saveOverrideAction: mockSaveOverrideAction,
-            getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
-          }));
-
-          jest.mock('../../../trailingTradeHelper/configuration', () => ({
-            archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-            deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
-            getSymbolGridTrade: mockGetSymbolGridTrade
-          }));
-
-          mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
-
-          jest.mock('../../../trailingTradeHelper/order', () => ({
-            getGridTradeOrder: mockGetGridTradeOrder
-          }));
-
-          const step = require('../remove-last-buy-price');
-
-          rawData = {
-            action: 'not-determined',
-            isLocked: false,
-            symbol: 'BTCUPUSDT',
-            symbolConfiguration: {
-              symbols: ['BTCUSDT', 'BNBUSDT', 'BTCUPUSDT'],
-              buy: { lastBuyPriceRemoveThreshold: 10 }
-            },
-            symbolInfo: {
-              filterLotSize: {
-                stepSize: '0.01000000',
-                minQty: '0.01000000'
-              },
-              filterMinNotional: {
-                minNotional: '10.00000000'
-              }
-            },
-            openOrders: [],
-            baseAssetBalance: {
-              free: 0,
-              locked: 0.04
-            },
-            sell: {
-              currentPrice: 200,
-              lastBuyPrice: 160
-            }
-          };
-
-          result = await step.execute(loggerMock, rawData);
-        });
-
-        it('does not trigger archiveSymbolGridTrade', () => {
-          expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
-        });
-
-        it('does not trigger deleteSymbolGridTrade', () => {
-          expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
-        });
-
-        it('does not trigger saveOrderStats', () => {
-          expect(mockSaveOrderStats).not.toHaveBeenCalled();
-        });
-
-        it('returns expected data', () => {
-          expect(result).toStrictEqual(rawData);
-        });
-      });
-
-      describe('when cannot find open orders', () => {
-        describe('last buy price remove threshold is same as minimum notional', () => {
-          beforeEach(async () => {
-            jest.mock('../../../trailingTradeHelper/common', () => ({
-              isActionDisabled: mockIsActionDisabled,
-              getAPILimit: mockGetAPILimit,
-              removeLastBuyPrice: mockRemoveLastBuyPrice,
-              saveOrderStats: mockSaveOrderStats,
-              saveOverrideAction: mockSaveOverrideAction,
-              getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
-            }));
-
-            mockArchiveSymbolGridTrade = jest.fn().mockResolvedValue({
-              profit: -10,
-              profitPercentage: -0.1,
-              totalBuyQuoteBuy: 110,
-              totalSellQuoteQty: 100
-            });
-
-            jest.mock('../../../trailingTradeHelper/configuration', () => ({
-              archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-              deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
-              getSymbolGridTrade: mockGetSymbolGridTrade
-            }));
-
-            mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
-
-            jest.mock('../../../trailingTradeHelper/order', () => ({
-              getGridTradeOrder: mockGetGridTradeOrder
-            }));
-
-            const step = require('../remove-last-buy-price');
-
-            rawData = {
-              action: 'not-determined',
-              isLocked: false,
-              symbol: 'BTCUPUSDT',
-              symbolConfiguration: {
-                symbols: ['BTCUSDT', 'BNBUSDT', 'BTCUPUSDT'],
-                buy: { lastBuyPriceRemoveThreshold: 10 },
-                botOptions: {
-                  autoTriggerBuy: {
-                    enabled: true,
-                    triggerAfter: 20
-                  }
-                }
-              },
-              symbolInfo: {
-                filterLotSize: {
-                  stepSize: '0.01000000',
-                  minQty: '0.01000000'
-                },
-                filterMinNotional: {
-                  minNotional: '10.00000000'
-                }
-              },
-              openOrders: [],
-              baseAssetBalance: {
-                free: 0,
-                locked: 0.04
-              },
-              sell: {
-                currentPrice: 200,
-                lastBuyPrice: 160
-              }
-            };
-
-            result = await step.execute(loggerMock, rawData);
-          });
-
-          it('triggers removeLastBuyPrice', () => {
-            expect(mockRemoveLastBuyPrice).toHaveBeenCalledWith(
-              loggerMock,
-              'BTCUPUSDT'
-            );
-          });
-
-          it('triggers archiveSymbolGridTrade', () => {
-            expect(mockArchiveSymbolGridTrade).toHaveBeenCalledWith(
-              loggerMock,
-              'BTCUPUSDT'
-            );
-          });
-
-          it('triggers deleteSymbolGridTrade', () => {
-            expect(mockDeleteSymbolGridTrade).toHaveBeenCalledWith(
-              loggerMock,
-              'BTCUPUSDT'
-            );
-          });
-
-          it('triggers saveOverrideAction', () => {
-            expect(mockSaveOverrideAction).toHaveBeenCalledWith(
-              loggerMock,
-              'BTCUPUSDT',
-              {
-                action: 'buy',
-                actionAt: expect.any(String),
-                triggeredBy: 'auto-trigger',
-                notify: true,
-                checkTradingView: true
-              },
-              `The bot queued the action to trigger the grid trade for buying after 20 minutes later.`
-            );
-          });
-
-          it('triggers saveOrderStats', () => {
-            expect(mockSaveOrderStats).toHaveBeenCalledWith(loggerMock, [
-              'BTCUSDT',
-              'BNBUSDT',
-              'BTCUPUSDT'
-            ]);
-          });
-
-          it('returns expected data', () => {
-            expect(result).toStrictEqual({
-              ...rawData,
-              ...{
-                sell: {
-                  currentPrice: 200,
-                  lastBuyPrice: 160,
-                  processMessage:
-                    'Balance is less than the last buy price remove threshold. Delete last buy price.',
-                  updatedAt: expect.any(Object)
-                }
-              }
-            });
-          });
-        });
-
-        describe('last buy price remove threshold is less than minimum notional', () => {
-          beforeEach(async () => {
-            jest.mock('../../../trailingTradeHelper/common', () => ({
-              isActionDisabled: mockIsActionDisabled,
-              getAPILimit: mockGetAPILimit,
-              removeLastBuyPrice: mockRemoveLastBuyPrice,
-              saveOrderStats: mockSaveOrderStats,
-              saveOverrideAction: mockSaveOverrideAction,
-              getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
-            }));
-
-            mockArchiveSymbolGridTrade = jest.fn().mockResolvedValue({
-              profit: 10,
-              profitPercentage: 0.1,
-              totalBuyQuoteBuy: 100,
-              totalSellQuoteQty: 110
-            });
-
-            jest.mock('../../../trailingTradeHelper/configuration', () => ({
-              archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-              deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
-              getSymbolGridTrade: mockGetSymbolGridTrade
-            }));
-
-            mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
-
-            jest.mock('../../../trailingTradeHelper/order', () => ({
-              getGridTradeOrder: mockGetGridTradeOrder
-            }));
-
-            const step = require('../remove-last-buy-price');
-
-            rawData = {
-              action: 'not-determined',
-              isLocked: false,
-              symbol: 'BTCUPUSDT',
-              symbolConfiguration: {
-                symbols: ['BTCUSDT', 'BNBUSDT', 'BTCUPUSDT'],
-                buy: { lastBuyPriceRemoveThreshold: 5 },
-                botOptions: {
-                  autoTriggerBuy: {
-                    enabled: false,
-                    triggerAfter: 20
-                  }
-                }
-              },
-              symbolInfo: {
-                filterLotSize: {
-                  stepSize: '0.01000000',
-                  minQty: '0.01000000'
-                },
-                filterMinNotional: {
-                  minNotional: '10.00000000'
-                }
-              },
-              openOrders: [],
-              baseAssetBalance: {
-                free: 0,
-                locked: 0.04
-              },
-              sell: {
-                currentPrice: 200,
-                lastBuyPrice: 160
-              }
-            };
-
-            result = await step.execute(loggerMock, rawData);
-          });
-
-          it('does not trigger removeLastBuyPrice', () => {
-            expect(mockRemoveLastBuyPrice).not.toHaveBeenCalled();
-          });
-
-          it('does not trigger archiveSymbolGridTrade', () => {
-            expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
-          });
-
-          it('does not trigger deleteSymbolGridTrade', () => {
-            expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
-          });
-
-          it('does not trigger saveOverrideAction', () => {
-            expect(mockSaveOverrideAction).not.toHaveBeenCalled();
-          });
-
-          it('does not trigger saveOrderStats', () => {
-            expect(mockSaveOrderStats).not.toHaveBeenCalled();
-          });
-
-          it('returns expected data', () => {
-            expect(result).toStrictEqual(rawData);
-          });
-        });
-      });
-    });
-
-    describe('when there is enough balance', () => {
+    describe('when sell order is completed', () => {
       beforeEach(() => {
+        mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([
+          {
+            orderId: 123456
+          }
+        ]);
+
         jest.mock('../../../trailingTradeHelper/common', () => ({
           isActionDisabled: mockIsActionDisabled,
           getAPILimit: mockGetAPILimit,
@@ -1206,7 +485,11 @@ describe('remove-last-buy-price.js', () => {
               minNotional: '10.00000000'
             }
           },
-          openOrders: [],
+          openOrders: [
+            {
+              orderId: 123456
+            }
+          ],
           baseAssetBalance: {
             free: 0,
             locked: 0.2
@@ -1231,6 +514,10 @@ describe('remove-last-buy-price.js', () => {
           const step = require('../remove-last-buy-price');
 
           result = await step.execute(loggerMock, rawData);
+        });
+
+        it('does not trigger binance.client.cancelOrder', () => {
+          expect(binanceMock.client.cancelOrder).not.toHaveBeenCalled();
         });
 
         it('does not trigger removeLastBuyPrice', () => {
@@ -1275,6 +562,10 @@ describe('remove-last-buy-price.js', () => {
           const step = require('../remove-last-buy-price');
 
           result = await step.execute(loggerMock, rawData);
+        });
+
+        it('does not trigger binance.client.cancelOrder', () => {
+          expect(binanceMock.client.cancelOrder).not.toHaveBeenCalled();
         });
 
         it('does not trigger removeLastBuyPrice', () => {
@@ -1328,6 +619,10 @@ describe('remove-last-buy-price.js', () => {
           result = await step.execute(loggerMock, rawData);
         });
 
+        it('does not trigger binance.client.cancelOrder', () => {
+          expect(binanceMock.client.cancelOrder).not.toHaveBeenCalled();
+        });
+
         it('does not trigger removeLastBuyPrice', () => {
           expect(mockRemoveLastBuyPrice).not.toHaveBeenCalled();
         });
@@ -1377,6 +672,13 @@ describe('remove-last-buy-price.js', () => {
           const step = require('../remove-last-buy-price');
 
           result = await step.execute(loggerMock, rawData);
+        });
+
+        it('triggers binance.client.cancelOrder', () => {
+          expect(binanceMock.client.cancelOrder).toHaveBeenCalledWith({
+            symbol: 'BTCUPUSDT',
+            orderId: 123456
+          });
         });
 
         it('triggers removeLastBuyPrice', () => {
@@ -1436,6 +738,512 @@ describe('remove-last-buy-price.js', () => {
               }
             }
           });
+        });
+      });
+    });
+
+    describe('when quantity is not enough to sell', () => {
+      beforeEach(() => {
+        jest.mock('../../../trailingTradeHelper/common', () => ({
+          isActionDisabled: mockIsActionDisabled,
+          getAPILimit: mockGetAPILimit,
+          removeLastBuyPrice: mockRemoveLastBuyPrice,
+          saveOrderStats: mockSaveOrderStats,
+          saveOverrideAction: mockSaveOverrideAction,
+          getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
+        }));
+
+        mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
+
+        jest.mock('../../../trailingTradeHelper/order', () => ({
+          getGridTradeOrder: mockGetGridTradeOrder
+        }));
+      });
+
+      [
+        {
+          symbol: 'ALPHABTC',
+          archivedSymbolGridTradeResult: {
+            profit: 10,
+            profitPercentage: 0.1,
+            totalBuyQuoteBuy: 100,
+            totalSellQuoteQty: 110
+          },
+          rawData: {
+            action: 'not-determined',
+            isLocked: false,
+            symbol: 'ALPHABTC',
+            symbolConfiguration: {
+              symbols: ['BTCUSDT', 'BNBUSDT', 'ALPHABTC'],
+              buy: { lastBuyPriceRemoveThreshold: 0.0001 },
+              botOptions: {
+                autoTriggerBuy: {
+                  enabled: true,
+                  triggerAfter: 20
+                }
+              }
+            },
+            symbolInfo: {
+              filterLotSize: {
+                stepSize: '1.00000000',
+                minQty: '1.00000000'
+              },
+              filterMinNotional: {
+                minNotional: '0.00010000'
+              }
+            },
+            openOrders: [],
+            baseAssetBalance: {
+              free: 1,
+              locked: 0
+            },
+            sell: {
+              currentPrice: 0.000038,
+              lastBuyPrice: 0.00003179
+            }
+          }
+        },
+        {
+          symbol: 'BTCUPUSDT',
+          archivedSymbolGridTradeResult: {},
+          rawData: {
+            action: 'not-determined',
+            isLocked: false,
+            symbol: 'BTCUPUSDT',
+            symbolConfiguration: {
+              symbols: ['BTCUSDT', 'BNBUSDT', 'BTCUPUSDT'],
+              buy: { lastBuyPriceRemoveThreshold: 10 },
+              botOptions: {
+                autoTriggerBuy: {
+                  enabled: false,
+                  triggerAfter: 20
+                }
+              }
+            },
+            symbolInfo: {
+              filterLotSize: {
+                stepSize: '0.01000000',
+                minQty: '0.01000000'
+              },
+              filterMinNotional: {
+                minNotional: '10.00000000'
+              }
+            },
+            openOrders: [],
+            baseAssetBalance: {
+              free: 0,
+              locked: 0
+            },
+            sell: {
+              currentPrice: 200,
+              lastBuyPrice: 160
+            }
+          }
+        }
+      ].forEach(test => {
+        describe(`${test.symbol}`, () => {
+          beforeEach(async () => {
+            mockArchiveSymbolGridTrade = jest
+              .fn()
+              .mockResolvedValue(test.archivedSymbolGridTradeResult);
+
+            jest.mock('../../../trailingTradeHelper/configuration', () => ({
+              archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
+              deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+              getSymbolGridTrade: mockGetSymbolGridTrade
+            }));
+
+            const step = require('../remove-last-buy-price');
+
+            result = await step.execute(loggerMock, test.rawData);
+          });
+
+          it('triggers removeLastBuyPrice', () => {
+            expect(mockRemoveLastBuyPrice).toHaveBeenCalledWith(
+              loggerMock,
+              test.symbol
+            );
+          });
+
+          it('triggers archiveSymbolGridTrade', () => {
+            expect(mockArchiveSymbolGridTrade).toHaveBeenCalledWith(
+              loggerMock,
+              test.symbol
+            );
+          });
+
+          it('triggers deleteSymbolGridTrade', () => {
+            expect(mockDeleteSymbolGridTrade).toHaveBeenCalledWith(
+              loggerMock,
+              test.symbol
+            );
+          });
+
+          if (
+            test.rawData.symbolConfiguration.botOptions.autoTriggerBuy.enabled
+          ) {
+            it('triggers saveOverrideAction', () => {
+              expect(mockSaveOverrideAction).toHaveBeenCalledWith(
+                loggerMock,
+                test.symbol,
+                {
+                  action: 'buy',
+                  actionAt: expect.any(String),
+                  triggeredBy: 'auto-trigger',
+                  notify: true,
+                  checkTradingView: true
+                },
+                `The bot queued the action to trigger the grid trade for buying after` +
+                  ` ${test.rawData.symbolConfiguration.botOptions.autoTriggerBuy.triggerAfter} minutes later.`
+              );
+            });
+          } else {
+            it('does not trigger saveOverrideAction', () => {
+              expect(mockSaveOverrideAction).not.toHaveBeenCalled();
+            });
+          }
+
+          it('triggers saveOrderStats', () => {
+            expect(mockSaveOrderStats).toHaveBeenCalledWith(
+              loggerMock,
+              test.rawData.symbolConfiguration.symbols
+            );
+          });
+
+          it('returns expected data', () => {
+            expect(result).toMatchObject({
+              sell: {
+                processMessage:
+                  'Balance is not enough to sell. Delete last buy price.',
+                updatedAt: expect.any(Object)
+              }
+            });
+          });
+        });
+      });
+    });
+
+    describe('when balance is less than minimum notional', () => {
+      describe('last buy price remove threshold is same as minimum notional', () => {
+        beforeEach(async () => {
+          jest.mock('../../../trailingTradeHelper/common', () => ({
+            isActionDisabled: mockIsActionDisabled,
+            getAPILimit: mockGetAPILimit,
+            removeLastBuyPrice: mockRemoveLastBuyPrice,
+            saveOrderStats: mockSaveOrderStats,
+            saveOverrideAction: mockSaveOverrideAction,
+            getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
+          }));
+
+          mockArchiveSymbolGridTrade = jest.fn().mockResolvedValue({
+            profit: -10,
+            profitPercentage: -0.1,
+            totalBuyQuoteBuy: 110,
+            totalSellQuoteQty: 100
+          });
+
+          jest.mock('../../../trailingTradeHelper/configuration', () => ({
+            archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
+            deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+            getSymbolGridTrade: mockGetSymbolGridTrade
+          }));
+
+          mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
+
+          jest.mock('../../../trailingTradeHelper/order', () => ({
+            getGridTradeOrder: mockGetGridTradeOrder
+          }));
+
+          const step = require('../remove-last-buy-price');
+
+          rawData = {
+            action: 'not-determined',
+            isLocked: false,
+            symbol: 'BTCUPUSDT',
+            symbolConfiguration: {
+              symbols: ['BTCUSDT', 'BNBUSDT', 'BTCUPUSDT'],
+              buy: { lastBuyPriceRemoveThreshold: 10 },
+              botOptions: {
+                autoTriggerBuy: {
+                  enabled: true,
+                  triggerAfter: 20
+                }
+              }
+            },
+            symbolInfo: {
+              filterLotSize: {
+                stepSize: '0.01000000',
+                minQty: '0.01000000'
+              },
+              filterMinNotional: {
+                minNotional: '10.00000000'
+              }
+            },
+            openOrders: [],
+            baseAssetBalance: {
+              free: 0,
+              locked: 0.04
+            },
+            sell: {
+              currentPrice: 200,
+              lastBuyPrice: 160
+            }
+          };
+
+          result = await step.execute(loggerMock, rawData);
+        });
+
+        it('triggers removeLastBuyPrice', () => {
+          expect(mockRemoveLastBuyPrice).toHaveBeenCalledWith(
+            loggerMock,
+            'BTCUPUSDT'
+          );
+        });
+
+        it('triggers archiveSymbolGridTrade', () => {
+          expect(mockArchiveSymbolGridTrade).toHaveBeenCalledWith(
+            loggerMock,
+            'BTCUPUSDT'
+          );
+        });
+
+        it('triggers deleteSymbolGridTrade', () => {
+          expect(mockDeleteSymbolGridTrade).toHaveBeenCalledWith(
+            loggerMock,
+            'BTCUPUSDT'
+          );
+        });
+
+        it('triggers saveOverrideAction', () => {
+          expect(mockSaveOverrideAction).toHaveBeenCalledWith(
+            loggerMock,
+            'BTCUPUSDT',
+            {
+              action: 'buy',
+              actionAt: expect.any(String),
+              triggeredBy: 'auto-trigger',
+              notify: true,
+              checkTradingView: true
+            },
+            `The bot queued the action to trigger the grid trade for buying after 20 minutes later.`
+          );
+        });
+
+        it('triggers saveOrderStats', () => {
+          expect(mockSaveOrderStats).toHaveBeenCalledWith(loggerMock, [
+            'BTCUSDT',
+            'BNBUSDT',
+            'BTCUPUSDT'
+          ]);
+        });
+
+        it('returns expected data', () => {
+          expect(result).toStrictEqual({
+            ...rawData,
+            ...{
+              sell: {
+                currentPrice: 200,
+                lastBuyPrice: 160,
+                processMessage:
+                  'Balance is less than the last buy price remove threshold. Delete last buy price.',
+                updatedAt: expect.any(Object)
+              }
+            }
+          });
+        });
+      });
+
+      describe('last buy price remove threshold is less than minimum notional', () => {
+        beforeEach(async () => {
+          jest.mock('../../../trailingTradeHelper/common', () => ({
+            isActionDisabled: mockIsActionDisabled,
+            getAPILimit: mockGetAPILimit,
+            removeLastBuyPrice: mockRemoveLastBuyPrice,
+            saveOrderStats: mockSaveOrderStats,
+            saveOverrideAction: mockSaveOverrideAction,
+            getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
+          }));
+
+          mockArchiveSymbolGridTrade = jest.fn().mockResolvedValue({
+            profit: 10,
+            profitPercentage: 0.1,
+            totalBuyQuoteBuy: 100,
+            totalSellQuoteQty: 110
+          });
+
+          jest.mock('../../../trailingTradeHelper/configuration', () => ({
+            archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
+            deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+            getSymbolGridTrade: mockGetSymbolGridTrade
+          }));
+
+          mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
+
+          jest.mock('../../../trailingTradeHelper/order', () => ({
+            getGridTradeOrder: mockGetGridTradeOrder
+          }));
+
+          const step = require('../remove-last-buy-price');
+
+          rawData = {
+            action: 'not-determined',
+            isLocked: false,
+            symbol: 'BTCUPUSDT',
+            symbolConfiguration: {
+              symbols: ['BTCUSDT', 'BNBUSDT', 'BTCUPUSDT'],
+              buy: { lastBuyPriceRemoveThreshold: 5 },
+              botOptions: {
+                autoTriggerBuy: {
+                  enabled: false,
+                  triggerAfter: 20
+                }
+              }
+            },
+            symbolInfo: {
+              filterLotSize: {
+                stepSize: '0.01000000',
+                minQty: '0.01000000'
+              },
+              filterMinNotional: {
+                minNotional: '10.00000000'
+              }
+            },
+            openOrders: [],
+            baseAssetBalance: {
+              free: 0,
+              locked: 0.04
+            },
+            sell: {
+              currentPrice: 200,
+              lastBuyPrice: 160
+            }
+          };
+
+          result = await step.execute(loggerMock, rawData);
+        });
+
+        it('does not trigger removeLastBuyPrice', () => {
+          expect(mockRemoveLastBuyPrice).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger archiveSymbolGridTrade', () => {
+          expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger deleteSymbolGridTrade', () => {
+          expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger saveOverrideAction', () => {
+          expect(mockSaveOverrideAction).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger saveOrderStats', () => {
+          expect(mockSaveOrderStats).not.toHaveBeenCalled();
+        });
+
+        it('returns expected data', () => {
+          expect(result).toStrictEqual(rawData);
+        });
+      });
+    });
+
+    describe('when there is enough balance', () => {
+      beforeEach(async () => {
+        jest.mock('../../../trailingTradeHelper/common', () => ({
+          isActionDisabled: mockIsActionDisabled,
+          getAPILimit: mockGetAPILimit,
+          removeLastBuyPrice: mockRemoveLastBuyPrice,
+          saveOrderStats: mockSaveOrderStats,
+          saveOverrideAction: mockSaveOverrideAction,
+          getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
+        }));
+
+        mockArchiveSymbolGridTrade = jest.fn().mockResolvedValue({
+          profit: 10,
+          profitPercentage: 0.1,
+          totalBuyQuoteBuy: 100,
+          totalSellQuoteQty: 110
+        });
+
+        mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
+
+        jest.mock('../../../trailingTradeHelper/order', () => ({
+          getGridTradeOrder: mockGetGridTradeOrder
+        }));
+
+        rawData = {
+          action: 'not-determined',
+          isLocked: false,
+          symbol: 'BTCUPUSDT',
+          symbolConfiguration: {
+            symbols: ['BTCUSDT', 'BNBUSDT', 'BTCUPUSDT'],
+            buy: { lastBuyPriceRemoveThreshold: 10 },
+            botOptions: {
+              autoTriggerBuy: {
+                enabled: true,
+                triggerAfter: 20
+              }
+            }
+          },
+          symbolInfo: {
+            filterLotSize: {
+              stepSize: '0.01000000',
+              minQty: '0.01000000'
+            },
+            filterMinNotional: {
+              minNotional: '10.00000000'
+            }
+          },
+          openOrders: [],
+          baseAssetBalance: {
+            free: 0,
+            locked: 0.2
+          },
+          sell: {
+            currentPrice: 200,
+            lastBuyPrice: 160
+          }
+        };
+
+        jest.mock('../../../trailingTradeHelper/configuration', () => ({
+          archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
+          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+          getSymbolGridTrade: mockGetSymbolGridTrade
+        }));
+
+        const step = require('../remove-last-buy-price');
+
+        result = await step.execute(loggerMock, rawData);
+      });
+
+      it('does not trigger binance.client.cancelOrder', () => {
+        expect(binanceMock.client.cancelOrder).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger removeLastBuyPrice', () => {
+        expect(mockRemoveLastBuyPrice).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger archiveSymbolGridTrade', () => {
+        expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger deleteSymbolGridTrade', () => {
+        expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger saveOverrideAction', () => {
+        expect(mockSaveOverrideAction).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger saveOrderStats', () => {
+        expect(mockSaveOrderStats).not.toHaveBeenCalled();
+      });
+
+      it('returns expected data', () => {
+        expect(result).toStrictEqual({
+          ...rawData
         });
       });
     });

--- a/app/cronjob/trailingTrade/step/__tests__/remove-last-buy-price.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/remove-last-buy-price.test.js
@@ -17,6 +17,7 @@ describe('remove-last-buy-price.js', () => {
 
   let mockArchiveSymbolGridTrade;
   let mockDeleteSymbolGridTrade;
+  let mockGetSymbolGridTrade;
 
   let mockGetGridTradeOrder;
 
@@ -52,6 +53,7 @@ describe('remove-last-buy-price.js', () => {
         totalSellQuoteQty: 0
       });
       mockDeleteSymbolGridTrade = jest.fn().mockResolvedValue(true);
+      mockGetSymbolGridTrade = jest.fn().mockResolvedValue({});
 
       mockGetGridTradeOrder = jest.fn().mockResolvedValue({});
     });
@@ -69,7 +71,8 @@ describe('remove-last-buy-price.js', () => {
 
         jest.mock('../../../trailingTradeHelper/configuration', () => ({
           archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+          getSymbolGridTrade: mockGetSymbolGridTrade
         }));
 
         jest.mock('../../../trailingTradeHelper/order', () => ({
@@ -139,7 +142,8 @@ describe('remove-last-buy-price.js', () => {
 
         jest.mock('../../../trailingTradeHelper/configuration', () => ({
           archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+          getSymbolGridTrade: mockGetSymbolGridTrade
         }));
 
         jest.mock('../../../trailingTradeHelper/order', () => ({
@@ -209,7 +213,8 @@ describe('remove-last-buy-price.js', () => {
 
         jest.mock('../../../trailingTradeHelper/configuration', () => ({
           archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+          getSymbolGridTrade: mockGetSymbolGridTrade
         }));
 
         mockGetGridTradeOrder = jest.fn().mockImplementation((_logger, key) => {
@@ -286,7 +291,8 @@ describe('remove-last-buy-price.js', () => {
 
         jest.mock('../../../trailingTradeHelper/configuration', () => ({
           archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+          getSymbolGridTrade: mockGetSymbolGridTrade
         }));
 
         mockGetGridTradeOrder = jest.fn().mockImplementation((_logger, key) => {
@@ -363,7 +369,8 @@ describe('remove-last-buy-price.js', () => {
 
         jest.mock('../../../trailingTradeHelper/configuration', () => ({
           archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+          getSymbolGridTrade: mockGetSymbolGridTrade
         }));
 
         mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
@@ -435,7 +442,8 @@ describe('remove-last-buy-price.js', () => {
 
         jest.mock('../../../trailingTradeHelper/configuration', () => ({
           archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+          getSymbolGridTrade: mockGetSymbolGridTrade
         }));
 
         mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
@@ -523,7 +531,8 @@ describe('remove-last-buy-price.js', () => {
 
         jest.mock('../../../trailingTradeHelper/configuration', () => ({
           archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+          deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+          getSymbolGridTrade: mockGetSymbolGridTrade
         }));
 
         mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
@@ -602,7 +611,8 @@ describe('remove-last-buy-price.js', () => {
 
           jest.mock('../../../trailingTradeHelper/configuration', () => ({
             archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-            deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+            deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+            getSymbolGridTrade: mockGetSymbolGridTrade
           }));
 
           mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
@@ -768,7 +778,8 @@ describe('remove-last-buy-price.js', () => {
 
               jest.mock('../../../trailingTradeHelper/configuration', () => ({
                 archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-                deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+                deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+                getSymbolGridTrade: mockGetSymbolGridTrade
               }));
 
               const step = require('../remove-last-buy-price');
@@ -862,7 +873,8 @@ describe('remove-last-buy-price.js', () => {
 
           jest.mock('../../../trailingTradeHelper/configuration', () => ({
             archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-            deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+            deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+            getSymbolGridTrade: mockGetSymbolGridTrade
           }));
 
           mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
@@ -942,7 +954,8 @@ describe('remove-last-buy-price.js', () => {
 
             jest.mock('../../../trailingTradeHelper/configuration', () => ({
               archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-              deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+              deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+              getSymbolGridTrade: mockGetSymbolGridTrade
             }));
 
             mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
@@ -1070,7 +1083,8 @@ describe('remove-last-buy-price.js', () => {
 
             jest.mock('../../../trailingTradeHelper/configuration', () => ({
               archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-              deleteSymbolGridTrade: mockDeleteSymbolGridTrade
+              deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+              getSymbolGridTrade: mockGetSymbolGridTrade
             }));
 
             mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
@@ -1146,7 +1160,7 @@ describe('remove-last-buy-price.js', () => {
     });
 
     describe('when there is enough balance', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         jest.mock('../../../trailingTradeHelper/common', () => ({
           isActionDisabled: mockIsActionDisabled,
           getAPILimit: mockGetAPILimit,
@@ -1163,18 +1177,11 @@ describe('remove-last-buy-price.js', () => {
           totalSellQuoteQty: 110
         });
 
-        jest.mock('../../../trailingTradeHelper/configuration', () => ({
-          archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
-          deleteSymbolGridTrade: mockDeleteSymbolGridTrade
-        }));
-
         mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
 
         jest.mock('../../../trailingTradeHelper/order', () => ({
           getGridTradeOrder: mockGetGridTradeOrder
         }));
-
-        const step = require('../remove-last-buy-price');
 
         rawData = {
           action: 'not-determined',
@@ -1209,33 +1216,226 @@ describe('remove-last-buy-price.js', () => {
             lastBuyPrice: 160
           }
         };
-
-        result = await step.execute(loggerMock, rawData);
       });
 
-      it('does not trigger removeLastBuyPrice', () => {
-        expect(mockRemoveLastBuyPrice).not.toHaveBeenCalled();
+      describe('when symbol grid trade is empty', () => {
+        beforeEach(async () => {
+          mockGetSymbolGridTrade = jest.fn().mockResolvedValue({});
+
+          jest.mock('../../../trailingTradeHelper/configuration', () => ({
+            archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
+            deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+            getSymbolGridTrade: mockGetSymbolGridTrade
+          }));
+
+          const step = require('../remove-last-buy-price');
+
+          result = await step.execute(loggerMock, rawData);
+        });
+
+        it('does not trigger removeLastBuyPrice', () => {
+          expect(mockRemoveLastBuyPrice).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger archiveSymbolGridTrade', () => {
+          expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger deleteSymbolGridTrade', () => {
+          expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger saveOverrideAction', () => {
+          expect(mockSaveOverrideAction).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger saveOrderStats', () => {
+          expect(mockSaveOrderStats).not.toHaveBeenCalled();
+        });
+
+        it('returns expected data', () => {
+          expect(result).toStrictEqual({
+            ...rawData
+          });
+        });
       });
 
-      it('does not trigger archiveSymbolGridTrade', () => {
-        expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
+      describe('when sell array of symbol grid trade is empty', () => {
+        beforeEach(async () => {
+          mockGetSymbolGridTrade = jest.fn().mockResolvedValue({
+            sell: []
+          });
+
+          jest.mock('../../../trailingTradeHelper/configuration', () => ({
+            archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
+            deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+            getSymbolGridTrade: mockGetSymbolGridTrade
+          }));
+
+          const step = require('../remove-last-buy-price');
+
+          result = await step.execute(loggerMock, rawData);
+        });
+
+        it('does not trigger removeLastBuyPrice', () => {
+          expect(mockRemoveLastBuyPrice).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger archiveSymbolGridTrade', () => {
+          expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger deleteSymbolGridTrade', () => {
+          expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger saveOverrideAction', () => {
+          expect(mockSaveOverrideAction).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger saveOrderStats', () => {
+          expect(mockSaveOrderStats).not.toHaveBeenCalled();
+        });
+
+        it('returns expected data', () => {
+          expect(result).toStrictEqual({
+            ...rawData
+          });
+        });
       });
 
-      it('does not trigger deleteSymbolGridTrade', () => {
-        expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
+      describe('there is no sell order executed', () => {
+        beforeEach(async () => {
+          mockGetSymbolGridTrade = jest.fn().mockResolvedValue({
+            sell: [
+              {
+                executed: true
+              },
+              {
+                executed: false
+              }
+            ]
+          });
+
+          jest.mock('../../../trailingTradeHelper/configuration', () => ({
+            archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
+            deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+            getSymbolGridTrade: mockGetSymbolGridTrade
+          }));
+
+          const step = require('../remove-last-buy-price');
+
+          result = await step.execute(loggerMock, rawData);
+        });
+
+        it('does not trigger removeLastBuyPrice', () => {
+          expect(mockRemoveLastBuyPrice).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger archiveSymbolGridTrade', () => {
+          expect(mockArchiveSymbolGridTrade).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger deleteSymbolGridTrade', () => {
+          expect(mockDeleteSymbolGridTrade).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger saveOverrideAction', () => {
+          expect(mockSaveOverrideAction).not.toHaveBeenCalled();
+        });
+
+        it('does not trigger saveOrderStats', () => {
+          expect(mockSaveOrderStats).not.toHaveBeenCalled();
+        });
+
+        it('returns expected data', () => {
+          expect(result).toStrictEqual({
+            ...rawData
+          });
+        });
       });
 
-      it('does not trigger saveOverrideAction', () => {
-        expect(mockSaveOverrideAction).not.toHaveBeenCalled();
-      });
+      describe('there is all sell order executed', () => {
+        beforeEach(async () => {
+          mockGetSymbolGridTrade = jest.fn().mockResolvedValue({
+            sell: [
+              {
+                executed: true
+              },
+              {
+                executed: true
+              }
+            ]
+          });
 
-      it('does not trigger saveOrderStats', () => {
-        expect(mockSaveOrderStats).not.toHaveBeenCalled();
-      });
+          jest.mock('../../../trailingTradeHelper/configuration', () => ({
+            archiveSymbolGridTrade: mockArchiveSymbolGridTrade,
+            deleteSymbolGridTrade: mockDeleteSymbolGridTrade,
+            getSymbolGridTrade: mockGetSymbolGridTrade
+          }));
 
-      it('returns expected data', () => {
-        expect(result).toStrictEqual({
-          ...rawData
+          const step = require('../remove-last-buy-price');
+
+          result = await step.execute(loggerMock, rawData);
+        });
+
+        it('triggers removeLastBuyPrice', () => {
+          expect(mockRemoveLastBuyPrice).toHaveBeenCalledWith(
+            loggerMock,
+            'BTCUPUSDT'
+          );
+        });
+
+        it('triggers archiveSymbolGridTrade', () => {
+          expect(mockArchiveSymbolGridTrade).toHaveBeenCalledWith(
+            loggerMock,
+            'BTCUPUSDT'
+          );
+        });
+
+        it('triggers deleteSymbolGridTrade', () => {
+          expect(mockDeleteSymbolGridTrade).toHaveBeenCalledWith(
+            loggerMock,
+            'BTCUPUSDT'
+          );
+        });
+
+        it('triggers saveOverrideAction', () => {
+          expect(mockSaveOverrideAction).toHaveBeenCalledWith(
+            loggerMock,
+            'BTCUPUSDT',
+            {
+              action: 'buy',
+              actionAt: expect.any(String),
+              triggeredBy: 'auto-trigger',
+              notify: true,
+              checkTradingView: true
+            },
+            `The bot queued the action to trigger the grid trade for buying after 20 minutes later.`
+          );
+        });
+
+        it('triggers saveOrderStats', () => {
+          expect(mockSaveOrderStats).toHaveBeenCalledWith(loggerMock, [
+            'BTCUSDT',
+            'BNBUSDT',
+            'BTCUPUSDT'
+          ]);
+        });
+
+        it('returns expected data', () => {
+          expect(result).toStrictEqual({
+            ...rawData,
+            ...{
+              sell: {
+                currentPrice: 200,
+                lastBuyPrice: 160,
+                processMessage:
+                  'All sell orders are executed. Delete last buy price.',
+                updatedAt: expect.any(Object)
+              }
+            }
+          });
         });
       });
     });

--- a/app/cronjob/trailingTrade/step/remove-last-buy-price.js
+++ b/app/cronjob/trailingTrade/step/remove-last-buy-price.js
@@ -288,30 +288,11 @@ const execute = async (logger, rawData) => {
     return data;
   }
 
-  // If there is open order for grid trade buy order, then do not process.
-  // const gridTradeLastBuyOrder = await getGridTradeLastOrder(
-  //   logger,
-  //   symbol,
-  //   'buy'
-  // );
-  // if (_.isEmpty(gridTradeLastBuyOrder) === false) {
-  //   logger.info(
-  //     'Do not process to remove last buy price because there is a grid trade last buy order to be confirmed.'
-  //   );
-  //   return data;
-  // }
-
   // If last buy price is null, undefined, 0, NaN or less than 0.
   if (!lastBuyPrice || lastBuyPrice <= 0) {
     logger.info('Do not process because last buy price does not exist.');
     return data;
   }
-
-  // If there is an open order, then do not process.
-  // if (_.isEmpty(openOrders) === false) {
-  //   logger.info('Do not remove last buy price in case the order is related.');
-  //   return data;
-  // }
 
   // If the action is disabled, then do not process.
   const checkDisable = await isActionDisabled(symbol);
@@ -319,6 +300,7 @@ const execute = async (logger, rawData) => {
     { tag: 'check-disable', checkDisable },
     'Checked whether symbol is disabled or not.'
   );
+
   if (checkDisable.isDisabled && checkDisable.canRemoveLastBuyPrice === false) {
     logger.info('Do not remove last buy price because action is disabled.');
     return data;

--- a/app/cronjob/trailingTrade/step/remove-last-buy-price.js
+++ b/app/cronjob/trailingTrade/step/remove-last-buy-price.js
@@ -11,9 +11,70 @@ const {
 } = require('../../trailingTradeHelper/common');
 const {
   archiveSymbolGridTrade,
-  deleteSymbolGridTrade
+  deleteSymbolGridTrade,
+  getSymbolGridTrade
 } = require('../../trailingTradeHelper/configuration');
 const { getGridTradeOrder } = require('../../trailingTradeHelper/order');
+
+/**
+ * Check if base quantity is less than minimum quantity
+ *
+ * @param {*} param0
+ * @returns
+ */
+const isLessThanMinimumQuantity = ({ baseAssetQuantity, minQty }) =>
+  baseAssetQuantity <= parseFloat(minQty);
+
+/**
+ * Check if remained amount is less than last buy price remove threshold
+ *
+ * @param {*} param0
+ * @returns
+ */
+const isLessThanLastBuyPriceRemoveThreshold = ({
+  baseAssetQuantity,
+  currentPrice,
+  lastBuyPriceRemoveThreshold
+}) => baseAssetQuantity * currentPrice < lastBuyPriceRemoveThreshold;
+
+/**
+ * Check if sell order is completed
+ *
+ * @param {*} logger
+ * @param {*} symbol
+ * @returns
+ */
+const isSellOrderCompleted = async (logger, symbol) => {
+  // Get trade order
+  const gridTrade = await getSymbolGridTrade(logger, symbol);
+  if (_.isEmpty(gridTrade)) {
+    logger.info('There is no grid trade for the symbol. Do not process.');
+    return false;
+  }
+
+  const { sell } = gridTrade;
+  if (_.isEmpty(sell)) {
+    logger.info(
+      'There is no sell order in the grid trade for the symbol. Do not process.'
+    );
+    return false;
+  }
+
+  const allExecuted = _.every(sell, s => s.executed);
+  if (allExecuted) {
+    logger.info(
+      { sell, allExecuted },
+      'All sell orders are executed. Delete last buy price.'
+    );
+    return true;
+  }
+
+  logger.info(
+    { sell, allExecuted },
+    'There is unexecuted sell order. Do not process.'
+  );
+  return false;
+};
 
 /**
  * Set message and return data
@@ -144,6 +205,37 @@ const removeLastBuyPrice = async (
 };
 
 /**
+ * Process removing last buy price
+ *
+ * @param {*} logger
+ * @param {*} symbol
+ * @param {*} data
+ * @param {*} processMessage
+ * @param {*} extraMessages
+ * @returns
+ */
+const processRemoveLastBuyPrice = async (
+  logger,
+  symbol,
+  data,
+  processMessage,
+  extraMessages
+) => {
+  const refreshedOpenOrders = await getAndCacheOpenOrdersForSymbol(
+    logger,
+    symbol
+  );
+  if (refreshedOpenOrders.length > 0) {
+    logger.info('Do not remove last buy price. Found open orders.');
+    return data;
+  }
+
+  await removeLastBuyPrice(logger, symbol, data, processMessage, extraMessages);
+
+  return setMessage(logger, data, processMessage);
+};
+
+/**
  * Remove last buy price if applicable
  *
  * @param {*} logger
@@ -184,6 +276,7 @@ const execute = async (logger, rawData) => {
     return data;
   }
 
+  // If there is open order for grid trade buy order, then do not process.
   const gridTradeLastBuyOrder = await getGridTradeLastOrder(
     logger,
     symbol,
@@ -196,6 +289,7 @@ const execute = async (logger, rawData) => {
     return data;
   }
 
+  // If there is open order for grid trade sell order, then do not process.
   const gridTradeLastSellOrder = await getGridTradeLastOrder(
     logger,
     symbol,
@@ -208,17 +302,19 @@ const execute = async (logger, rawData) => {
     return data;
   }
 
-  // If last buy price is null, undefined, 0, NaN or less than 0
+  // If last buy price is null, undefined, 0, NaN or less than 0.
   if (!lastBuyPrice || lastBuyPrice <= 0) {
     logger.info('Do not process because last buy price does not exist.');
     return data;
   }
 
+  // If there is an open order, then do not process.
   if (_.isEmpty(openOrders) === false) {
     logger.info('Do not remove last buy price in case the order is related.');
     return data;
   }
 
+  // If the action is disabled, then do not process.
   const checkDisable = await isActionDisabled(symbol);
   logger.info(
     { tag: 'check-disable', checkDisable },
@@ -229,7 +325,6 @@ const execute = async (logger, rawData) => {
     return data;
   }
 
-  // Check one last time for open orders to make sure.
   const lotPrecision = parseFloat(stepSize) === 1 ? 0 : stepSize.indexOf(1) - 1;
 
   const totalBaseAssetBalance =
@@ -244,15 +339,7 @@ const execute = async (logger, rawData) => {
 
   let processMessage = '';
 
-  let refreshedOpenOrders = [];
-  if (baseAssetQuantity <= parseFloat(minQty)) {
-    // Final check for open orders
-    refreshedOpenOrders = await getAndCacheOpenOrdersForSymbol(logger, symbol);
-    if (refreshedOpenOrders.length > 0) {
-      logger.info('Do not remove last buy price. Found open orders.');
-      return data;
-    }
-
+  if (isLessThanMinimumQuantity({ baseAssetQuantity, minQty })) {
     processMessage = 'Balance is not enough to sell. Delete last buy price.';
 
     logger.error(
@@ -261,7 +348,7 @@ const execute = async (logger, rawData) => {
       processMessage
     );
 
-    await removeLastBuyPrice(logger, symbol, data, processMessage, {
+    return processRemoveLastBuyPrice(logger, symbol, data, processMessage, {
       lastBuyPrice,
       baseAssetQuantity,
       minQty,
@@ -270,32 +357,41 @@ const execute = async (logger, rawData) => {
       totalBaseAssetBalance,
       openOrders
     });
-
-    return setMessage(logger, data, processMessage);
   }
 
-  if (baseAssetQuantity * currentPrice < lastBuyPriceRemoveThreshold) {
-    // Final check for open orders
-    refreshedOpenOrders = await getAndCacheOpenOrdersForSymbol(logger, symbol);
-    if (refreshedOpenOrders.length > 0) {
-      logger.info('Do not remove last buy price. Found open orders.');
-      return data;
-    }
-
+  if (
+    isLessThanLastBuyPriceRemoveThreshold({
+      baseAssetQuantity,
+      currentPrice,
+      lastBuyPriceRemoveThreshold
+    })
+  ) {
     processMessage =
       'Balance is less than the last buy price remove threshold. Delete last buy price.';
 
     logger.error({ baseAssetQuantity }, processMessage);
 
-    await removeLastBuyPrice(logger, symbol, data, processMessage, {
+    return processRemoveLastBuyPrice(logger, symbol, data, processMessage, {
       lastBuyPrice,
       baseAssetQuantity,
       currentPrice,
       minNotional,
       openOrders
     });
+  }
 
-    return setMessage(logger, data, processMessage);
+  if (await isSellOrderCompleted(logger, symbol)) {
+    processMessage = 'All sell orders are executed. Delete last buy price.';
+
+    logger.error({ baseAssetQuantity }, processMessage);
+
+    return processRemoveLastBuyPrice(logger, symbol, data, processMessage, {
+      lastBuyPrice,
+      baseAssetQuantity,
+      currentPrice,
+      minNotional,
+      openOrders
+    });
   }
 
   return data;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In a very rare situation, there is a case that it does not archive the order even if all sell orders are executed.
i.e. 
- buy/sell orders are concurrently opened, 
- and then the sell order is executed, but the buy order is still opened. 
- then the `remove-last-buy-price` will not archive the order even after the sell order is executed. 

If all sell orders are executed, then there is no way to sell the remaining coins. 
So it should archive if all sell orders are executed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See description

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
