### PR TITLE
fix: assign specific version for axios

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -73,7 +73,7 @@
       src="https://unpkg.com/lodash@4.17.20/lodash.min.js"
       crossorigin></script>
     <script
-      src="https://unpkg.com/axios/dist/axios.min.js"
+      src="https://unpkg.com/axios@0.27.2/dist/axios.min.js"
       crossorigin></script>
     <script
       src="https://unpkg.com/react-bootstrap-typeahead@5.1.4/dist/react-bootstrap-typeahead.min.js"

--- a/public/index.prod.html
+++ b/public/index.prod.html
@@ -59,7 +59,7 @@
       src="https://unpkg.com/lodash@4.17.20/lodash.min.js"
       crossorigin></script>
     <script
-      src="https://unpkg.com/axios/dist/axios.min.js"
+      src="https://unpkg.com/axios@0.27.2/dist/axios.min.js"
       crossorigin></script>
     <script
       src="https://unpkg.com/react-bootstrap-typeahead@5.1.4/dist/react-bootstrap-typeahead.min.js"


### PR DESCRIPTION
## Description

Axios `v1.0` was released 2 days ago and it has some breaking changes.
The CDN url of `axios` in `index.html` and `index.prod.html` always points to the latest version which is dangerous.
Also, it's making the frontend unreachable.

This PR specifies the version of Axios to be always `v0.27.2` 

## Related Issue

#520 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
