### PR TITLE
fix: give redlock enough time for locking

### DIFF
--- a/app/helpers/__tests__/cache.test.js
+++ b/app/helpers/__tests__/cache.test.js
@@ -74,7 +74,7 @@ describe('cache', () => {
       });
 
       it('triggers lock', () => {
-        expect(mockLock).toHaveBeenCalledWith('redlock:my-key', 500);
+        expect(mockLock).toHaveBeenCalledWith('redlock:my-key', 1000);
       });
 
       it('does not trigger setex', () => {
@@ -100,7 +100,7 @@ describe('cache', () => {
       });
 
       it('triggers lock', () => {
-        expect(mockLock).toHaveBeenCalledWith('redlock:my-key', 500);
+        expect(mockLock).toHaveBeenCalledWith('redlock:my-key', 1000);
       });
 
       it('triggers setex', () => {
@@ -147,7 +147,7 @@ describe('cache', () => {
     });
 
     it('triggers lock', () => {
-      expect(mockLock).toHaveBeenCalledWith('redlock:my-key', 500);
+      expect(mockLock).toHaveBeenCalledWith('redlock:my-key', 1000);
     });
 
     it('triggers get', () => {
@@ -228,7 +228,7 @@ describe('cache', () => {
     });
 
     it('triggers lock', () => {
-      expect(mockLock).toHaveBeenCalledWith('redlock:my-key', 500);
+      expect(mockLock).toHaveBeenCalledWith('redlock:my-key', 1000);
     });
 
     it('triggers del', () => {
@@ -270,7 +270,7 @@ describe('cache', () => {
       });
 
       it('triggers lock', () => {
-        expect(mockLock).toHaveBeenCalledWith('redlock:my-key:my-field', 500);
+        expect(mockLock).toHaveBeenCalledWith('redlock:my-key:my-field', 1000);
       });
 
       it('triggers set', () => {
@@ -311,7 +311,7 @@ describe('cache', () => {
       });
 
       it('triggers lock', () => {
-        expect(mockLock).toHaveBeenCalledWith('redlock:my-key:my-field', 500);
+        expect(mockLock).toHaveBeenCalledWith('redlock:my-key:my-field', 1000);
       });
 
       it('triggers setex', () => {
@@ -357,7 +357,7 @@ describe('cache', () => {
     });
 
     it('triggers lock', () => {
-      expect(mockLock).toHaveBeenCalledWith('redlock:my-key:my-field', 500);
+      expect(mockLock).toHaveBeenCalledWith('redlock:my-key:my-field', 1000);
     });
 
     it('triggers get', () => {
@@ -566,7 +566,7 @@ describe('cache', () => {
     });
 
     it('triggers lock', () => {
-      expect(mockLock).toHaveBeenCalledWith('redlock:my-key:my-field', 500);
+      expect(mockLock).toHaveBeenCalledWith('redlock:my-key:my-field', 1000);
     });
 
     it('triggers del', () => {

--- a/app/helpers/cache.js
+++ b/app/helpers/cache.js
@@ -43,7 +43,7 @@ const keys = async pattern => redis.keys(pattern);
  * @param {*} ttl seconds
  */
 const set = async (key, value, ttl = undefined) => {
-  const lock = await redlock.lock(`redlock:${key}`, 500);
+  const lock = await redlock.lock(`redlock:${key}`, 1000);
 
   let result;
   if (ttl) {
@@ -63,7 +63,7 @@ const set = async (key, value, ttl = undefined) => {
  * @param {*} key
  */
 const get = async key => {
-  const lock = await redlock.lock(`redlock:${key}`, 500);
+  const lock = await redlock.lock(`redlock:${key}`, 1000);
   const result = await redis.get(key);
   await lock.unlock();
 
@@ -93,7 +93,7 @@ const getWithTTL = async key => redis.multi().ttl(key).get(key).exec();
  * @param {*} key
  */
 const del = async key => {
-  const lock = await redlock.lock(`redlock:${key}`, 500);
+  const lock = await redlock.lock(`redlock:${key}`, 1000);
   const result = await redis.del(key);
   await lock.unlock();
   return result;


### PR DESCRIPTION
## Description

`redlock` does not have enough time to unlock after doing the requested operation.
What I mean is that if the `redlock` locks a key for `500ms` and it is expired before calling `lock.unlock()`, and then calling  `lock.unlock()` will throw an exception like:

> Unable to fully release the lock on resource "redlock:trailing-trade-configurations:global"

Because the lock already expired and unlock cannot be done on an expired lock.
Increasing the lock time to `1000ms` solves the problem and it will not affect the performance or the behavior.

Suggestions from: https://github.com/mike-marcacci/node-redlock/issues/65

## Related Issue

Partially solve #519 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tests provided

## Screenshots (if appropriate):

Posted on #519
