### PR TITLE
feat: show error when use wrong API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Added API error message when using the wrong API key/secret - [#544](https://github.com/chrisleekr/binance-trading-bot/pull/544)
+
 ## [0.0.94] - 2022-11-24
 
 - Added advanced chart link to Tradingview section by [@rando128](https://github.com/rando128) - [#525](https://github.com/chrisleekr/binance-trading-bot/pull/525)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,7 @@ module.exports = grunt => {
           './public/dist/js/LockIcon.min.js',
           './public/dist/js/UnlockIcon.min.js',
           './public/dist/js/Header.min.js',
+          './public/dist/js/APIError.min.js',
           './public/dist/js/LockScreen.min.js',
           './public/dist/js/AppSorting.min.js',
           './public/dist/js/AppLoading.min.js',

--- a/app/frontend/websocket/handlers/__tests__/fixtures/latest-stats-invalid-cache.json
+++ b/app/frontend/websocket/handlers/__tests__/fixtures/latest-stats-invalid-cache.json
@@ -1,0 +1,1236 @@
+{
+  "result": true,
+  "type": "latest",
+  "isAuthenticated": true,
+  "configuration": {
+    "enabled": true,
+    "symbols": ["BTCUSDT", "BNBUSDT"]
+  },
+  "common": {
+    "version": "0.0.94",
+    "gitHash": "unspecified",
+    "accountInfo": {
+      "balances": []
+    },
+    "apiInfo": {
+      "spot": {
+        "usedWeight1m": "60"
+      },
+      "futures": {}
+    },
+    "closedTradesSetting": {},
+    "orderStats": {
+      "numberOfOpenTrades": null,
+      "numberOfBuyOpenOrders": null
+    },
+    "closedTrades": [],
+    "totalProfitAndLoss": [],
+    "streamsCount": 6,
+    "monitoringSymbolsCount": 2,
+    "cachedMonitoringSymbolsCount": 5,
+    "totalPages": 1
+  },
+  "stats": {
+    "symbols": [
+      {
+        "symbol": "BNBUSDT",
+        "isLocked": false,
+        "featureToggle": {
+          "notifyOrderConfirm": true,
+          "notifyDebug": true,
+          "notifyOrderExecute": true
+        },
+        "lastCandle": {
+          "eventType": "kline",
+          "symbol": "BNBUSDT",
+          "close": "485.70000000"
+        },
+        "symbolConfiguration": {
+          "_id": "61167428434d24b0b57ce954",
+          "key": "configuration",
+          "enabled": true,
+          "cronTime": "* * * * * *",
+          "botOptions": {
+            "authentication": {
+              "lockList": false,
+              "lockAfter": 120
+            },
+            "autoTriggerBuy": {
+              "enabled": true,
+              "triggerAfter": 1
+            }
+          },
+          "candles": {
+            "interval": "1m",
+            "limit": 10
+          },
+          "buy": {
+            "enabled": true,
+            "lastBuyPriceRemoveThreshold": 10,
+            "athRestriction": {
+              "enabled": false,
+              "candles": {
+                "interval": "1d",
+                "limit": 30
+              },
+              "restrictionPercentage": 0.9
+            },
+            "maxPurchaseAmount": -1,
+            "gridTrade": [
+              {
+                "triggerPercentage": 1,
+                "stopPercentage": 1.001,
+                "limitPercentage": 1.0011,
+                "maxPurchaseAmount": 21,
+                "executed": true,
+                "executedOrder": {
+                  "symbol": "BNBUSDT",
+                  "orderId": 5213213,
+                  "orderListId": -1,
+                  "clientOrderId": "duQYBSnlLOoDgcN3Xa1OsO",
+                  "price": "449.52000000",
+                  "origQty": "0.04000000",
+                  "executedQty": "0.04000000",
+                  "cummulativeQuoteQty": "17.98080000",
+                  "status": "FILLED",
+                  "timeInForce": "GTC",
+                  "type": "STOP_LOSS_LIMIT",
+                  "side": "BUY",
+                  "stopPrice": "449.47000000",
+                  "icebergQty": "0.00000000",
+                  "time": 1629590089149,
+                  "updateTime": 1629590131092,
+                  "isWorking": true,
+                  "origQuoteOrderQty": "0.00000000",
+                  "currentGridTradeIndex": 0,
+                  "nextCheck": "2021-08-21T23:55:33.247Z"
+                }
+              }
+            ],
+            "currentGridTradeIndex": -1,
+            "currentGridTrade": null
+          },
+          "sell": {
+            "enabled": true,
+            "stopLoss": {
+              "enabled": true,
+              "maxLossPercentage": 0.99,
+              "disableBuyMinutes": 1,
+              "orderType": "market"
+            },
+            "gridTrade": [
+              {
+                "triggerPercentage": 1.001,
+                "stopPercentage": 0.999,
+                "limitPercentage": 0.998,
+                "quantityPercentage": 1,
+                "executed": false,
+                "executedOrder": null
+              }
+            ],
+            "currentGridTradeIndex": 0,
+            "currentGridTrade": {
+              "triggerPercentage": 1.001,
+              "stopPercentage": 0.999,
+              "limitPercentage": 0.998,
+              "quantityPercentage": 1,
+              "executed": false,
+              "executedOrder": null
+            }
+          },
+          "system": {
+            "temporaryDisableActionAfterConfirmingOrder": 20,
+            "checkManualBuyOrderPeriod": 5,
+            "placeManualOrderInterval": 5,
+            "refreshAccountInfoPeriod": 1,
+            "checkOrderExecutePeriod": 10,
+            "checkManualOrderPeriod": 5
+          }
+        },
+        "indicators": {
+          "highestPrice": 485.9,
+          "lowestPrice": 484.1,
+          "athPrice": null
+        },
+        "symbolInfo": {
+          "symbol": "BNBUSDT",
+          "status": "TRADING",
+          "baseAsset": "BNB",
+          "baseAssetPrecision": 8,
+          "quoteAsset": "USDT",
+          "quotePrecision": 8,
+          "filterLotSize": {
+            "filterType": "LOT_SIZE",
+            "minQty": "0.01000000",
+            "maxQty": "9000.00000000",
+            "stepSize": "0.01000000"
+          },
+          "filterPrice": {
+            "filterType": "PRICE_FILTER",
+            "minPrice": "0.01000000",
+            "maxPrice": "10000.00000000",
+            "tickSize": "0.01000000"
+          },
+          "filterMinNotional": {
+            "filterType": "MIN_NOTIONAL",
+            "minNotional": "10.00000000",
+            "applyToMarket": true,
+            "avgPriceMins": 5
+          }
+        },
+        "openOrders": [
+          {
+            "symbol": "BNBUSDT",
+            "orderId": 6398822,
+            "orderListId": -1,
+            "clientOrderId": "m471GLEsN8YzBDVweWQgN0",
+            "price": "643.11000000",
+            "origQty": "0.04000000",
+            "executedQty": "0.00000000",
+            "cummulativeQuoteQty": "0.00000000",
+            "status": "NEW",
+            "timeInForce": "GTC",
+            "type": "STOP_LOSS_LIMIT",
+            "side": "SELL",
+            "stopPrice": "643.75000000",
+            "icebergQty": "0.00000000",
+            "time": 1630129419133,
+            "updateTime": 1630129428568,
+            "isWorking": true,
+            "origQuoteOrderQty": "0.00000000",
+            "currentPrice": 485.7,
+            "updatedAt": "2021-08-28T05:43:39.133Z",
+            "differenceToExecute": -32.54066296067533,
+            "differenceToCancel": -32.80627551169872,
+            "minimumProfit": 6.163200000000002,
+            "minimumProfitPercentage": 31.507269492669177
+          }
+        ],
+        "action": "sell-order-wait",
+        "baseAssetBalance": {
+          "asset": "BNB",
+          "free": "0.01000000",
+          "locked": "0.04000000",
+          "total": 0.05,
+          "estimatedValue": 24.285,
+          "updatedAt": "2021-08-28T11:56:27+00:00",
+          "isLessThanMinNotionalValue": false
+        },
+        "quoteAssetBalance": {
+          "asset": "USDT",
+          "free": "379068.42127337",
+          "locked": "0.00000000"
+        },
+        "buy": {
+          "currentPrice": 485.7,
+          "limitPrice": null,
+          "highestPrice": 485.9,
+          "lowestPrice": 484.1,
+          "athPrice": null,
+          "athRestrictionPrice": null,
+          "triggerPrice": null,
+          "difference": null,
+          "openOrders": [],
+          "processMessage": "",
+          "updatedAt": "2021-08-28T12:09:50.048Z"
+        },
+        "sell": {
+          "currentPrice": 485.7,
+          "limitPrice": 484.7286,
+          "lastBuyPrice": 489.03,
+          "triggerPrice": 489.51902999999993,
+          "difference": -0.7862940086472925,
+          "stopLossTriggerPrice": 484.13969999999995,
+          "stopLossDifference": 0.32124768375541013,
+          "currentProfit": -0.1664999999999992,
+          "currentProfitPercentage": -0.6809398196429672,
+          "openOrders": [
+            {
+              "symbol": "BNBUSDT",
+              "orderId": 6398822,
+              "orderListId": -1,
+              "clientOrderId": "m471GLEsN8YzBDVweWQgN0",
+              "price": "643.11000000",
+              "origQty": "0.04000000",
+              "executedQty": "0.00000000",
+              "cummulativeQuoteQty": "0.00000000",
+              "status": "NEW",
+              "timeInForce": "GTC",
+              "type": "STOP_LOSS_LIMIT",
+              "side": "SELL",
+              "stopPrice": "643.75000000",
+              "icebergQty": "0.00000000",
+              "time": 1630129419133,
+              "updateTime": 1630129428568,
+              "isWorking": true,
+              "origQuoteOrderQty": "0.00000000",
+              "currentPrice": 485.7,
+              "updatedAt": "2021-08-28T05:43:39.133Z",
+              "differenceToExecute": -32.54066296067533,
+              "differenceToCancel": -32.80627551169872,
+              "minimumProfit": 6.163200000000002,
+              "minimumProfitPercentage": 31.507269492669177
+            }
+          ],
+          "processMessage": "",
+          "updatedAt": "2021-08-28T12:09:50.048Z"
+        },
+        "order": {},
+        "saveToCache": true,
+        "isActionDisabled": {
+          "isDisabled": true,
+          "ttl": 330,
+          "disabledBy": "stop loss",
+          "canResume": true,
+          "message": "Temporary disabled by stop loss"
+        }
+      },
+      {
+        "symbol": "BTCUSDT",
+        "isLocked": false,
+        "featureToggle": {
+          "notifyOrderConfirm": true,
+          "notifyDebug": true,
+          "notifyOrderExecute": true
+        },
+        "lastCandle": {
+          "eventType": "kline",
+          "symbol": "BTCUSDT",
+          "close": "48942.03000000"
+        },
+        "symbolConfiguration": {
+          "_id": "611e5f2dd3630e44f849b05b",
+          "key": "BTCUSDT-configuration",
+          "candles": {
+            "interval": "1m",
+            "limit": 10
+          },
+          "buy": {
+            "enabled": true,
+            "lastBuyPriceRemoveThreshold": 10,
+            "athRestriction": {
+              "enabled": false,
+              "candles": {
+                "interval": "1d",
+                "limit": 30
+              },
+              "restrictionPercentage": 0.9
+            },
+            "maxPurchaseAmount": -1,
+            "gridTrade": [
+              {
+                "triggerPercentage": 1,
+                "stopPercentage": 1.001,
+                "limitPercentage": 1.0011,
+                "maxPurchaseAmount": 21,
+                "executed": false,
+                "executedOrder": null
+              }
+            ],
+            "currentGridTradeIndex": 0,
+            "currentGridTrade": {
+              "triggerPercentage": 1,
+              "stopPercentage": 1.001,
+              "limitPercentage": 1.0011,
+              "maxPurchaseAmount": 21,
+              "executed": false,
+              "executedOrder": null
+            }
+          },
+          "sell": {
+            "enabled": true,
+            "stopLoss": {
+              "enabled": true,
+              "maxLossPercentage": 0.99,
+              "disableBuyMinutes": 1,
+              "orderType": "market"
+            },
+            "gridTrade": [
+              {
+                "triggerPercentage": 1.001,
+                "stopPercentage": 0.999,
+                "limitPercentage": 0.998,
+                "quantityPercentage": 1,
+                "executed": false,
+                "executedOrder": null
+              }
+            ],
+            "currentGridTradeIndex": 0,
+            "currentGridTrade": {
+              "triggerPercentage": 1.001,
+              "stopPercentage": 0.999,
+              "limitPercentage": 0.998,
+              "quantityPercentage": 1,
+              "executed": false,
+              "executedOrder": null
+            }
+          },
+          "botOptions": {
+            "authentication": {
+              "lockList": false,
+              "lockAfter": 120
+            },
+            "autoTriggerBuy": {
+              "enabled": true,
+              "triggerAfter": 1
+            }
+          },
+          "enabled": true,
+          "cronTime": "* * * * * *",
+          "system": {
+            "temporaryDisableActionAfterConfirmingOrder": 20,
+            "checkManualBuyOrderPeriod": 5,
+            "placeManualOrderInterval": 5,
+            "refreshAccountInfoPeriod": 1,
+            "checkOrderExecutePeriod": 10,
+            "checkManualOrderPeriod": 5
+          }
+        },
+        "indicators": {
+          "highestPrice": 49015.11,
+          "lowestPrice": 48892.71,
+          "athPrice": null
+        },
+        "symbolInfo": {
+          "symbol": "BTCUSDT",
+          "status": "TRADING",
+          "baseAsset": "BTC",
+          "baseAssetPrecision": 8,
+          "quoteAsset": "USDT",
+          "quotePrecision": 8,
+          "filterLotSize": {
+            "filterType": "LOT_SIZE",
+            "minQty": "0.00000100",
+            "maxQty": "900.00000000",
+            "stepSize": "0.00000100"
+          },
+          "filterPrice": {
+            "filterType": "PRICE_FILTER",
+            "minPrice": "0.01000000",
+            "maxPrice": "1000000.00000000",
+            "tickSize": "0.01000000"
+          },
+          "filterMinNotional": {
+            "filterType": "MIN_NOTIONAL",
+            "minNotional": "10.00000000",
+            "applyToMarket": true,
+            "avgPriceMins": 5
+          }
+        },
+        "openOrders": [
+          {
+            "symbol": "BTCUSDT",
+            "orderId": 7010265,
+            "orderListId": -1,
+            "clientOrderId": "Gox2Mu7nLcDBeAj6mZFVVU",
+            "price": "48995.86000000",
+            "origQty": "0.00042800",
+            "executedQty": "0.00000000",
+            "cummulativeQuoteQty": "0.00000000",
+            "status": "NEW",
+            "timeInForce": "GTC",
+            "type": "STOP_LOSS_LIMIT",
+            "side": "BUY",
+            "stopPrice": "48990.97000000",
+            "icebergQty": "0.00000000",
+            "time": 1629594092089,
+            "updateTime": 1629594092089,
+            "isWorking": false,
+            "origQuoteOrderQty": "0.00000000",
+            "currentPrice": 48942.03,
+            "updatedAt": "2021-08-22T01:01:32.089Z",
+            "differenceToExecute": -0.09999585223581242,
+            "differenceToCancel": 0.009993155293375189
+          }
+        ],
+        "action": "buy-order-wait",
+        "baseAssetBalance": {
+          "asset": "BTC",
+          "free": "0.00000100",
+          "locked": "0.00000000",
+          "total": 0.000001,
+          "estimatedValue": 0.04894203,
+          "updatedAt": "2021-08-22T01:01:32+00:00",
+          "isLessThanMinNotionalValue": true
+        },
+        "quoteAssetBalance": {
+          "asset": "USDT",
+          "free": "378987.63247205",
+          "locked": "20.97022808"
+        },
+        "buy": {
+          "currentPrice": 48942.03,
+          "limitPrice": 48995.866233,
+          "highestPrice": 49015.11,
+          "lowestPrice": 48892.71,
+          "athPrice": null,
+          "athRestrictionPrice": null,
+          "triggerPrice": 48892.71,
+          "difference": 0.10087393396684963,
+          "openOrders": [
+            {
+              "symbol": "BTCUSDT",
+              "orderId": 7010265,
+              "orderListId": -1,
+              "clientOrderId": "Gox2Mu7nLcDBeAj6mZFVVU",
+              "price": "48995.86000000",
+              "origQty": "0.00042800",
+              "executedQty": "0.00000000",
+              "cummulativeQuoteQty": "0.00000000",
+              "status": "NEW",
+              "timeInForce": "GTC",
+              "type": "STOP_LOSS_LIMIT",
+              "side": "BUY",
+              "stopPrice": "48990.97000000",
+              "icebergQty": "0.00000000",
+              "time": 1629594092089,
+              "updateTime": 1629594092089,
+              "isWorking": false,
+              "origQuoteOrderQty": "0.00000000",
+              "currentPrice": 48942.03,
+              "updatedAt": "2021-08-22T01:01:32.089Z",
+              "differenceToExecute": -0.09999585223581242,
+              "differenceToCancel": 0.009993155293375189
+            }
+          ],
+          "processMessage": "",
+          "updatedAt": "2021-08-22T01:04:08.210Z"
+        },
+        "sell": {
+          "currentPrice": 48942.03,
+          "limitPrice": null,
+          "lastBuyPrice": null,
+          "triggerPrice": null,
+          "difference": null,
+          "stopLossTriggerPrice": null,
+          "stopLossDifference": null,
+          "currentProfit": null,
+          "currentProfitPercentage": null,
+          "openOrders": [],
+          "processMessage": "",
+          "updatedAt": "2021-08-22T01:04:08.210Z"
+        },
+        "order": {},
+        "saveToCache": true,
+        "isActionDisabled": {
+          "isDisabled": false,
+          "ttl": -2
+        }
+      },
+      {
+        "symbol": "ETHBUSD",
+        "isLocked": false,
+        "featureToggle": {
+          "notifyOrderConfirm": true,
+          "notifyDebug": true,
+          "notifyOrderExecute": true
+        },
+        "lastCandle": {
+          "eventType": "kline",
+          "symbol": "ETHBUSD",
+          "close": "1000.01000000"
+        },
+        "symbolConfiguration": {
+          "_id": "61167428434d24b0b57ce954",
+          "key": "configuration",
+          "enabled": true,
+          "cronTime": "* * * * * *",
+          "botOptions": {
+            "authentication": {
+              "lockList": false,
+              "lockAfter": 120
+            },
+            "autoTriggerBuy": {
+              "enabled": true,
+              "triggerAfter": 1
+            }
+          },
+          "candles": {
+            "interval": "1m",
+            "limit": 10
+          },
+          "buy": {
+            "enabled": true,
+            "lastBuyPriceRemoveThreshold": 10,
+            "athRestriction": {
+              "enabled": false,
+              "candles": {
+                "interval": "1d",
+                "limit": 30
+              },
+              "restrictionPercentage": 0.9
+            },
+            "maxPurchaseAmount": -1,
+            "gridTrade": [
+              {
+                "triggerPercentage": 1,
+                "stopPercentage": 1.001,
+                "limitPercentage": 1.0011,
+                "maxPurchaseAmount": 21,
+                "executed": true,
+                "executedOrder": {
+                  "symbol": "ETHBUSD",
+                  "orderId": 3424,
+                  "orderListId": -1,
+                  "clientOrderId": "PwNd1dkdHiQG4d7vBbhRYp",
+                  "price": "3049.95000000",
+                  "origQty": "0.00688000",
+                  "executedQty": "0.00688000",
+                  "cummulativeQuoteQty": "20.98365600",
+                  "status": "FILLED",
+                  "timeInForce": "GTC",
+                  "type": "STOP_LOSS_LIMIT",
+                  "side": "BUY",
+                  "stopPrice": "3049.64000000",
+                  "icebergQty": "0.00000000",
+                  "time": 1629425885316,
+                  "updateTime": 1629513026900,
+                  "isWorking": true,
+                  "origQuoteOrderQty": "0.00000000",
+                  "currentGridTradeIndex": 0,
+                  "nextCheck": "2021-08-20T12:40:35.226Z"
+                }
+              }
+            ],
+            "currentGridTradeIndex": -1,
+            "currentGridTrade": null
+          },
+          "sell": {
+            "enabled": true,
+            "stopLoss": {
+              "enabled": true,
+              "maxLossPercentage": 0.99,
+              "disableBuyMinutes": 1,
+              "orderType": "market"
+            },
+            "gridTrade": [
+              {
+                "triggerPercentage": 1.001,
+                "stopPercentage": 0.999,
+                "limitPercentage": 0.998,
+                "quantityPercentage": 1,
+                "executed": false,
+                "executedOrder": null
+              }
+            ],
+            "currentGridTradeIndex": 0,
+            "currentGridTrade": {
+              "triggerPercentage": 1.001,
+              "stopPercentage": 0.999,
+              "limitPercentage": 0.998,
+              "quantityPercentage": 1,
+              "executed": false,
+              "executedOrder": null
+            }
+          },
+          "system": {
+            "temporaryDisableActionAfterConfirmingOrder": 20,
+            "checkManualBuyOrderPeriod": 5,
+            "placeManualOrderInterval": 5,
+            "refreshAccountInfoPeriod": 1,
+            "checkOrderExecutePeriod": 10,
+            "checkManualOrderPeriod": 5
+          }
+        },
+        "indicators": {
+          "highestPrice": 1000.01,
+          "lowestPrice": 1000.01,
+          "athPrice": null
+        },
+        "symbolInfo": {
+          "symbol": "ETHBUSD",
+          "status": "TRADING",
+          "baseAsset": "ETH",
+          "baseAssetPrecision": 8,
+          "quoteAsset": "BUSD",
+          "quotePrecision": 8,
+          "filterLotSize": {
+            "filterType": "LOT_SIZE",
+            "minQty": "0.00001000",
+            "maxQty": "9000.00000000",
+            "stepSize": "0.00001000"
+          },
+          "filterPrice": {
+            "filterType": "PRICE_FILTER",
+            "minPrice": "0.01000000",
+            "maxPrice": "100000.00000000",
+            "tickSize": "0.01000000"
+          },
+          "filterMinNotional": {
+            "filterType": "MIN_NOTIONAL",
+            "minNotional": "10.00000000",
+            "applyToMarket": true,
+            "avgPriceMins": 5
+          }
+        },
+        "openOrders": [
+          {
+            "symbol": "ETHBUSD",
+            "orderId": 3632,
+            "orderListId": -1,
+            "clientOrderId": "2jdLRcZMCmjDA9qf1YAeHf",
+            "price": "3344.21000000",
+            "origQty": "99.90687000",
+            "executedQty": "0.00000000",
+            "cummulativeQuoteQty": "0.00000000",
+            "status": "NEW",
+            "timeInForce": "GTC",
+            "type": "STOP_LOSS_LIMIT",
+            "side": "SELL",
+            "stopPrice": "3347.56000000",
+            "icebergQty": "0.00000000",
+            "time": 1629755493058,
+            "updateTime": 1629803948834,
+            "isWorking": true,
+            "origQuoteOrderQty": "0.00000000",
+            "currentPrice": 1000.01,
+            "updatedAt": "2021-08-23T21:51:33.058Z",
+            "differenceToExecute": -234.75265247347528,
+            "differenceToCancel": -235.42349947242008,
+            "minimumProfit": 29398.595566199976,
+            "minimumProfitPercentage": 9.648027016836336
+          }
+        ],
+        "action": "sell-order-wait",
+        "baseAssetBalance": {
+          "asset": "ETH",
+          "free": "0.10001000",
+          "locked": "99.90687000",
+          "total": 100.00688,
+          "estimatedValue": 100007.88006879999,
+          "updatedAt": "2021-08-28T11:56:27+00:00",
+          "isLessThanMinNotionalValue": false
+        },
+        "quoteAssetBalance": {
+          "asset": "BUSD",
+          "free": "9904.79690824",
+          "locked": "41.96541778"
+        },
+        "buy": {
+          "currentPrice": 1000.01,
+          "limitPrice": null,
+          "highestPrice": 1000.01,
+          "lowestPrice": 1000.01,
+          "athPrice": null,
+          "athRestrictionPrice": null,
+          "triggerPrice": null,
+          "difference": null,
+          "openOrders": [],
+          "processMessage": "",
+          "updatedAt": "2021-08-28T12:09:50.060Z"
+        },
+        "sell": {
+          "currentPrice": 1000.01,
+          "limitPrice": 998.00998,
+          "lastBuyPrice": 3049.9500000000003,
+          "triggerPrice": 3052.99995,
+          "difference": -205.2969420305797,
+          "stopLossTriggerPrice": 3019.4505000000004,
+          "stopLossDifference": -201.94203057969426,
+          "currentProfit": -205008.10358720005,
+          "currentProfitPercentage": -67.2122493811374,
+          "openOrders": [
+            {
+              "symbol": "ETHBUSD",
+              "orderId": 3632,
+              "orderListId": -1,
+              "clientOrderId": "2jdLRcZMCmjDA9qf1YAeHf",
+              "price": "3344.21000000",
+              "origQty": "99.90687000",
+              "executedQty": "0.00000000",
+              "cummulativeQuoteQty": "0.00000000",
+              "status": "NEW",
+              "timeInForce": "GTC",
+              "type": "STOP_LOSS_LIMIT",
+              "side": "SELL",
+              "stopPrice": "3347.56000000",
+              "icebergQty": "0.00000000",
+              "time": 1629755493058,
+              "updateTime": 1629803948834,
+              "isWorking": true,
+              "origQuoteOrderQty": "0.00000000",
+              "currentPrice": 1000.01,
+              "updatedAt": "2021-08-23T21:51:33.058Z",
+              "differenceToExecute": -234.75265247347528,
+              "differenceToCancel": -235.42349947242008,
+              "minimumProfit": 29398.595566199976,
+              "minimumProfitPercentage": 9.648027016836336
+            }
+          ],
+          "processMessage": "",
+          "updatedAt": "2021-08-28T12:09:50.060Z"
+        },
+        "order": {},
+        "saveToCache": true,
+        "isActionDisabled": {
+          "isDisabled": false,
+          "ttl": -2
+        }
+      },
+      {
+        "symbol": "BTCBUSD",
+        "isLocked": false,
+        "featureToggle": {
+          "notifyOrderConfirm": true,
+          "notifyDebug": true,
+          "notifyOrderExecute": true
+        },
+        "lastCandle": {
+          "eventType": "kline",
+          "symbol": "BTCBUSD",
+          "close": "48878.93000000"
+        },
+        "symbolConfiguration": {
+          "_id": "61167428434d24b0b57ce954",
+          "key": "configuration",
+          "enabled": true,
+          "cronTime": "* * * * * *",
+          "botOptions": {
+            "authentication": {
+              "lockList": false,
+              "lockAfter": 120
+            },
+            "autoTriggerBuy": {
+              "enabled": true,
+              "triggerAfter": 1
+            }
+          },
+          "candles": {
+            "interval": "1m",
+            "limit": 10
+          },
+          "buy": {
+            "enabled": true,
+            "lastBuyPriceRemoveThreshold": 10,
+            "athRestriction": {
+              "enabled": false,
+              "candles": {
+                "interval": "1d",
+                "limit": 30
+              },
+              "restrictionPercentage": 0.9
+            },
+            "maxPurchaseAmount": -1,
+            "gridTrade": [
+              {
+                "triggerPercentage": 1,
+                "stopPercentage": 1.001,
+                "limitPercentage": 1.0011,
+                "maxPurchaseAmount": 21,
+                "executed": false,
+                "executedOrder": null
+              }
+            ],
+            "currentGridTradeIndex": 0,
+            "currentGridTrade": {
+              "triggerPercentage": 1,
+              "stopPercentage": 1.001,
+              "limitPercentage": 1.0011,
+              "maxPurchaseAmount": 21,
+              "executed": false,
+              "executedOrder": null
+            }
+          },
+          "sell": {
+            "enabled": true,
+            "stopLoss": {
+              "enabled": true,
+              "maxLossPercentage": 0.99,
+              "disableBuyMinutes": 1,
+              "orderType": "market"
+            },
+            "gridTrade": [
+              {
+                "triggerPercentage": 1.001,
+                "stopPercentage": 0.999,
+                "limitPercentage": 0.998,
+                "quantityPercentage": 1,
+                "executed": false,
+                "executedOrder": null
+              }
+            ],
+            "currentGridTradeIndex": 0,
+            "currentGridTrade": {
+              "triggerPercentage": 1.001,
+              "stopPercentage": 0.999,
+              "limitPercentage": 0.998,
+              "quantityPercentage": 1,
+              "executed": false,
+              "executedOrder": null
+            }
+          },
+          "system": {
+            "temporaryDisableActionAfterConfirmingOrder": 20,
+            "checkManualBuyOrderPeriod": 5,
+            "placeManualOrderInterval": 5,
+            "refreshAccountInfoPeriod": 1,
+            "checkOrderExecutePeriod": 10,
+            "checkManualOrderPeriod": 5
+          }
+        },
+        "indicators": {
+          "highestPrice": 48878.93,
+          "lowestPrice": 48878.93,
+          "athPrice": null
+        },
+        "symbolInfo": {
+          "symbol": "BTCBUSD",
+          "status": "TRADING",
+          "baseAsset": "BTC",
+          "baseAssetPrecision": 8,
+          "quoteAsset": "BUSD",
+          "quotePrecision": 8,
+          "filterLotSize": {
+            "filterType": "LOT_SIZE",
+            "minQty": "0.00000100",
+            "maxQty": "900.00000000",
+            "stepSize": "0.00000100"
+          },
+          "filterPrice": {
+            "filterType": "PRICE_FILTER",
+            "minPrice": "0.01000000",
+            "maxPrice": "1000000.00000000",
+            "tickSize": "0.01000000"
+          },
+          "filterMinNotional": {
+            "filterType": "MIN_NOTIONAL",
+            "minNotional": "10.00000000",
+            "applyToMarket": true,
+            "avgPriceMins": 5
+          }
+        },
+        "openOrders": [
+          {
+            "symbol": "BTCBUSD",
+            "orderId": 23261,
+            "orderListId": -1,
+            "clientOrderId": "G5BfeMmFcgN8LKX5EIthqB",
+            "price": "47054.93000000",
+            "origQty": "0.00044600",
+            "executedQty": "0.00000000",
+            "cummulativeQuoteQty": "0.00000000",
+            "status": "NEW",
+            "timeInForce": "GTC",
+            "type": "STOP_LOSS_LIMIT",
+            "side": "BUY",
+            "stopPrice": "47050.23000000",
+            "icebergQty": "0.00000000",
+            "time": 1630126065539,
+            "updateTime": 1630151787045,
+            "isWorking": true,
+            "origQuoteOrderQty": "0.00000000",
+            "currentPrice": 48878.93,
+            "updatedAt": "2021-08-28T04:47:45.539Z",
+            "differenceToExecute": 3.7412848440012803,
+            "differenceToCancel": 3.8470530856071328
+          }
+        ],
+        "action": "buy-order-wait",
+        "baseAssetBalance": {
+          "asset": "BTC",
+          "free": "0.00000100",
+          "locked": "0.00000000",
+          "total": 0.000001,
+          "estimatedValue": 0.04887893,
+          "updatedAt": "2021-08-28T11:56:27+00:00",
+          "isLessThanMinNotionalValue": true
+        },
+        "quoteAssetBalance": {
+          "asset": "BUSD",
+          "free": "9904.79690824",
+          "locked": "41.96541778"
+        },
+        "buy": {
+          "currentPrice": 48878.93,
+          "limitPrice": 48932.696823000006,
+          "highestPrice": 48878.93,
+          "lowestPrice": 48878.93,
+          "athPrice": null,
+          "athRestrictionPrice": null,
+          "triggerPrice": 48878.93,
+          "difference": 0,
+          "openOrders": [
+            {
+              "symbol": "BTCBUSD",
+              "orderId": 23261,
+              "orderListId": -1,
+              "clientOrderId": "G5BfeMmFcgN8LKX5EIthqB",
+              "price": "47054.93000000",
+              "origQty": "0.00044600",
+              "executedQty": "0.00000000",
+              "cummulativeQuoteQty": "0.00000000",
+              "status": "NEW",
+              "timeInForce": "GTC",
+              "type": "STOP_LOSS_LIMIT",
+              "side": "BUY",
+              "stopPrice": "47050.23000000",
+              "icebergQty": "0.00000000",
+              "time": 1630126065539,
+              "updateTime": 1630151787045,
+              "isWorking": true,
+              "origQuoteOrderQty": "0.00000000",
+              "currentPrice": 48878.93,
+              "updatedAt": "2021-08-28T04:47:45.539Z",
+              "differenceToExecute": 3.7412848440012803,
+              "differenceToCancel": 3.8470530856071328
+            }
+          ],
+          "processMessage": "",
+          "updatedAt": "2021-08-28T12:09:50.056Z"
+        },
+        "sell": {
+          "currentPrice": 48878.93,
+          "limitPrice": null,
+          "lastBuyPrice": null,
+          "triggerPrice": null,
+          "difference": null,
+          "stopLossTriggerPrice": null,
+          "stopLossDifference": null,
+          "currentProfit": null,
+          "currentProfitPercentage": null,
+          "openOrders": [],
+          "processMessage": "",
+          "updatedAt": "2021-08-28T12:09:50.056Z"
+        },
+        "order": {},
+        "saveToCache": true,
+        "isActionDisabled": {
+          "isDisabled": false,
+          "ttl": -2
+        }
+      },
+      {
+        "symbol": "LTCBUSD",
+        "isLocked": false,
+        "featureToggle": {
+          "notifyOrderConfirm": true,
+          "notifyDebug": true,
+          "notifyOrderExecute": true
+        },
+        "lastCandle": {
+          "eventType": "kline",
+          "symbol": "LTCBUSD",
+          "close": "70.42000000"
+        },
+        "symbolConfiguration": {
+          "_id": "61167428434d24b0b57ce954",
+          "key": "configuration",
+          "enabled": true,
+          "cronTime": "* * * * * *",
+          "botOptions": {
+            "authentication": {
+              "lockList": false,
+              "lockAfter": 120
+            },
+            "autoTriggerBuy": {
+              "enabled": true,
+              "triggerAfter": 1
+            }
+          },
+          "candles": {
+            "interval": "1m",
+            "limit": 10
+          },
+          "buy": {
+            "enabled": true,
+            "lastBuyPriceRemoveThreshold": 10,
+            "athRestriction": {
+              "enabled": false,
+              "candles": {
+                "interval": "1d",
+                "limit": 30
+              },
+              "restrictionPercentage": 0.9
+            },
+            "maxPurchaseAmount": -1,
+            "gridTrade": [
+              {
+                "triggerPercentage": 1,
+                "stopPercentage": 1.001,
+                "limitPercentage": 1.0011,
+                "maxPurchaseAmount": 21,
+                "executed": false,
+                "executedOrder": null
+              }
+            ],
+            "currentGridTradeIndex": 0,
+            "currentGridTrade": {
+              "triggerPercentage": 1,
+              "stopPercentage": 1.001,
+              "limitPercentage": 1.0011,
+              "maxPurchaseAmount": 21,
+              "executed": false,
+              "executedOrder": null
+            }
+          },
+          "sell": {
+            "enabled": true,
+            "stopLoss": {
+              "enabled": true,
+              "maxLossPercentage": 0.99,
+              "disableBuyMinutes": 1,
+              "orderType": "market"
+            },
+            "gridTrade": [
+              {
+                "triggerPercentage": 1.001,
+                "stopPercentage": 0.999,
+                "limitPercentage": 0.998,
+                "quantityPercentage": 1,
+                "executed": false,
+                "executedOrder": null
+              }
+            ],
+            "currentGridTradeIndex": 0,
+            "currentGridTrade": {
+              "triggerPercentage": 1.001,
+              "stopPercentage": 0.999,
+              "limitPercentage": 0.998,
+              "quantityPercentage": 1,
+              "executed": false,
+              "executedOrder": null
+            }
+          },
+          "system": {
+            "temporaryDisableActionAfterConfirmingOrder": 20,
+            "checkManualBuyOrderPeriod": 5,
+            "placeManualOrderInterval": 5,
+            "refreshAccountInfoPeriod": 1,
+            "checkOrderExecutePeriod": 10,
+            "checkManualOrderPeriod": 5
+          }
+        },
+        "indicators": {
+          "highestPrice": 70.42,
+          "lowestPrice": 70.42,
+          "athPrice": null
+        },
+        "symbolInfo": {
+          "symbol": "LTCBUSD",
+          "status": "TRADING",
+          "baseAsset": "LTC",
+          "baseAssetPrecision": 8,
+          "quoteAsset": "BUSD",
+          "quotePrecision": 8,
+          "filterLotSize": {
+            "filterType": "LOT_SIZE",
+            "minQty": "0.00001000",
+            "maxQty": "9000.00000000",
+            "stepSize": "0.00001000"
+          },
+          "filterPrice": {
+            "filterType": "PRICE_FILTER",
+            "minPrice": "0.01000000",
+            "maxPrice": "100000.00000000",
+            "tickSize": "0.01000000"
+          },
+          "filterMinNotional": {
+            "filterType": "MIN_NOTIONAL",
+            "minNotional": "10.00000000",
+            "applyToMarket": true,
+            "avgPriceMins": 5
+          }
+        },
+        "openOrders": [
+          {
+            "symbol": "LTCBUSD",
+            "orderId": 1927,
+            "orderListId": -1,
+            "clientOrderId": "JZVoOLOxJ6468XhpkGO0QL",
+            "price": "70.47000000",
+            "origQty": "0.29770000",
+            "executedQty": "0.00000000",
+            "cummulativeQuoteQty": "0.00000000",
+            "status": "NEW",
+            "timeInForce": "GTC",
+            "type": "STOP_LOSS_LIMIT",
+            "side": "BUY",
+            "stopPrice": "70.47000000",
+            "icebergQty": "0.00000000",
+            "time": 1629614577188,
+            "updateTime": 1629614577188,
+            "isWorking": false,
+            "origQuoteOrderQty": "0.00000000",
+            "currentPrice": 70.42,
+            "updatedAt": "2021-08-22T06:42:57.188Z",
+            "differenceToExecute": -0.07100255609202577,
+            "differenceToCancel": 0.038954593854756414
+          }
+        ],
+        "action": "buy-order-wait",
+        "baseAssetBalance": {
+          "asset": "LTC",
+          "free": "499.75398000",
+          "locked": "0.00000000",
+          "total": 499.75398,
+          "estimatedValue": 35192.675271600005,
+          "updatedAt": "2021-08-28T11:56:27+00:00",
+          "isLessThanMinNotionalValue": false
+        },
+        "quoteAssetBalance": {
+          "asset": "BUSD",
+          "free": "9904.79690824",
+          "locked": "41.96541778"
+        },
+        "buy": {
+          "currentPrice": 70.42,
+          "limitPrice": 70.49746200000001,
+          "highestPrice": 70.42,
+          "lowestPrice": 70.42,
+          "athPrice": null,
+          "athRestrictionPrice": null,
+          "triggerPrice": 70.42,
+          "difference": 0,
+          "openOrders": [
+            {
+              "symbol": "LTCBUSD",
+              "orderId": 1927,
+              "orderListId": -1,
+              "clientOrderId": "JZVoOLOxJ6468XhpkGO0QL",
+              "price": "70.47000000",
+              "origQty": "0.29770000",
+              "executedQty": "0.00000000",
+              "cummulativeQuoteQty": "0.00000000",
+              "status": "NEW",
+              "timeInForce": "GTC",
+              "type": "STOP_LOSS_LIMIT",
+              "side": "BUY",
+              "stopPrice": "70.47000000",
+              "icebergQty": "0.00000000",
+              "time": 1629614577188,
+              "updateTime": 1629614577188,
+              "isWorking": false,
+              "origQuoteOrderQty": "0.00000000",
+              "currentPrice": 70.42,
+              "updatedAt": "2021-08-22T06:42:57.188Z",
+              "differenceToExecute": -0.07100255609202577,
+              "differenceToCancel": 0.038954593854756414
+            }
+          ],
+          "processMessage": "",
+          "updatedAt": "2021-08-28T12:09:50.051Z"
+        },
+        "sell": {
+          "currentPrice": 70.42,
+          "limitPrice": null,
+          "lastBuyPrice": null,
+          "triggerPrice": null,
+          "difference": null,
+          "stopLossTriggerPrice": null,
+          "stopLossDifference": null,
+          "currentProfit": null,
+          "currentProfitPercentage": null,
+          "openOrders": [],
+          "processMessage": "",
+          "updatedAt": "2021-08-28T12:09:50.051Z"
+        },
+        "order": {},
+        "saveToCache": true,
+        "isActionDisabled": {
+          "isDisabled": false,
+          "ttl": -2
+        }
+      }
+    ]
+  }
+}

--- a/app/frontend/websocket/handlers/__tests__/latest.test.js
+++ b/app/frontend/websocket/handlers/__tests__/latest.test.js
@@ -9,6 +9,7 @@ describe('latest.test.js', () => {
   const trailingTradeStateNotAuthenticatedUnlockList = require('./fixtures/latest-stats-not-authenticated-unlock-list.json');
 
   const trailingTradeStatsAuthenticated = require('./fixtures/latest-stats-authenticated.json');
+  const trailingTradeStateInvalidCache = require('./fixtures/latest-stats-invalid-cache.json');
 
   let mockCountCacheTrailingTradeSymbols;
   let mockGetCacheTrailingTradeSymbols;
@@ -29,6 +30,8 @@ describe('latest.test.js', () => {
 
   beforeEach(() => {
     jest.clearAllMocks().resetModules();
+
+    process.env.GIT_HASH = 'some-hash';
 
     mockBinanceClientGetInfo = jest.fn().mockReturnValue({
       spot: {
@@ -160,6 +163,7 @@ describe('latest.test.js', () => {
 
       const { handleLatest } = require('../latest');
       await handleLatest(logger, mockWebSocketServer, {
+        isAuthenticated: true,
         data: {
           sortBy: 'default',
           sortByDesc: false,
@@ -169,15 +173,19 @@ describe('latest.test.js', () => {
       });
     });
 
-    it('does not trigger ws.send', () => {
-      expect(mockWebSocketServerWebSocketSend).not.toHaveBeenCalled();
+    it('triggers ws.send with latest', () => {
+      trailingTradeStateInvalidCache.common.version =
+        require('../../../../../package.json').version;
+      trailingTradeStateInvalidCache.common.gitHash = 'some-hash';
+
+      expect(mockWebSocketServerWebSocketSend).toHaveBeenCalledWith(
+        JSON.stringify(trailingTradeStateInvalidCache)
+      );
     });
   });
 
   describe('with valid cache', () => {
     beforeEach(async () => {
-      process.env.GIT_HASH = 'some-hash';
-
       mockCacheHGetAll = jest.fn().mockImplementation((_key, pattern) => {
         if (pattern === 'trailing-trade-common:*') {
           return trailingTradeCommonJson;

--- a/app/frontend/websocket/handlers/latest.js
+++ b/app/frontend/websocket/handlers/latest.js
@@ -113,59 +113,56 @@ const handleLatest = async (logger, ws, payload) => {
   );
 
   let common = {};
-  try {
-    const accountInfo = JSON.parse(cacheTrailingTradeCommon['account-info']);
-    accountInfo.balances = accountInfo.balances.map(balance => {
-      const quoteEstimate = {
-        quote: null,
-        estimate: null,
-        tickSize: null
-      };
-
-      if (quoteEstimatesGroupedByBaseAsset[balance.asset]) {
-        quoteEstimate.quote =
-          quoteEstimatesGroupedByBaseAsset[balance.asset][0].quoteAsset;
-        quoteEstimate.estimate =
-          quoteEstimatesGroupedByBaseAsset[balance.asset][0].estimatedValue;
-        quoteEstimate.tickSize =
-          quoteEstimatesGroupedByBaseAsset[balance.asset][0].tickSize;
-      }
-
-      return {
-        ...balance,
-        ...quoteEstimate
-      };
-    });
-
-    common = {
-      version,
-      gitHash: process.env.GIT_HASH || 'unspecified',
-      accountInfo,
-      apiInfo: binance.client.getInfo(),
-      closedTradesSetting: JSON.parse(
-        cacheTrailingTradeCommon['closed-trades'] || '{}'
-      ),
-      orderStats: {
-        numberOfOpenTrades: parseInt(
-          cacheTrailingTradeCommon['number-of-open-trades'],
-          10
-        ),
-        numberOfBuyOpenOrders: parseInt(
-          cacheTrailingTradeCommon['number-of-buy-open-orders'],
-          10
-        )
-      },
-      closedTrades: cacheTrailingTradeClosedTrades,
-      totalProfitAndLoss: cacheTrailingTradeTotalProfitAndLoss,
-      streamsCount,
-      monitoringSymbolsCount,
-      cachedMonitoringSymbolsCount,
-      totalPages
+  const accountInfo = JSON.parse(
+    cacheTrailingTradeCommon['account-info'] || '{}'
+  );
+  accountInfo.balances = (accountInfo.balances || []).map(balance => {
+    const quoteEstimate = {
+      quote: null,
+      estimate: null,
+      tickSize: null
     };
-  } catch (err) {
-    logger.error({ err }, 'Something wrong with trailing-trade-common cache');
-    return;
-  }
+
+    if (quoteEstimatesGroupedByBaseAsset[balance.asset]) {
+      quoteEstimate.quote =
+        quoteEstimatesGroupedByBaseAsset[balance.asset][0].quoteAsset;
+      quoteEstimate.estimate =
+        quoteEstimatesGroupedByBaseAsset[balance.asset][0].estimatedValue;
+      quoteEstimate.tickSize =
+        quoteEstimatesGroupedByBaseAsset[balance.asset][0].tickSize;
+    }
+
+    return {
+      ...balance,
+      ...quoteEstimate
+    };
+  });
+
+  common = {
+    version,
+    gitHash: process.env.GIT_HASH || 'unspecified',
+    accountInfo,
+    apiInfo: binance.client.getInfo(),
+    closedTradesSetting: JSON.parse(
+      cacheTrailingTradeCommon['closed-trades'] || '{}'
+    ),
+    orderStats: {
+      numberOfOpenTrades: parseInt(
+        cacheTrailingTradeCommon['number-of-open-trades'],
+        10
+      ),
+      numberOfBuyOpenOrders: parseInt(
+        cacheTrailingTradeCommon['number-of-buy-open-orders'],
+        10
+      )
+    },
+    closedTrades: cacheTrailingTradeClosedTrades,
+    totalProfitAndLoss: cacheTrailingTradeTotalProfitAndLoss,
+    streamsCount,
+    monitoringSymbolsCount,
+    cachedMonitoringSymbolsCount,
+    totalPages
+  };
 
   logger.info(
     {

--- a/public/index.html
+++ b/public/index.html
@@ -180,6 +180,7 @@
     <script type="text/babel" src="./js/LockIcon.js"></script>
     <script type="text/babel" src="./js/UnlockIcon.js"></script>
     <script type="text/babel" src="./js/Header.js"></script>
+    <script type="text/babel" src="./js/APIError.js"></script>
     <script type="text/babel" src="./js/LockScreen.js"></script>
     <script type="text/babel" src="./js/AppSorting.js"></script>
     <script type="text/babel" src="./js/AppLoading.js"></script>

--- a/public/js/APIError.js
+++ b/public/js/APIError.js
@@ -56,6 +56,10 @@ class APIError extends React.Component {
                 rel='noreferrer'>
                 https://github.com/chrisleekr/binance-trading-bot/wiki/Install#how-to-install
               </a>
+              <br />
+              <br />
+              If the issue persists after confirming the API key/secret, please
+              open a new issue in Github.
             </p>
           </div>
         </div>

--- a/public/js/APIError.js
+++ b/public/js/APIError.js
@@ -1,0 +1,65 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/jsx-no-undef */
+/* eslint-disable no-undef */
+class APIError extends React.Component {
+  componentDidMount() {
+    document.body.classList.add('app-locked');
+  }
+
+  componentWillUnmount() {
+    document.body.classList.remove('app-locked');
+  }
+
+  render() {
+    return (
+      <div className='app-lock-screen flex-column d-flex h-100 justify-content-center align-content-center'>
+        <div className='lock-screen-wrapper d-flex flex-column justify-content-center'>
+          <h1 className='app-h1 my-2 mb-3 text-center'>
+            <img
+              src='./img/binance.png'
+              className='binance-img'
+              alt='Binance logo'
+            />{' '}
+            Binance Trading Bot
+          </h1>
+
+          <h3 className='text-danger'>
+            Failed to load your account information.
+          </h3>
+
+          <div className='text-left'>
+            <p>
+              You are seeing this error message because of one of the following
+              situations:
+              <br />
+              <ul>
+                <li>You are using TestNet API/Secret for Live Binance.</li>
+                <li>You are using Live API/Secret for TestNet Binance.</li>
+                <li>Your API key is revoked/deleted.</li>
+                <li>
+                  Your API key is not permitted to "Enable Reading" and "Enable
+                  Spot & Margin Trading".
+                </li>
+                <li>
+                  Your API key is restricted to trusted IP, and your bot is
+                  located not in trusted IP.
+                </li>
+              </ul>
+            </p>
+            <p>
+              Please read the following document carefully, update your
+              configuration. And then try to launch the bot again.
+              <br />
+              <a
+                href='https://github.com/chrisleekr/binance-trading-bot/wiki/Install#how-to-install'
+                target='_blank'
+                rel='noreferrer'>
+                https://github.com/chrisleekr/binance-trading-bot/wiki/Install#how-to-install
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/public/js/App.js
+++ b/public/js/App.js
@@ -268,6 +268,22 @@ class App extends React.Component {
     };
   }
 
+  isAccountLoaded() {
+    const { isLoaded, accountInfo } = this.state;
+
+    return isLoaded === true && _.get(accountInfo, 'accountType') === 'SPOT';
+  }
+
+  isLocked() {
+    const { isAuthenticated, botOptions, isLoaded } = this.state;
+
+    return (
+      isLoaded === true &&
+      isAuthenticated === false &&
+      _.get(botOptions, ['authentication', 'lockList'], true) === true
+    );
+  }
+
   sendWebSocket(command, data = {}) {
     const { instance, connected } = this.state.webSocket;
 
@@ -347,7 +363,6 @@ class App extends React.Component {
       selectedSortOption,
       searchKeyword,
       isAuthenticated,
-      botOptions,
       isLoaded,
       totalProfitAndLoss,
       page,
@@ -358,11 +373,11 @@ class App extends React.Component {
       return <AppLoading />;
     }
 
-    if (
-      isLoaded === true &&
-      isAuthenticated === false &&
-      _.get(botOptions, ['authentication', 'lockList'], true) === true
-    ) {
+    if (this.isAccountLoaded() === false) {
+      return <APIError />;
+    }
+
+    if (this.isLocked()) {
       return <LockScreen />;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

There have been several issues opened that the bot is stuck at loading. 99% of this issue is caused by using a wrong API key. 

To provide more information, I've updated the front end to display an error message when the bot can't get account information.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#538 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As description.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/5715919/204785977-62c63e3a-e41b-4eb8-b8f4-9188f891cc32.png)
