### PR TITLE
feat: show next best grid amount

### DIFF
--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -328,7 +328,7 @@ class CoinWrapperBuySignal extends React.Component {
             key={'coin-wrapper-buy-next-grid-row-' + symbol}>
           <div className='coin-info-column coin-info-column-price'>
             <span className='coin-info-label'>
-              &#62; Next grid amount:
+              &#62; Suggested next grid amount:
               <OverlayTrigger
                 trigger='click'
                 key='buy-grid-exit-overlay'

--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -323,7 +323,7 @@ class CoinWrapperBuySignal extends React.Component {
 
       const nextGridAmount = nextGridQty * currentPrice;
 
-      return (
+      return nextGridAmount > 0 ? (
         <React.Fragment
             key={'coin-wrapper-buy-next-grid-row-' + symbol}>
           <div className='coin-info-column coin-info-column-price'>
@@ -355,8 +355,8 @@ class CoinWrapperBuySignal extends React.Component {
             </span>
           </div>
         </React.Fragment>
+      ) : ( ''
       );
-
     }
 
     return (

--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -301,6 +301,64 @@ class CoinWrapperBuySignal extends React.Component {
       );
     });
 
+    const buyNextGrid = () => {
+      const sellGridTrade = symbolConfiguration.sell.gridTrade;
+
+      const currentPrice = parseFloat(buy.currentPrice)
+      const lastBuyPrice = parseFloat(sell.lastBuyPrice)
+
+      if (isNaN(lastBuyPrice) || sellGridTrade.length != 1 || currentPrice >= lastBuyPrice)
+        return ('')
+
+      const totalBoughtQty = gridTrade
+          .filter(trade => trade.executed)
+          .map(order => parseFloat(order.executedOrder.executedQty))
+          .reduce((acc, qty) => acc + qty, 0);
+
+      const triggerSellPercentage = sellGridTrade[0].triggerPercentage;
+
+      const gain = triggerSellPercentage - 1;
+
+      const nextGridQty = -totalBoughtQty * (1 + ((currentPrice - lastBuyPrice) / (gain * currentPrice)));
+
+      const nextGridAmount = nextGridQty * currentPrice;
+
+      return (
+        <React.Fragment
+            key={'coin-wrapper-buy-next-grid-row-' + symbol}>
+          <div className='coin-info-column coin-info-column-price'>
+            <span className='coin-info-label'>
+              &#62; Next grid amount:
+              <OverlayTrigger
+                trigger='click'
+                key='buy-grid-exit-overlay'
+                placement='bottom'
+                overlay={
+                  <Popover id='buy-next-grid-overlay-right'>
+                    <Popover.Content>
+                      This is the amount you would need to purchase (at the current price) to
+                      close the grid trade assuming the price reaches your sell trigger
+                      point ({((triggerSellPercentage - 1) * 100).toFixed(2)}%).
+                    </Popover.Content>
+                  </Popover>
+                }>
+                <Button
+                    variant='link'
+                    className='p-0 m-0 ml-1 text-info d-inline-block'
+                    style={{lineHeight: '10px'}}>
+                  <i className='fas fa-question-circle fa-sm'></i>
+                </Button>
+              </OverlayTrigger>
+            </span>
+            <span className='coin-info-value'>
+              {nextGridAmount.toFixed(precision)}{' '}{quoteAsset}
+            </span>
+          </div>
+        </React.Fragment>
+      );
+
+    }
+
     return (
       <div className='coin-info-sub-wrapper'>
         <div className='coin-info-column coin-info-column-title'>
@@ -431,6 +489,7 @@ class CoinWrapperBuySignal extends React.Component {
         )}
         <div className='coin-info-column coin-info-column-price divider mb-1'></div>
         {buyGridRows}
+        {buyNextGrid()}
         {buy.processMessage ? (
           <div className='d-flex flex-column w-100'>
             <div className='coin-info-column coin-info-column-price divider'></div>

--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -328,7 +328,7 @@ class CoinWrapperBuySignal extends React.Component {
             key={'coin-wrapper-buy-next-grid-row-' + symbol}>
           <div className='coin-info-column coin-info-column-price'>
             <span className='coin-info-label'>
-              &#62; Suggested next grid amount:
+              &#62; Suggested break-even amount:
               <OverlayTrigger
                 trigger='click'
                 key='buy-grid-exit-overlay'
@@ -337,8 +337,8 @@ class CoinWrapperBuySignal extends React.Component {
                   <Popover id='buy-next-grid-overlay-right'>
                     <Popover.Content>
                       This is the amount you would need to purchase (at the current price) to
-                      close the grid trade assuming the price reaches your sell trigger
-                      point ({((triggerSellPercentage - 1) * 100).toFixed(2)}%).
+                      close the grid trade at break-even if the price reaches your sell trigger
+                      point ({((triggerSellPercentage - 1) * 100).toFixed(2)}%) after the purchase.
                     </Popover.Content>
                   </Popover>
                 }>


### PR DESCRIPTION
## Description

The feature suggests the amount of money you would need to invest in a coin (as a new grid item or a manual trade) to expect closing the grid at break-event (i.e. without losing money) if the coin price eventually reaches your current sell percentage trigger. 

The amount appears only for coins with active grid trades that have one selling grid.

The calculation is based on the following formula: 

**next best grid quantity** = - qi * (1+(p - pi) / (gain * p)), 

where gain = (triggerSellPercentage - 1)
and:

| **Current grid state** | **Suggested best trade**       |
|------------------------|---------------------------|
| Quantity bought (qi)   | Quantity to determine (q) |
| Last price (pi)        | Current price (p)         |
| Spent amount (ai)      | Amount to spend (a)       |


## Motivation and Context

When a coin goes deeper than expected for too long, I often find myself doing a lot of calculations to figure out the best next grid I would need to add to reactivate trading without losing money.

For new comers, it can be difficult to understand how to setup buy-grid-trades and this feature gives some better insight for grid management

## How Has This Been Tested?

It's been running on my server.

## Screenshots (if appropriate):
<img width="359" alt="Screenshot 2022-11-19 at 11 32 59" src="https://user-images.githubusercontent.com/1491835/202847251-39bdbab7-677f-47db-932a-8dbcbfbe4af4.png">
