### PR TITLE
feat: show buy/sell order details in the grid trade sections

### DIFF
--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -249,6 +249,48 @@ class CoinWrapperBuySignal extends React.Component {
               ''
             )}
 
+            {grid.executed && grid.executedOrder.currentGridTradeIndex === i ? (
+                <div
+                    className={`coin-info-content-setting ${
+                        collapsed ? 'd-none' : ''
+                    }`}>
+                  <div className='coin-info-column coin-info-column-order'>
+                    <span className='coin-info-label'>
+                      - Purchased date:
+                    </span>
+                    <div className='coin-info-value'>
+                      {moment(grid.executedOrder.transactTime).format('YYYY-MM-DD HH:mm')}
+                    </div>
+                  </div>
+                  <div className='coin-info-column coin-info-column-order'>
+                    <span className='coin-info-label'>
+                      - Purchased price:
+                    </span>
+                    <div className='coin-info-value'>
+                      {parseFloat(grid.executedOrder.price).toFixed(precision)}
+                    </div>
+                  </div>
+                  <div className='coin-info-column coin-info-column-order'>
+                    <span className='coin-info-label'>
+                      - Purchased qty:
+                    </span>
+                    <div className='coin-info-value'>
+                      {parseFloat(grid.executedOrder.executedQty)}
+                    </div>
+                  </div>
+                  <div className='coin-info-column coin-info-column-order'>
+                    <span className='coin-info-label'>
+                      - Purchased amount:
+                    </span>
+                    <div className='coin-info-value'>
+                      {parseFloat(grid.executedOrder.cummulativeQuoteQty).toFixed(precision)}
+                    </div>
+                  </div>
+                </div>
+            ) : (
+                ''
+            )}
+
             <div
               className={`coin-info-content-setting ${
                 collapsed ? 'd-none' : ''

--- a/public/js/CoinWrapperSellSignal.js
+++ b/public/js/CoinWrapperSellSignal.js
@@ -186,6 +186,48 @@ class CoinWrapperSellSignal extends React.Component {
               ''
             )}
 
+            {grid.executed && grid.executedOrder.currentGridTradeIndex === i ? (
+                <div
+                    className={`coin-info-content-setting ${
+                        collapsed ? 'd-none' : ''
+                    }`}>
+                  <div className='coin-info-column coin-info-column-order'>
+                    <span className='coin-info-label'>
+                      - Sold date:
+                    </span>
+                    <div className='coin-info-value'>
+                      {moment(grid.executedOrder.transactTime).format('YYYY-MM-DD HH:mm')}
+                    </div>
+                  </div>
+                  <div className='coin-info-column coin-info-column-order'>
+                    <span className='coin-info-label'>
+                      - Sold price:
+                    </span>
+                    <div className='coin-info-value'>
+                      {parseFloat(grid.executedOrder.price).toFixed(precision)}
+                    </div>
+                  </div>
+                  <div className='coin-info-column coin-info-column-order'>
+                    <span className='coin-info-label'>
+                      - Sold qty:
+                    </span>
+                    <div className='coin-info-value'>
+                      {parseFloat(grid.executedOrder.executedQty)}
+                    </div>
+                  </div>
+                  <div className='coin-info-column coin-info-column-order'>
+                    <span className='coin-info-label'>
+                      - Sold amount:
+                    </span>
+                    <div className='coin-info-value'>
+                      {parseFloat(grid.executedOrder.cummulativeQuoteQty).toFixed(precision)}
+                    </div>
+                  </div>
+                </div>
+            ) : (
+                ''
+            )}
+
             <div
               className={`coin-info-content-setting ${
                 collapsed ? 'd-none' : ''


### PR DESCRIPTION
## Description
Improve the frontend with information about the recent orders that took place in the current grid trading.

## Motivation and Context
Today there is no way to get the details of buy and sell orders that the bot executed in a specific coin grid. This PR is about showing the date, price, quantity and amount for each buy/sell order happening in an active trading grid.

## How Has This Been Tested?
This PR simply expands the grid trade sections with order details ( date, price, quantity, amount) only when the grid got executed. This has been tested on my local setup with multi-grid coins.

I couldn't write tests as I couldn't find existing tests dealing with UI aspects that I could reuse.

## Screenshots (if appropriate):
<img width="298" alt="Screenshot 2022-10-14 at 18 54 10" src="https://user-images.githubusercontent.com/1491835/195902030-501dc66d-f7fa-425f-b3a2-889f4f1b9f54.png">

