### PR TITLE
Remove last buy price slack updates unless notifyDebug or notifyOrder are enabled

### DIFF
--- a/app/cronjob/trailingTrade/step/__tests__/place-buy-order.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/place-buy-order.test.js
@@ -246,7 +246,7 @@ describe('place-buy-order.js', () => {
           name: 'when tradingView is not enabled, then place an order',
           rawData: {
             symbol: 'BTCUPUSDT',
-            featureToggle: { notifyDebug: true },
+            featureToggle: { notifyDebug: true, notifyOrderConfirm: true },
             symbolConfiguration: {
               buy: {
                 enabled: true,
@@ -299,7 +299,7 @@ describe('place-buy-order.js', () => {
             `then place an order`,
           rawData: {
             symbol: 'BTCUPUSDT',
-            featureToggle: { notifyDebug: true },
+            featureToggle: { notifyDebug: true, notifyOrderConfirm: false },
             symbolConfiguration: {
               buy: {
                 enabled: true,
@@ -344,7 +344,7 @@ describe('place-buy-order.js', () => {
             `then place an order`,
           rawData: {
             symbol: 'BTCUPUSDT',
-            featureToggle: { notifyDebug: true },
+            featureToggle: { notifyDebug: true, notifyOrderConfirm: true },
             symbolConfiguration: {
               buy: {
                 enabled: true,
@@ -394,7 +394,7 @@ describe('place-buy-order.js', () => {
             `if expires, then place an order`,
           rawData: {
             symbol: 'BTCUPUSDT',
-            featureToggle: { notifyDebug: false },
+            featureToggle: { notifyDebug: false, notifyOrderConfirm: false },
             symbolConfiguration: {
               buy: {
                 enabled: true,
@@ -447,7 +447,7 @@ describe('place-buy-order.js', () => {
             `if expires, then do not place an order`,
           rawData: {
             symbol: 'BTCUPUSDT',
-            featureToggle: { notifyDebug: false },
+            featureToggle: { notifyDebug: false, notifyOrderConfirm: true },
             symbolConfiguration: {
               buy: {
                 enabled: true,
@@ -500,7 +500,7 @@ describe('place-buy-order.js', () => {
           name: 'when tradingView are enabled and recommendation is strong buy, then place an order',
           rawData: {
             symbol: 'BTCUPUSDT',
-            featureToggle: { notifyDebug: true },
+            featureToggle: { notifyDebug: true, notifyOrderConfirm: false },
             symbolConfiguration: {
               buy: {
                 enabled: true,
@@ -551,7 +551,7 @@ describe('place-buy-order.js', () => {
           name: 'when tradingView are enabled and recommendation is buy, then place an order',
           rawData: {
             symbol: 'BTCUPUSDT',
-            featureToggle: { notifyDebug: false },
+            featureToggle: { notifyDebug: false, notifyOrderConfirm: true },
             symbolConfiguration: {
               buy: {
                 enabled: true,
@@ -602,7 +602,7 @@ describe('place-buy-order.js', () => {
           name: 'when tradingView are enabled and recommendation is not strong buy or buy, do not place an order',
           rawData: {
             symbol: 'BTCUPUSDT',
-            featureToggle: { notifyDebug: false },
+            featureToggle: { notifyDebug: false, notifyOrderConfirm: false },
             symbolConfiguration: {
               buy: {
                 enabled: true,
@@ -715,7 +715,7 @@ describe('place-buy-order.js', () => {
             `but the action is overriden and checking tradingView is false, then place an order`,
           rawData: {
             symbol: 'BTCUPUSDT',
-            featureToggle: { notifyDebug: false },
+            featureToggle: { notifyDebug: false, notifyOrderConfirm: true },
             symbolConfiguration: {
               buy: {
                 enabled: true,
@@ -807,6 +807,23 @@ describe('place-buy-order.js', () => {
           });
 
           if (t.expectedToPlaceOrder === true) {
+            if (
+              t.rawData.featureToggle.notifyDebug === true ||
+              t.rawData.featureToggle.notifyOrderConfirm === true
+            ) {
+              it('triggers slack.sendMessage for buy action', () => {
+                expect(slackMock.sendMessage.mock.calls[0][0]).toContain(
+                  'Action - Buy Trade #1: *STOP_LOSS_LIMIT'
+                );
+              });
+
+              it('triggers slack.sendMessage for buy result', () => {
+                expect(slackMock.sendMessage.mock.calls[1][0]).toContain(
+                  'Buy Action Grid Trade #1 Result: *STOP_LOSS_LIMIT*'
+                );
+              });
+            }
+
             it('triggers binance.client.order', () => {
               expect(binanceMock.client.order).toHaveBeenCalledWith({
                 price: 202.2,
@@ -3062,7 +3079,8 @@ describe('place-buy-order.js', () => {
             symbol: 'BTCUPUSDT',
             isLocked: false,
             featureToggle: {
-              notifyDebug: true
+              notifyDebug: true,
+              notifyOrderConfirm: false
             },
             symbolInfo: {
               baseAsset: 'BTCUP',
@@ -3157,6 +3175,18 @@ describe('place-buy-order.js', () => {
             'BTCBRL',
             'BNBUSDT'
           ]);
+        });
+
+        it('triggers slack.sendMessage for buy action', () => {
+          expect(slackMock.sendMessage.mock.calls[0][0]).toContain(
+            '*BTCUPUSDT* Action - Buy Trade #1: *STOP_LOSS_LIMIT'
+          );
+        });
+
+        it('triggers slack.sendMessage for buy result', () => {
+          expect(slackMock.sendMessage.mock.calls[1][0]).toContain(
+            '*BTCUPUSDT* Buy Action Grid Trade #1 Result: *STOP_LOSS_LIMIT*'
+          );
         });
 
         it('retruns expected value', () => {

--- a/app/cronjob/trailingTrade/step/place-buy-order.js
+++ b/app/cronjob/trailingTrade/step/place-buy-order.js
@@ -159,7 +159,7 @@ const execute = async (logger, rawData) => {
   const {
     symbol,
     isLocked,
-    featureToggle: { notifyDebug },
+    featureToggle: { notifyDebug, notifyOrderConfirm },
     symbolInfo: {
       baseAsset,
       quoteAsset,
@@ -405,12 +405,13 @@ const execute = async (logger, rawData) => {
     notifyMessage.calculationParams = calculationParams;
   }
 
-  slack.sendMessage(
-    `*${symbol}* Action - Buy Trade #${humanisedGridTradeIndex}: *STOP_LOSS_LIMIT*\n` +
-      `- Order Params: \n` +
-      `\`\`\`${JSON.stringify(notifyMessage, undefined, 2)}\`\`\``,
-    { symbol, apiLimit: getAPILimit(logger) }
-  );
+  if (notifyDebug || notifyOrderConfirm)
+    slack.sendMessage(
+      `*${symbol}* Action - Buy Trade #${humanisedGridTradeIndex}: *STOP_LOSS_LIMIT*\n` +
+        `- Order Params: \n` +
+        `\`\`\`${JSON.stringify(notifyMessage, undefined, 2)}\`\`\``,
+      { symbol, apiLimit: getAPILimit(logger) }
+    );
 
   logger.info(
     {
@@ -447,15 +448,16 @@ const execute = async (logger, rawData) => {
   // Refresh account info
   data.accountInfo = await getAccountInfoFromAPI(logger);
 
-  slack.sendMessage(
-    `*${symbol}* Buy Action Grid Trade #${humanisedGridTradeIndex} Result: *STOP_LOSS_LIMIT*\n` +
-      `- Order Result: \`\`\`${JSON.stringify(
-        orderResult,
-        undefined,
-        2
-      )}\`\`\``,
-    { symbol, apiLimit: getAPILimit(logger) }
-  );
+  if (notifyDebug || notifyOrderConfirm)
+    slack.sendMessage(
+      `*${symbol}* Buy Action Grid Trade #${humanisedGridTradeIndex} Result: *STOP_LOSS_LIMIT*\n` +
+        `- Order Result: \`\`\`${JSON.stringify(
+          orderResult,
+          undefined,
+          2
+        )}\`\`\``,
+      { symbol, apiLimit: getAPILimit(logger) }
+    );
 
   return setMessage(
     logger,

--- a/app/cronjob/trailingTradeHelper/common.js
+++ b/app/cronjob/trailingTradeHelper/common.js
@@ -523,6 +523,9 @@ const calculateLastBuyPrice = async (logger, symbol, order) => {
 
   const newLastBuyPrice = newTotalAmount / newQuantity;
 
+  const notifyDebug = config.get('featureToggle.notifyDebug');
+  const notifyOrderConfirm = config.get('featureToggle.notifyOrderConfirm');
+
   logger.info(
     { newLastBuyPrice, newTotalAmount, newQuantity, saveLog: true },
     `The last buy price will be saved. New last buy price: ${newLastBuyPrice}`
@@ -537,22 +540,23 @@ const calculateLastBuyPrice = async (logger, symbol, order) => {
     title: `New last buy price for ${symbol} has been updated.`
   });
 
-  slack.sendMessage(
-    `*${symbol}* Last buy price Updated: *${type}*\n` +
-      `- Order Result: \`\`\`${JSON.stringify(
-        {
-          orgLastBuyPrice,
-          orgQuantity,
-          orgTotalAmount,
-          newLastBuyPrice,
-          newQuantity,
-          newTotalAmount
-        },
-        undefined,
-        2
-      )}\`\`\``,
-    { symbol, apiLimit: getAPILimit(logger) }
-  );
+  if (notifyDebug || notifyOrderConfirm)
+    slack.sendMessage(
+      `*${symbol}* Last buy price Updated: *${type}*\n` +
+        `- Order Result: \`\`\`${JSON.stringify(
+          {
+            orgLastBuyPrice,
+            orgQuantity,
+            orgTotalAmount,
+            newLastBuyPrice,
+            newQuantity,
+            newTotalAmount
+          },
+          undefined,
+          2
+        )}\`\`\``,
+      { symbol, apiLimit: getAPILimit(logger) }
+    );
 };
 
 /**


### PR DESCRIPTION
## Description
The existing slack notification settings are still quite verbose even when notifyOrderConfirm and notifyDebug are disabled. Also as a user, if I only enable notifyOrderExecute, I expect to not receive trailing price update notifications. 


## Related Issue

This PR tries to address [#515](https://github.com/chrisleekr/binance-trading-bot/issues/515)


## How Has This Been Tested?

This has been tested in live mode on my own setup and trailing updates are not sent anymore with notifyOrderConfirm and notifyDebug set to false.

