### PR TITLE
fix: account balance calculation

### DIFF
--- a/app/cronjob/trailingTrade/step/__tests__/cancel-order.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/cancel-order.test.js
@@ -10,7 +10,7 @@ describe('cancel-order.js', () => {
 
   let mockGetAPILimit;
   let mockGetAndCacheOpenOrdersForSymbol;
-  let mockGetAccountInfo;
+  let mockGetAccountInfoFromAPI;
 
   let mockDeleteManualOrder;
 
@@ -29,7 +29,7 @@ describe('cancel-order.js', () => {
       binanceMock.client.cancelOrder = jest.fn().mockResolvedValue(true);
       mockGetAPILimit = jest.fn().mockReturnValue(10);
       mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-      mockGetAccountInfo = jest.fn().mockResolvedValue({
+      mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
         account: 'info'
       });
       PubSubMock.publish = jest.fn().mockResolvedValue(true);
@@ -46,7 +46,7 @@ describe('cancel-order.js', () => {
         jest.mock('../../../trailingTradeHelper/common', () => ({
           getAPILimit: mockGetAPILimit,
           getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol,
-          getAccountInfo: mockGetAccountInfo
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI
         }));
 
         const step = require('../cancel-order');
@@ -74,7 +74,7 @@ describe('cancel-order.js', () => {
         jest.mock('../../../trailingTradeHelper/common', () => ({
           getAPILimit: mockGetAPILimit,
           getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol,
-          getAccountInfo: mockGetAccountInfo
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI
         }));
 
         const step = require('../cancel-order');
@@ -114,7 +114,7 @@ describe('cancel-order.js', () => {
           jest.mock('../../../trailingTradeHelper/common', () => ({
             getAPILimit: mockGetAPILimit,
             getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol,
-            getAccountInfo: mockGetAccountInfo
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI
           }));
 
           const step = require('../cancel-order');
@@ -226,7 +226,7 @@ describe('cancel-order.js', () => {
           jest.mock('../../../trailingTradeHelper/common', () => ({
             getAPILimit: mockGetAPILimit,
             getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol,
-            getAccountInfo: mockGetAccountInfo
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI
           }));
 
           const step = require('../cancel-order');

--- a/app/cronjob/trailingTrade/step/__tests__/handle-open-orders.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/handle-open-orders.test.js
@@ -10,7 +10,7 @@ describe('handle-open-orders.js', () => {
 
   let mockCancelOrder;
   let mockRefreshOpenOrdersAndAccountInfo;
-  let mockUpdateAccountInfo;
+  let mockGetAccountInfoFromAPI;
   let mockSaveOverrideAction;
 
   let mockIsExceedingMaxOpenTrades;
@@ -34,7 +34,7 @@ describe('handle-open-orders.js', () => {
       mockCancelOrder = jest.fn().mockResolvedValue(true);
 
       mockSaveOverrideAction = jest.fn().mockResolvedValue(true);
-      mockUpdateAccountInfo = jest.fn().mockResolvedValue({
+      mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
         account: 'updated'
       });
 
@@ -44,7 +44,7 @@ describe('handle-open-orders.js', () => {
     describe('when symbol is locked', () => {
       beforeEach(async () => {
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          updateAccountInfo: mockUpdateAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           saveOverrideAction: mockSaveOverrideAction,
           isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
           cancelOrder: mockCancelOrder,
@@ -135,7 +135,7 @@ describe('handle-open-orders.js', () => {
     describe('when action is not not-determined', () => {
       beforeEach(async () => {
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          updateAccountInfo: mockUpdateAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           saveOverrideAction: mockSaveOverrideAction,
           isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
           cancelOrder: mockCancelOrder,
@@ -226,7 +226,7 @@ describe('handle-open-orders.js', () => {
     describe('when order is not STOP_LOSS_LIMIT', () => {
       beforeEach(async () => {
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          updateAccountInfo: mockUpdateAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           saveOverrideAction: mockSaveOverrideAction,
           isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
           cancelOrder: mockCancelOrder,
@@ -316,13 +316,13 @@ describe('handle-open-orders.js', () => {
 
     describe('when order is buy', () => {
       describe('when open trade limit is reached', () => {
-        describe('when cancelling order is failedd', () => {
+        describe('when cancelling order is failed', () => {
           beforeEach(async () => {
             mockIsExceedingMaxOpenTrades = jest.fn().mockResolvedValue(true);
             mockCancelOrder = jest.fn().mockResolvedValue(false);
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              updateAccountInfo: mockUpdateAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               saveOverrideAction: mockSaveOverrideAction,
               isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
               cancelOrder: mockCancelOrder,
@@ -409,13 +409,13 @@ describe('handle-open-orders.js', () => {
           });
         });
 
-        describe('when cancelling order is succeedd', () => {
+        describe('when cancelling order is succeeded', () => {
           beforeEach(async () => {
             mockIsExceedingMaxOpenTrades = jest.fn().mockResolvedValue(true);
             mockCancelOrder = jest.fn().mockResolvedValue(true);
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              updateAccountInfo: mockUpdateAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               saveOverrideAction: mockSaveOverrideAction,
               isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
               cancelOrder: mockCancelOrder,
@@ -478,18 +478,8 @@ describe('handle-open-orders.js', () => {
             expect(mockRefreshOpenOrdersAndAccountInfo).not.toHaveBeenCalled();
           });
 
-          it('triggers updateAccountInfo', () => {
-            expect(mockUpdateAccountInfo).toHaveBeenCalledWith(
-              loggerMock,
-              [
-                {
-                  asset: 'USDT',
-                  free: 50.0179958,
-                  locked: 0
-                }
-              ],
-              expect.any(String)
-            );
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalledWith(loggerMock);
           });
 
           it('returns expected value', () => {
@@ -536,7 +526,7 @@ describe('handle-open-orders.js', () => {
             mockCancelOrder = jest.fn().mockResolvedValue(false);
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              updateAccountInfo: mockUpdateAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               saveOverrideAction: mockSaveOverrideAction,
               isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
               cancelOrder: mockCancelOrder,
@@ -629,8 +619,8 @@ describe('handle-open-orders.js', () => {
             );
           });
 
-          it('does not trigger updateAccountInfo', () => {
-            expect(mockUpdateAccountInfo).not.toHaveBeenCalled();
+          it('does not trigger getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
           });
 
           it('returns expected value', () => {
@@ -668,7 +658,7 @@ describe('handle-open-orders.js', () => {
         describe('when cancelling order is succeed', () => {
           beforeEach(async () => {
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              updateAccountInfo: mockUpdateAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               saveOverrideAction: mockSaveOverrideAction,
               isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
               cancelOrder: mockCancelOrder,
@@ -743,18 +733,8 @@ describe('handle-open-orders.js', () => {
             expect(mockRefreshOpenOrdersAndAccountInfo).not.toHaveBeenCalled();
           });
 
-          it('triggers updateAccountInfo', () => {
-            expect(mockUpdateAccountInfo).toHaveBeenCalledWith(
-              loggerMock,
-              [
-                {
-                  asset: 'USDT',
-                  free: 50.0179958,
-                  locked: 0
-                }
-              ],
-              expect.any(String)
-            );
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalledWith(loggerMock);
           });
 
           it('returns expected value', () => {
@@ -795,7 +775,7 @@ describe('handle-open-orders.js', () => {
           mockIsExceedingMaxOpenTrades = jest.fn().mockResolvedValue(false);
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            updateAccountInfo: mockUpdateAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             saveOverrideAction: mockSaveOverrideAction,
             isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
             cancelOrder: mockCancelOrder,
@@ -897,7 +877,7 @@ describe('handle-open-orders.js', () => {
             mockCancelOrder = jest.fn().mockResolvedValue(false);
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              updateAccountInfo: mockUpdateAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               saveOverrideAction: mockSaveOverrideAction,
               isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
               cancelOrder: mockCancelOrder,
@@ -1009,7 +989,7 @@ describe('handle-open-orders.js', () => {
         describe('when cancel order is succeed', () => {
           beforeEach(async () => {
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              updateAccountInfo: mockUpdateAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               saveOverrideAction: mockSaveOverrideAction,
               isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
               cancelOrder: mockCancelOrder,
@@ -1085,18 +1065,8 @@ describe('handle-open-orders.js', () => {
             expect(mockRefreshOpenOrdersAndAccountInfo).not.toHaveBeenCalled();
           });
 
-          it('triggers updateAccountInfo', () => {
-            expect(mockUpdateAccountInfo).toHaveBeenCalledWith(
-              loggerMock,
-              [
-                {
-                  asset: 'BTC',
-                  free: 0.00001,
-                  locked: 0
-                }
-              ],
-              expect.any(String)
-            );
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalledWith(loggerMock);
           });
 
           it('returns expected value', () => {

--- a/app/cronjob/trailingTrade/step/__tests__/place-buy-order.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/place-buy-order.test.js
@@ -11,7 +11,7 @@ describe('place-buy-order.js', () => {
   let slackMock;
   let loggerMock;
 
-  let mockUpdateAccountInfo;
+  let mockGetAccountInfoFromAPI;
   let mockIsExceedAPILimit;
   let mockGetAPILimit;
   let mockSaveOrderStats;
@@ -42,14 +42,14 @@ describe('place-buy-order.js', () => {
       mockSaveOrderStats = jest.fn().mockResolvedValue(true);
       mockSaveOverrideAction = jest.fn().mockResolvedValue(true);
 
-      mockUpdateAccountInfo = jest.fn().mockResolvedValue({
+      mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
         account: 'info'
       });
 
       mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
 
       jest.mock('../../../trailingTradeHelper/common', () => ({
-        updateAccountInfo: mockUpdateAccountInfo,
+        getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
         isExceedAPILimit: mockIsExceedAPILimit,
         getAPILimit: mockGetAPILimit,
         saveOrderStats: mockSaveOrderStats,
@@ -120,8 +120,8 @@ describe('place-buy-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger updateAccountInfo', () => {
-        expect(mockUpdateAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('does not trigger saveGridTradeOrder', () => {
@@ -791,7 +791,7 @@ describe('place-buy-order.js', () => {
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              updateAccountInfo: mockUpdateAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               getAPILimit: mockGetAPILimit,
               saveOrderStats: mockSaveOrderStats,
@@ -842,11 +842,9 @@ describe('place-buy-order.js', () => {
               );
             });
 
-            it('triggers updateAccountInfo', () => {
-              expect(mockUpdateAccountInfo).toHaveBeenCalledWith(
-                loggerMock,
-                [{ asset: 'USDT', free: 52.472, locked: 48.528 }],
-                expect.any(String)
+            it('triggers getAccountInfoFromAPI', () => {
+              expect(mockGetAccountInfoFromAPI).toHaveBeenCalledWith(
+                loggerMock
               );
             });
 
@@ -1574,7 +1572,7 @@ describe('place-buy-order.js', () => {
         mockIsExceedAPILimit = jest.fn().mockReturnValue(true);
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          updateAccountInfo: mockUpdateAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           getAPILimit: mockGetAPILimit,
           saveOrderStats: mockSaveOrderStats,
@@ -1631,7 +1629,7 @@ describe('place-buy-order.js', () => {
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              updateAccountInfo: mockUpdateAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               getAPILimit: mockGetAPILimit,
               saveOrderStats: mockSaveOrderStats,
@@ -2377,7 +2375,7 @@ describe('place-buy-order.js', () => {
                 .mockResolvedValue(t.binanceMockClientOrderResult);
 
               jest.mock('../../../trailingTradeHelper/common', () => ({
-                updateAccountInfo: mockUpdateAccountInfo,
+                getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
                 isExceedAPILimit: mockIsExceedAPILimit,
                 getAPILimit: mockGetAPILimit,
                 saveOrderStats: mockSaveOrderStats,
@@ -2414,11 +2412,9 @@ describe('place-buy-order.js', () => {
               );
             });
 
-            it('triggers updateAccountInfo', () => {
-              expect(mockUpdateAccountInfo).toHaveBeenCalledWith(
-                loggerMock,
-                t.expectedBalances,
-                expect.any(String)
+            it('triggers getAccountInfoFromAPI', () => {
+              expect(mockGetAccountInfoFromAPI).toHaveBeenCalledWith(
+                loggerMock
               );
             });
 
@@ -2982,7 +2978,7 @@ describe('place-buy-order.js', () => {
                 .mockResolvedValue(t.binanceMockClientOrderResult);
 
               jest.mock('../../../trailingTradeHelper/common', () => ({
-                updateAccountInfo: mockUpdateAccountInfo,
+                getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
                 isExceedAPILimit: mockIsExceedAPILimit,
                 getAPILimit: mockGetAPILimit,
                 saveOrderStats: mockSaveOrderStats,
@@ -3019,11 +3015,9 @@ describe('place-buy-order.js', () => {
               );
             });
 
-            it('triggers updateAccountInfo', () => {
-              expect(mockUpdateAccountInfo).toHaveBeenCalledWith(
-                loggerMock,
-                t.expectedBalances,
-                expect.any(String)
+            it('triggers getAccountInfoFromAPI', () => {
+              expect(mockGetAccountInfoFromAPI).toHaveBeenCalledWith(
+                loggerMock
               );
             });
 
@@ -3034,7 +3028,7 @@ describe('place-buy-order.js', () => {
               );
             });
 
-            it('retruns expected value', () => {
+            it('returns the expected value', () => {
               expect(result).toMatchObject(t.expected);
             });
           });
@@ -3054,7 +3048,7 @@ describe('place-buy-order.js', () => {
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            updateAccountInfo: mockUpdateAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             getAPILimit: mockGetAPILimit,
             saveOrderStats: mockSaveOrderStats,
@@ -3151,18 +3145,8 @@ describe('place-buy-order.js', () => {
           );
         });
 
-        it('triggers updateAccountInfo', () => {
-          expect(mockUpdateAccountInfo).toHaveBeenCalledWith(
-            loggerMock,
-            [
-              {
-                asset: 'USDT',
-                free: 52.472,
-                locked: 48.528
-              }
-            ],
-            expect.any(String)
-          );
+        it('triggers getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).toHaveBeenCalledWith(loggerMock);
         });
 
         it('triggers saveOrderStats', () => {

--- a/app/cronjob/trailingTrade/step/__tests__/place-manual-trade.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/place-manual-trade.test.js
@@ -8,7 +8,7 @@ describe('place-manual-trade.js', () => {
   let slackMock;
   let loggerMock;
 
-  let mockGetAccountInfo;
+  let mockGetAccountInfoFromAPI;
   let mockGetAPILimit;
   let mockGetAndCacheOpenOrdersForSymbol;
 
@@ -32,7 +32,7 @@ describe('place-manual-trade.js', () => {
     slackMock.sendMessage = jest.fn().mockResolvedValue(true);
     binanceMock.client.order = jest.fn().mockResolvedValue(true);
 
-    mockGetAccountInfo = jest.fn().mockResolvedValue({
+    mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
       account: 'info'
     });
 
@@ -45,7 +45,7 @@ describe('place-manual-trade.js', () => {
   describe('when symbol is locked', () => {
     beforeEach(async () => {
       jest.mock('../../../trailingTradeHelper/common', () => ({
-        getAccountInfo: mockGetAccountInfo,
+        getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
         getAPILimit: mockGetAPILimit,
         getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
       }));
@@ -97,7 +97,7 @@ describe('place-manual-trade.js', () => {
   describe('when action is not manual-trade', () => {
     beforeEach(async () => {
       jest.mock('../../../trailingTradeHelper/common', () => ({
-        getAccountInfo: mockGetAccountInfo,
+        getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
         getAPILimit: mockGetAPILimit,
         getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
       }));
@@ -770,7 +770,7 @@ describe('place-manual-trade.js', () => {
           );
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           getAPILimit: mockGetAPILimit,
           getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
         }));
@@ -832,7 +832,7 @@ describe('place-manual-trade.js', () => {
   describe('when unknown order side/type is provided', () => {
     beforeEach(async () => {
       jest.mock('../../../trailingTradeHelper/common', () => ({
-        getAccountInfo: mockGetAccountInfo,
+        getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
         getAPILimit: mockGetAPILimit,
         getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
       }));

--- a/app/cronjob/trailingTrade/step/__tests__/place-sell-order.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/place-sell-order.test.js
@@ -8,7 +8,7 @@ describe('place-sell-order.js', () => {
   let slackMock;
   let loggerMock;
 
-  let mockGetAccountInfo;
+  let mockGetAccountInfoFromAPI;
   let mockIsExceedAPILimit;
   let mockGetAPILimit;
   let mockGetAndCacheOpenOrdersForSymbol;
@@ -40,12 +40,12 @@ describe('place-sell-order.js', () => {
 
     describe('when symbol is locked', () => {
       beforeEach(async () => {
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           getAPILimit: mockGetAPILimit,
           getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -102,8 +102,8 @@ describe('place-sell-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('retruns expected value', () => {
@@ -113,12 +113,12 @@ describe('place-sell-order.js', () => {
 
     describe('when action is not sell', () => {
       beforeEach(async () => {
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           getAPILimit: mockGetAPILimit,
           getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -175,8 +175,8 @@ describe('place-sell-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('retruns expected value', () => {
@@ -186,12 +186,12 @@ describe('place-sell-order.js', () => {
 
     describe('when open orders exist', () => {
       beforeEach(async () => {
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           getAPILimit: mockGetAPILimit,
           getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -260,8 +260,8 @@ describe('place-sell-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('retruns expected value', () => {
@@ -291,12 +291,12 @@ describe('place-sell-order.js', () => {
 
     describe('when current grid trade is null', () => {
       beforeEach(async () => {
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           getAPILimit: mockGetAPILimit,
           getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -349,8 +349,8 @@ describe('place-sell-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('retruns expected value', () => {
@@ -372,12 +372,12 @@ describe('place-sell-order.js', () => {
     describe('when quantity is not enough', () => {
       describe('BTCUPUSDT', () => {
         beforeEach(async () => {
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             getAPILimit: mockGetAPILimit,
             getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -437,8 +437,8 @@ describe('place-sell-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveGridTradeOrder', () => {
@@ -464,12 +464,12 @@ describe('place-sell-order.js', () => {
 
       describe('ALPHABTC', () => {
         beforeEach(async () => {
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             getAPILimit: mockGetAPILimit,
             getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -529,8 +529,8 @@ describe('place-sell-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveGridTradeOrder', () => {
@@ -556,12 +556,12 @@ describe('place-sell-order.js', () => {
 
       describe('BTCBRL', () => {
         beforeEach(async () => {
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             getAPILimit: mockGetAPILimit,
             getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -621,8 +621,8 @@ describe('place-sell-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveGridTradeOrder', () => {
@@ -650,12 +650,12 @@ describe('place-sell-order.js', () => {
     describe('when order amount is less than minimum notional', () => {
       describe('BTCUPUSDT', () => {
         beforeEach(async () => {
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             getAPILimit: mockGetAPILimit,
             getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -715,8 +715,8 @@ describe('place-sell-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveGridTradeOrder', () => {
@@ -742,12 +742,12 @@ describe('place-sell-order.js', () => {
 
       describe('ALPHBTC', () => {
         beforeEach(async () => {
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             getAPILimit: mockGetAPILimit,
             getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -807,8 +807,8 @@ describe('place-sell-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveGridTradeOrder', () => {
@@ -834,12 +834,12 @@ describe('place-sell-order.js', () => {
 
       describe('BTCBRL', () => {
         beforeEach(async () => {
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             getAPILimit: mockGetAPILimit,
             getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -899,8 +899,8 @@ describe('place-sell-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveGridTradeOrder', () => {
@@ -927,12 +927,12 @@ describe('place-sell-order.js', () => {
 
     describe('when trading is disabled', () => {
       beforeEach(async () => {
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           getAPILimit: mockGetAPILimit,
           getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -992,8 +992,8 @@ describe('place-sell-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('does not trigger saveGridTradeOrder', () => {
@@ -1020,12 +1020,12 @@ describe('place-sell-order.js', () => {
       beforeEach(async () => {
         mockIsExceedAPILimit = jest.fn().mockReturnValue(true);
 
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           getAPILimit: mockGetAPILimit,
           getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -1085,8 +1085,8 @@ describe('place-sell-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('does not trigger saveGridTradeOrder', () => {
@@ -1133,12 +1133,12 @@ describe('place-sell-order.js', () => {
               transactTime: 1626946722520
             });
 
-            mockGetAccountInfo = jest.fn().mockResolvedValue({
+            mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
               account: 'info'
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              getAccountInfo: mockGetAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               getAPILimit: mockGetAPILimit,
               getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -1224,8 +1224,8 @@ describe('place-sell-order.js', () => {
             );
           });
 
-          it('triggers getAccountInfo', () => {
-            expect(mockGetAccountInfo).toHaveBeenCalled();
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
           });
 
           it('retruns expected value', () => {
@@ -1289,12 +1289,12 @@ describe('place-sell-order.js', () => {
               transactTime: 1626946722520
             });
 
-            mockGetAccountInfo = jest.fn().mockResolvedValue({
+            mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
               account: 'info'
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              getAccountInfo: mockGetAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               getAPILimit: mockGetAPILimit,
               getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -1380,8 +1380,8 @@ describe('place-sell-order.js', () => {
             );
           });
 
-          it('triggers getAccountInfo', () => {
-            expect(mockGetAccountInfo).toHaveBeenCalled();
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
           });
 
           it('retruns expected value', () => {
@@ -1445,12 +1445,12 @@ describe('place-sell-order.js', () => {
               transactTime: 1626946722520
             });
 
-            mockGetAccountInfo = jest.fn().mockResolvedValue({
+            mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
               account: 'info'
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              getAccountInfo: mockGetAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               getAPILimit: mockGetAPILimit,
               getAndCacheOpenOrdersForSymbol: mockGetAndCacheOpenOrdersForSymbol
@@ -1536,8 +1536,8 @@ describe('place-sell-order.js', () => {
             );
           });
 
-          it('triggers getAccountInfo', () => {
-            expect(mockGetAccountInfo).toHaveBeenCalled();
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
           });
 
           it('retruns expected value', () => {
@@ -1604,12 +1604,12 @@ describe('place-sell-order.js', () => {
                 transactTime: 1626946722520
               });
 
-              mockGetAccountInfo = jest.fn().mockResolvedValue({
+              mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
                 account: 'info'
               });
 
               jest.mock('../../../trailingTradeHelper/common', () => ({
-                getAccountInfo: mockGetAccountInfo,
+                getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
                 isExceedAPILimit: mockIsExceedAPILimit,
                 getAPILimit: mockGetAPILimit,
                 getAndCacheOpenOrdersForSymbol:
@@ -1696,8 +1696,8 @@ describe('place-sell-order.js', () => {
               );
             });
 
-            it('triggers getAccountInfo', () => {
-              expect(mockGetAccountInfo).toHaveBeenCalled();
+            it('triggers getAccountInfoFromAPI', () => {
+              expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
             });
 
             it('retruns expected value', () => {
@@ -1761,12 +1761,12 @@ describe('place-sell-order.js', () => {
                 transactTime: 1626946722520
               });
 
-              mockGetAccountInfo = jest.fn().mockResolvedValue({
+              mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
                 account: 'info'
               });
 
               jest.mock('../../../trailingTradeHelper/common', () => ({
-                getAccountInfo: mockGetAccountInfo,
+                getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
                 isExceedAPILimit: mockIsExceedAPILimit,
                 getAPILimit: mockGetAPILimit,
                 getAndCacheOpenOrdersForSymbol:
@@ -1853,8 +1853,8 @@ describe('place-sell-order.js', () => {
               );
             });
 
-            it('triggers getAccountInfo', () => {
-              expect(mockGetAccountInfo).toHaveBeenCalled();
+            it('triggers getAccountInfoFromAPI', () => {
+              expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
             });
 
             it('retruns expected value', () => {
@@ -1918,12 +1918,12 @@ describe('place-sell-order.js', () => {
                 transactTime: 1626946722520
               });
 
-              mockGetAccountInfo = jest.fn().mockResolvedValue({
+              mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
                 account: 'info'
               });
 
               jest.mock('../../../trailingTradeHelper/common', () => ({
-                getAccountInfo: mockGetAccountInfo,
+                getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
                 isExceedAPILimit: mockIsExceedAPILimit,
                 getAPILimit: mockGetAPILimit,
                 getAndCacheOpenOrdersForSymbol:
@@ -2010,8 +2010,8 @@ describe('place-sell-order.js', () => {
               );
             });
 
-            it('triggers getAccountInfo', () => {
-              expect(mockGetAccountInfo).toHaveBeenCalled();
+            it('triggers getAccountInfoFromAPI', () => {
+              expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
             });
 
             it('retruns expected value', () => {
@@ -2077,12 +2077,12 @@ describe('place-sell-order.js', () => {
                 transactTime: 1626946722520
               });
 
-              mockGetAccountInfo = jest.fn().mockResolvedValue({
+              mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
                 account: 'info'
               });
 
               jest.mock('../../../trailingTradeHelper/common', () => ({
-                getAccountInfo: mockGetAccountInfo,
+                getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
                 isExceedAPILimit: mockIsExceedAPILimit,
                 getAPILimit: mockGetAPILimit,
                 getAndCacheOpenOrdersForSymbol:
@@ -2169,8 +2169,8 @@ describe('place-sell-order.js', () => {
               );
             });
 
-            it('triggers getAccountInfo', () => {
-              expect(mockGetAccountInfo).toHaveBeenCalled();
+            it('triggers getAccountInfoFromAPI', () => {
+              expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
             });
 
             it('retruns expected value', () => {
@@ -2234,12 +2234,12 @@ describe('place-sell-order.js', () => {
                 transactTime: 1626946722520
               });
 
-              mockGetAccountInfo = jest.fn().mockResolvedValue({
+              mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
                 account: 'info'
               });
 
               jest.mock('../../../trailingTradeHelper/common', () => ({
-                getAccountInfo: mockGetAccountInfo,
+                getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
                 isExceedAPILimit: mockIsExceedAPILimit,
                 getAPILimit: mockGetAPILimit,
                 getAndCacheOpenOrdersForSymbol:
@@ -2326,8 +2326,8 @@ describe('place-sell-order.js', () => {
               );
             });
 
-            it('triggers getAccountInfo', () => {
-              expect(mockGetAccountInfo).toHaveBeenCalled();
+            it('triggers getAccountInfoFromAPI', () => {
+              expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
             });
 
             it('retruns expected value', () => {
@@ -2391,12 +2391,12 @@ describe('place-sell-order.js', () => {
                 transactTime: 1626946722520
               });
 
-              mockGetAccountInfo = jest.fn().mockResolvedValue({
+              mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
                 account: 'info'
               });
 
               jest.mock('../../../trailingTradeHelper/common', () => ({
-                getAccountInfo: mockGetAccountInfo,
+                getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
                 isExceedAPILimit: mockIsExceedAPILimit,
                 getAPILimit: mockGetAPILimit,
                 getAndCacheOpenOrdersForSymbol:
@@ -2483,8 +2483,8 @@ describe('place-sell-order.js', () => {
               );
             });
 
-            it('triggers getAccountInfo', () => {
-              expect(mockGetAccountInfo).toHaveBeenCalled();
+            it('triggers getAccountInfoFromAPI', () => {
+              expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
             });
 
             it('retruns expected value', () => {
@@ -2548,12 +2548,12 @@ describe('place-sell-order.js', () => {
                 transactTime: 1626946722520
               });
 
-              mockGetAccountInfo = jest.fn().mockResolvedValue({
+              mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
                 account: 'info'
               });
 
               jest.mock('../../../trailingTradeHelper/common', () => ({
-                getAccountInfo: mockGetAccountInfo,
+                getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
                 isExceedAPILimit: mockIsExceedAPILimit,
                 getAPILimit: mockGetAPILimit,
                 getAndCacheOpenOrdersForSymbol:
@@ -2640,8 +2640,8 @@ describe('place-sell-order.js', () => {
               );
             });
 
-            it('triggers getAccountInfo', () => {
-              expect(mockGetAccountInfo).toHaveBeenCalled();
+            it('triggers getAccountInfoFromAPI', () => {
+              expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
             });
 
             it('retruns expected value', () => {

--- a/app/cronjob/trailingTrade/step/__tests__/place-sell-stop-loss-order.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/place-sell-stop-loss-order.test.js
@@ -8,7 +8,7 @@ describe('place-sell-stop-loss-order.js', () => {
   let slackMock;
   let loggerMock;
 
-  let mockGetAccountInfo;
+  let mockGetAccountInfoFromAPI;
   let mockIsExceedAPILimit;
   let mockDisableAction;
   let mockGetAPILimit;
@@ -42,12 +42,12 @@ describe('place-sell-stop-loss-order.js', () => {
     describe('when symbol is locked', () => {
       beforeEach(async () => {
         mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           disableAction: mockDisableAction,
           getAPILimit: mockGetAPILimit,
@@ -100,8 +100,8 @@ describe('place-sell-stop-loss-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('does not trigger saveSymbolGridTrade', () => {
@@ -116,12 +116,12 @@ describe('place-sell-stop-loss-order.js', () => {
     describe('when action is not sell-stop-loss', () => {
       beforeEach(async () => {
         mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           disableAction: mockDisableAction,
           getAPILimit: mockGetAPILimit,
@@ -174,8 +174,8 @@ describe('place-sell-stop-loss-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('does not trigger saveSymbolGridTrade', () => {
@@ -190,12 +190,12 @@ describe('place-sell-stop-loss-order.js', () => {
     describe('when open orders exist', () => {
       beforeEach(async () => {
         mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           disableAction: mockDisableAction,
           getAPILimit: mockGetAPILimit,
@@ -260,8 +260,8 @@ describe('place-sell-stop-loss-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('does not trigger saveSymbolGridTrade', () => {
@@ -297,12 +297,12 @@ describe('place-sell-stop-loss-order.js', () => {
       describe('BTCUPUSDT', () => {
         beforeEach(async () => {
           mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             disableAction: mockDisableAction,
             getAPILimit: mockGetAPILimit,
@@ -358,8 +358,8 @@ describe('place-sell-stop-loss-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveSymbolGridTrade', () => {
@@ -386,12 +386,12 @@ describe('place-sell-stop-loss-order.js', () => {
       describe('ALPHABTC', () => {
         beforeEach(async () => {
           mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             disableAction: mockDisableAction,
             getAPILimit: mockGetAPILimit,
@@ -447,8 +447,8 @@ describe('place-sell-stop-loss-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveSymbolGridTrade', () => {
@@ -475,12 +475,12 @@ describe('place-sell-stop-loss-order.js', () => {
       describe('BTCBRL', () => {
         beforeEach(async () => {
           mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             disableAction: mockDisableAction,
             getAPILimit: mockGetAPILimit,
@@ -536,8 +536,8 @@ describe('place-sell-stop-loss-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveSymbolGridTrade', () => {
@@ -566,12 +566,12 @@ describe('place-sell-stop-loss-order.js', () => {
       describe('BTCUPUSDT', () => {
         beforeEach(async () => {
           mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             disableAction: mockDisableAction,
             getAPILimit: mockGetAPILimit,
@@ -627,8 +627,8 @@ describe('place-sell-stop-loss-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveSymbolGridTrade', () => {
@@ -654,12 +654,12 @@ describe('place-sell-stop-loss-order.js', () => {
       describe('ALPHABTC', () => {
         beforeEach(async () => {
           mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             disableAction: mockDisableAction,
             getAPILimit: mockGetAPILimit,
@@ -715,8 +715,8 @@ describe('place-sell-stop-loss-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveSymbolGridTrade', () => {
@@ -742,12 +742,12 @@ describe('place-sell-stop-loss-order.js', () => {
       describe('BTCBRL', () => {
         beforeEach(async () => {
           mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-          mockGetAccountInfo = jest.fn().mockResolvedValue({
+          mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
             account: 'info'
           });
 
           jest.mock('../../../trailingTradeHelper/common', () => ({
-            getAccountInfo: mockGetAccountInfo,
+            getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
             isExceedAPILimit: mockIsExceedAPILimit,
             disableAction: mockDisableAction,
             getAPILimit: mockGetAPILimit,
@@ -803,8 +803,8 @@ describe('place-sell-stop-loss-order.js', () => {
           expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
         });
 
-        it('does not trigger getAccountInfo', () => {
-          expect(mockGetAccountInfo).not.toHaveBeenCalled();
+        it('does not trigger getAccountInfoFromAPI', () => {
+          expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
         });
 
         it('does not trigger saveSymbolGridTrade', () => {
@@ -831,12 +831,12 @@ describe('place-sell-stop-loss-order.js', () => {
     describe('when trading is disabled', () => {
       beforeEach(async () => {
         mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           disableAction: mockDisableAction,
           getAPILimit: mockGetAPILimit,
@@ -892,8 +892,8 @@ describe('place-sell-stop-loss-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('does not trigger saveSymbolGridTrade', () => {
@@ -921,12 +921,12 @@ describe('place-sell-stop-loss-order.js', () => {
         mockIsExceedAPILimit = jest.fn().mockReturnValue(true);
 
         mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           disableAction: mockDisableAction,
           getAPILimit: mockGetAPILimit,
@@ -982,8 +982,8 @@ describe('place-sell-stop-loss-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('does not trigger saveSymbolGridTrade', () => {
@@ -1009,12 +1009,12 @@ describe('place-sell-stop-loss-order.js', () => {
     describe('when stop loss order type is not market', () => {
       beforeEach(async () => {
         mockGetAndCacheOpenOrdersForSymbol = jest.fn().mockResolvedValue([]);
-        mockGetAccountInfo = jest.fn().mockResolvedValue({
+        mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
           account: 'info'
         });
 
         jest.mock('../../../trailingTradeHelper/common', () => ({
-          getAccountInfo: mockGetAccountInfo,
+          getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
           isExceedAPILimit: mockIsExceedAPILimit,
           disableAction: mockDisableAction,
           getAPILimit: mockGetAPILimit,
@@ -1070,8 +1070,8 @@ describe('place-sell-stop-loss-order.js', () => {
         expect(mockGetAndCacheOpenOrdersForSymbol).not.toHaveBeenCalled();
       });
 
-      it('does not trigger getAccountInfo', () => {
-        expect(mockGetAccountInfo).not.toHaveBeenCalled();
+      it('does not trigger getAccountInfoFromAPI', () => {
+        expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
       });
 
       it('does not trigger saveSymbolGridTrade', () => {
@@ -1107,7 +1107,7 @@ describe('place-sell-stop-loss-order.js', () => {
                 type: 'MARKET'
               }
             ]);
-            mockGetAccountInfo = jest.fn().mockResolvedValue({
+            mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
               account: 'info'
             });
 
@@ -1120,7 +1120,7 @@ describe('place-sell-stop-loss-order.js', () => {
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              getAccountInfo: mockGetAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               disableAction: mockDisableAction,
               getAPILimit: mockGetAPILimit,
@@ -1217,8 +1217,8 @@ describe('place-sell-stop-loss-order.js', () => {
             );
           });
 
-          it('triggers getAccountInfo', () => {
-            expect(mockGetAccountInfo).toHaveBeenCalled();
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
           });
 
           it('triggers saveSymbolGridTrade', () => {
@@ -1299,7 +1299,7 @@ describe('place-sell-stop-loss-order.js', () => {
                 type: 'MARKET'
               }
             ]);
-            mockGetAccountInfo = jest.fn().mockResolvedValue({
+            mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
               account: 'info'
             });
 
@@ -1312,7 +1312,7 @@ describe('place-sell-stop-loss-order.js', () => {
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              getAccountInfo: mockGetAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               disableAction: mockDisableAction,
               getAPILimit: mockGetAPILimit,
@@ -1416,8 +1416,8 @@ describe('place-sell-stop-loss-order.js', () => {
             );
           });
 
-          it('triggers getAccountInfo', () => {
-            expect(mockGetAccountInfo).toHaveBeenCalled();
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
           });
 
           it('triggers saveSymbolGridTrade', () => {
@@ -1505,7 +1505,7 @@ describe('place-sell-stop-loss-order.js', () => {
                 type: 'MARKET'
               }
             ]);
-            mockGetAccountInfo = jest.fn().mockResolvedValue({
+            mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
               account: 'info'
             });
 
@@ -1518,7 +1518,7 @@ describe('place-sell-stop-loss-order.js', () => {
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              getAccountInfo: mockGetAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               disableAction: mockDisableAction,
               getAPILimit: mockGetAPILimit,
@@ -1622,8 +1622,8 @@ describe('place-sell-stop-loss-order.js', () => {
             );
           });
 
-          it('triggers getAccountInfo', () => {
-            expect(mockGetAccountInfo).toHaveBeenCalled();
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
           });
 
           it('triggers saveSymbolGridTrade', () => {
@@ -1713,7 +1713,7 @@ describe('place-sell-stop-loss-order.js', () => {
                 type: 'MARKET'
               }
             ]);
-            mockGetAccountInfo = jest.fn().mockResolvedValue({
+            mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
               account: 'info'
             });
 
@@ -1726,7 +1726,7 @@ describe('place-sell-stop-loss-order.js', () => {
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              getAccountInfo: mockGetAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               disableAction: mockDisableAction,
               getAPILimit: mockGetAPILimit,
@@ -1820,8 +1820,8 @@ describe('place-sell-stop-loss-order.js', () => {
             );
           });
 
-          it('triggers getAccountInfo', () => {
-            expect(mockGetAccountInfo).toHaveBeenCalled();
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
           });
 
           it('does not trigger saveSymbolGridTrade', () => {
@@ -1909,7 +1909,7 @@ describe('place-sell-stop-loss-order.js', () => {
                 type: 'MARKET'
               }
             ]);
-            mockGetAccountInfo = jest.fn().mockResolvedValue({
+            mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
               account: 'info'
             });
 
@@ -1922,7 +1922,7 @@ describe('place-sell-stop-loss-order.js', () => {
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              getAccountInfo: mockGetAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               disableAction: mockDisableAction,
               getAPILimit: mockGetAPILimit,
@@ -2016,8 +2016,8 @@ describe('place-sell-stop-loss-order.js', () => {
             );
           });
 
-          it('triggers getAccountInfo', () => {
-            expect(mockGetAccountInfo).toHaveBeenCalled();
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
           });
 
           it('triggers saveSymbolGridTrade', () => {
@@ -2105,7 +2105,7 @@ describe('place-sell-stop-loss-order.js', () => {
                 type: 'MARKET'
               }
             ]);
-            mockGetAccountInfo = jest.fn().mockResolvedValue({
+            mockGetAccountInfoFromAPI = jest.fn().mockResolvedValue({
               account: 'info'
             });
 
@@ -2118,7 +2118,7 @@ describe('place-sell-stop-loss-order.js', () => {
             });
 
             jest.mock('../../../trailingTradeHelper/common', () => ({
-              getAccountInfo: mockGetAccountInfo,
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
               isExceedAPILimit: mockIsExceedAPILimit,
               disableAction: mockDisableAction,
               getAPILimit: mockGetAPILimit,
@@ -2212,8 +2212,8 @@ describe('place-sell-stop-loss-order.js', () => {
             );
           });
 
-          it('triggers getAccountInfo', () => {
-            expect(mockGetAccountInfo).toHaveBeenCalled();
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalled();
           });
 
           it('triggers saveSymbolGridTrade', () => {

--- a/app/cronjob/trailingTrade/step/cancel-order.js
+++ b/app/cronjob/trailingTrade/step/cancel-order.js
@@ -2,8 +2,8 @@ const moment = require('moment');
 const { binance, slack, PubSub } = require('../../../helpers');
 const {
   getAPILimit,
-  getAccountInfo,
-  getAndCacheOpenOrdersForSymbol
+  getAndCacheOpenOrdersForSymbol,
+  getAccountInfoFromAPI
 } = require('../../trailingTradeHelper/common');
 const { deleteManualOrder } = require('../../trailingTradeHelper/order');
 
@@ -67,7 +67,7 @@ const execute = async (logger, rawData) => {
   );
 
   // Refresh account info
-  data.accountInfo = await getAccountInfo(logger);
+  data.accountInfo = await getAccountInfoFromAPI(logger);
 
   PubSub.publish('frontend-notification', {
     type: 'success',

--- a/app/cronjob/trailingTrade/step/place-manual-trade.js
+++ b/app/cronjob/trailingTrade/step/place-manual-trade.js
@@ -2,8 +2,8 @@ const moment = require('moment');
 const { binance, slack, PubSub } = require('../../../helpers');
 const {
   getAPILimit,
-  getAccountInfo,
-  getAndCacheOpenOrdersForSymbol
+  getAndCacheOpenOrdersForSymbol,
+  getAccountInfoFromAPI
 } = require('../../trailingTradeHelper/common');
 const { saveManualOrder } = require('../../trailingTradeHelper/order');
 
@@ -273,7 +273,7 @@ const execute = async (logger, rawData) => {
     o => o.side.toLowerCase() === 'sell'
   );
   // Refresh account info
-  data.accountInfo = await getAccountInfo(logger);
+  data.accountInfo = await getAccountInfoFromAPI(logger);
 
   slackMessageOrderResult(logger, symbol, order.side, order, orderResult);
 

--- a/app/cronjob/trailingTrade/step/place-sell-order.js
+++ b/app/cronjob/trailingTrade/step/place-sell-order.js
@@ -3,10 +3,10 @@ const moment = require('moment');
 const { binance, slack } = require('../../../helpers');
 const { roundDown } = require('../../trailingTradeHelper/util');
 const {
-  getAccountInfo,
   isExceedAPILimit,
   getAPILimit,
-  getAndCacheOpenOrdersForSymbol
+  getAndCacheOpenOrdersForSymbol,
+  getAccountInfoFromAPI
 } = require('../../trailingTradeHelper/common');
 const { saveGridTradeOrder } = require('../../trailingTradeHelper/order');
 
@@ -210,7 +210,7 @@ const execute = async (logger, rawData) => {
   );
 
   // Refresh account info
-  data.accountInfo = await getAccountInfo(logger);
+  data.accountInfo = await getAccountInfoFromAPI(logger);
 
   slack.sendMessage(
     `*${symbol}* Sell Action Grid Trade #${humanisedGridTradeIndex} Result: *STOP_LOSS_LIMIT*\n` +

--- a/app/cronjob/trailingTrade/step/place-sell-stop-loss-order.js
+++ b/app/cronjob/trailingTrade/step/place-sell-stop-loss-order.js
@@ -2,11 +2,11 @@ const _ = require('lodash');
 const moment = require('moment');
 const { binance, slack } = require('../../../helpers');
 const {
-  getAccountInfo,
   isExceedAPILimit,
   disableAction,
   getAPILimit,
-  getAndCacheOpenOrdersForSymbol
+  getAndCacheOpenOrdersForSymbol,
+  getAccountInfoFromAPI
 } = require('../../trailingTradeHelper/common');
 const {
   saveSymbolGridTrade
@@ -201,7 +201,7 @@ const execute = async (logger, rawData) => {
   );
 
   // Refresh account info
-  data.accountInfo = await getAccountInfo(logger);
+  data.accountInfo = await getAccountInfoFromAPI(logger);
 
   slack.sendMessage(
     `*${symbol}* Sell Stop-Loss Action Result: *MARKET*\n` +

--- a/app/cronjob/trailingTradeHelper/__tests__/common.test.js
+++ b/app/cronjob/trailingTradeHelper/__tests__/common.test.js
@@ -3347,12 +3347,18 @@ describe('common.js', () => {
         }
       ]);
 
+      binanceMock.client.accountInfo = jest.fn().mockResolvedValue({
+        account: 'updated',
+        balances: [
+          {
+            asset: 'USDT',
+            free: 50.0179958,
+            locked: 0
+          }
+        ]
+      });
+
       cacheMock.hset = jest.fn().mockResolvedValue(true);
-      cacheMock.hgetWithoutLock = jest.fn().mockResolvedValue(
-        JSON.stringify({
-          accountInfo: 'updated'
-        })
-      );
 
       commonHelper = require('../common');
       result = await commonHelper.refreshOpenOrdersAndAccountInfo(
@@ -3365,14 +3371,21 @@ describe('common.js', () => {
       expect(binanceMock.client.openOrders).toHaveBeenCalled();
     });
 
-    it('triggers cache.hgetWithoutLock', () => {
-      expect(cacheMock.hgetWithoutLock).toHaveBeenCalled();
+    it('triggers cache.hset', () => {
+      expect(cacheMock.hset).toHaveBeenCalled();
     });
 
     it('returns expected results', () => {
       expect(result).toStrictEqual({
         accountInfo: {
-          accountInfo: 'updated'
+          account: 'updated',
+          balances: [
+            {
+              asset: 'USDT',
+              free: 50.0179958,
+              locked: 0
+            }
+          ]
         },
         openOrders: [
           {

--- a/app/cronjob/trailingTradeHelper/common.js
+++ b/app/cronjob/trailingTradeHelper/common.js
@@ -175,7 +175,7 @@ const getAccountInfoFromAPI = async logger => {
 };
 
 /**
- * Retreive account info from cache
+ * Retrieve account info from cache
  *  If empty, retrieve from API
  *
  * @param {*} logger
@@ -1137,7 +1137,7 @@ const refreshOpenOrdersAndAccountInfo = async (logger, symbol) => {
   const openOrders = await getAndCacheOpenOrdersForSymbol(logger, symbol);
 
   // Refresh account info
-  const accountInfo = await getAccountInfo(logger);
+  const accountInfo = await getAccountInfoFromAPI(logger);
 
   const buyOpenOrders = openOrders.filter(o => o.side.toLowerCase() === 'buy');
 


### PR DESCRIPTION
## Description

When we use `updateAccountInfo` to update the account balances on actions like buy order or sell order, it causes a race condition with the WebSocket because of manually subtracting and adding values.

To solve this, I replaced `updateAccountInfo` with `getAccountFromAPI` on buy order, sell order, and manual orders
Also, I replaced `getAccountInfo` with `getAccountFromAPI` to avoid the race condition too.

## Related Issue

#512 

## Motivation and Context
## How Has This Been Tested?

Tests provided

## Screenshots (if appropriate):
