### PR TITLE
fix: remove last buy price not to check action buy-order-wait

### DIFF
--- a/app/cronjob/trailingTrade/step/remove-last-buy-price.js
+++ b/app/cronjob/trailingTrade/step/remove-last-buy-price.js
@@ -283,8 +283,10 @@ const execute = async (logger, rawData) => {
     return data;
   }
 
-  if (action !== 'not-determined') {
-    logger.info('Do not process to remove last buy price.');
+  if (['not-determined', 'buy-order-wait'].includes(action) === false) {
+    logger.info(
+      `Do not process to remove last buy price due to the ${action} action.`
+    );
     return data;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

When there is an open buy order after all sell orders are executed, then the `remove-last-buy-price` step is not executed because the action is `buy-order-wait`.

However, the step has been updated to archive the grid trade even if there is an open buy order.

This PR is to fix for processing the `remove-last-buy-price` even if the action is `buy-order-wait`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
