### PR TITLE
feat: add advanced chart link to Tradingview section

### DIFF
--- a/public/js/CoinWrapperTradingView.js
+++ b/public/js/CoinWrapperTradingView.js
@@ -312,14 +312,24 @@ class CoinWrapperTradingView extends React.Component {
       <div className='coin-info-sub-wrapper'>
         <div className='coin-info-column coin-info-column-title'>
           <div className='coin-info-label'>
-            Technical Analysis from{' '}
-            <a
+            Tradingview
+          </div>
+          <div className='coin-info-value'>
+            Open: <a
               href={
                 'https://www.tradingview.com/symbols/' + symbol + '/technicals/'
               }
               rel='noopener noreferrer'
               target='_blank'>
-              TradingView
+            Technical analysis
+          </a> &nbsp; | &nbsp;
+            <a
+                href={
+                  'https://www.tradingview.com/chart/?symbol=' + symbol
+                }
+                rel='noopener noreferrer'
+                target='_blank'>
+              Chart
             </a>
           </div>
         </div>


### PR DESCRIPTION
### Is your proposal related to a problem?

The existing Tradingview link in the coin wrapper view opens the browser to the Technical Analysis summary. If I want to access the advanced chart instead, I have to do it from TV TA page.

### Describe the solution you'd like
Ideally the coin wrapper view should offer both options:
- access to TV TA page
- access to TV advanced chart

### Describe alternatives you've considered

Here is an example of proposed UI:
<img width="430" alt="Screenshot 2022-10-09 at 19 10 18" src="https://user-images.githubusercontent.com/1491835/194770398-95a87f0d-d250-4bd3-b035-2e5a1271a944.png">