### PR TITLE
fix: sorting symbols when the field is null

### DIFF
--- a/app/cronjob/trailingTradeHelper/__tests__/common.test.js
+++ b/app/cronjob/trailingTradeHelper/__tests__/common.test.js
@@ -2855,7 +2855,7 @@ describe('common.js', () => {
             if: {
               $eq: ['$buy.difference', null]
             },
-            then: -999,
+            then: '$symbol',
             else: '$buy.difference'
           }
         }
@@ -2871,7 +2871,7 @@ describe('common.js', () => {
             if: {
               $eq: ['$buy.difference', null]
             },
-            then: 999,
+            then: '$symbol',
             else: '$buy.difference'
           }
         }
@@ -2887,7 +2887,7 @@ describe('common.js', () => {
             if: {
               $eq: ['$sell.currentProfitPercentage', null]
             },
-            then: 999,
+            then: '$symbol',
             else: '$sell.currentProfitPercentage'
           }
         }
@@ -2903,7 +2903,7 @@ describe('common.js', () => {
             if: {
               $eq: ['$sell.currentProfitPercentage', null]
             },
-            then: -999,
+            then: '$symbol',
             else: '$sell.currentProfitPercentage'
           }
         }

--- a/app/cronjob/trailingTradeHelper/common.js
+++ b/app/cronjob/trailingTradeHelper/common.js
@@ -966,7 +966,7 @@ const getCacheTrailingTradeSymbols = async (
         if: {
           $eq: ['$buy.difference', null]
         },
-        then: sortByDesc ? -999 : 999,
+        then: '$symbol',
         else: '$buy.difference'
       }
     };
@@ -978,7 +978,7 @@ const getCacheTrailingTradeSymbols = async (
         if: {
           $eq: ['$sell.currentProfitPercentage', null]
         },
-        then: sortByDesc ? -999 : 999,
+        then: '$symbol',
         else: '$sell.currentProfitPercentage'
       }
     };


### PR DESCRIPTION
## Description

This PR is going to fix the #491 issue.
We were assigning big numbers for nullable fields when sorting our monitoring symbols such as `Sell - Profit` which makes the sorting in Mongo DB unstable.
Based on that, we rely on `$symbol` field instead of big numbers when the fields are null to make the sorting functionality work as expected.

## Related Issue

#491 

## Motivation and Context
## How Has This Been Tested?

Tests have been written to verify that.

## Screenshots (if appropriate):

Refer to #491