### PR TITLE
feat: hide temporarily disabled trading coins from the dashboard

### DIFF
--- a/public/js/App.js
+++ b/public/js/App.js
@@ -486,7 +486,10 @@ class App extends React.Component {
                 sendWebSocket={this.sendWebSocket}
                 totalProfitAndLoss={totalProfitAndLoss}
               />
-              <OrderStats orderStats={orderStats} />
+              <OrderStats
+                  orderStats={orderStats}
+                  selectedSortOption={selectedSortOption}
+              />
             </div>
             <Pagination>{paginationItems}</Pagination>
             <div className='coin-wrappers'>{coinWrappers}</div>

--- a/public/js/App.js
+++ b/public/js/App.js
@@ -48,7 +48,8 @@ class App extends React.Component {
       ],
       selectedSortOption: {
         sortBy: 'default',
-        sortByDesc: false
+        sortByDesc: false,
+        hideInactive: false,
       },
       searchKeyword: '',
       isLoaded: false,
@@ -136,7 +137,8 @@ class App extends React.Component {
       page: this.state.page,
       searchKeyword: this.state.searchKeyword,
       sortBy: this.state.selectedSortOption.sortBy,
-      sortByDesc: this.state.selectedSortOption.sortByDesc
+      sortByDesc: this.state.selectedSortOption.sortByDesc,
+      hideInactive: this.state.selectedSortOption.hideInactive,
     });
   }
 
@@ -316,7 +318,8 @@ class App extends React.Component {
   componentDidMount() {
     let selectedSortOption = {
       sortBy: 'default',
-      sortByDesc: false
+      sortByDesc: false,
+      hideInactive: false,
     };
 
     try {
@@ -324,7 +327,8 @@ class App extends React.Component {
         localStorage.getItem('selectedSortOption')
       ) || {
         sortBy: 'default',
-        sortByDesc: false
+        sortByDesc: false,
+        hideInactive: false,
       };
     } catch (e) {}
 
@@ -381,7 +385,11 @@ class App extends React.Component {
       return <LockScreen />;
     }
 
-    const coinWrappers = symbols.map((symbol, index) => {
+    const activeSymbols = (selectedSortOption.hideInactive) ?
+        symbols.filter( s => s.symbolConfiguration.buy.enabled || s.symbolConfiguration.sell.enabled )
+        : symbols
+
+    const coinWrappers = activeSymbols.map((symbol, index) => {
       return (
         <CoinWrapper
           extraClassName={

--- a/public/js/FilterIcon.js
+++ b/public/js/FilterIcon.js
@@ -13,14 +13,16 @@ class FilterIcon extends React.Component {
       showFilterModal: false,
       selectedSortOption: {
         sortBy: 'default',
-        sortByDesc: false
+        sortByDesc: false,
+        hideInactive: false
       },
-      searchKeyword: ''
+      searchKeyword: '',
     };
 
     this.handleModalShow = this.handleModalShow.bind(this);
     this.handleModalClose = this.handleModalClose.bind(this);
     this.setSortOption = this.setSortOption.bind(this);
+    this.setHideOption = this.setHideOption.bind(this);
     this.setSearchKeyword = this.setSearchKeyword.bind(this);
     this.handleApply = this.handleApply.bind(this);
   }
@@ -67,13 +69,28 @@ class FilterIcon extends React.Component {
     });
   }
 
-  setSortOption(newSortOption) {
+  setHideOption(newHideOption) {
+    const newSortOption = {
+      ...this.state.selectedSortOption,  hideInactive: newHideOption.target.checked
+    }
+
     this.setState({
       selectedSortOption: newSortOption
     });
     this.props.setSortOption(newSortOption);
     // Save to local storage
     localStorage.setItem('selectedSortOption', JSON.stringify(newSortOption));
+  }
+
+  setSortOption(newSortOption) {
+    const mergedSortOption = {...newSortOption, hideInactive:this.state.selectedSortOption.hideInactive}
+
+    this.setState({
+      selectedSortOption: mergedSortOption
+    });
+    this.props.setSortOption(mergedSortOption);
+    // Save to local storage
+    localStorage.setItem('selectedSortOption', JSON.stringify(mergedSortOption));
   }
 
   setSearchKeyword(event) {
@@ -98,6 +115,8 @@ class FilterIcon extends React.Component {
     }
 
     const { selectedSortOption, searchKeyword } = this.state;
+
+    const { hideInactive } = selectedSortOption;
 
     const sortingOptionWrappers = availableSortOptions.map((option, index) => {
       return (
@@ -176,6 +195,41 @@ class FilterIcon extends React.Component {
                 <Accordion.Collapse eventKey='0'>
                   <Card.Body className='px-2 py-1'>
                     <div className='row'>{sortingOptionWrappers} </div>
+                    <Form.Group
+                        controlId='field-hide-inactive-enabled'
+                        className='mb-2'>
+                      <Form.Check size='sm'>
+                        <Form.Check.Input
+                            type='checkbox'
+                            data-state-key='hide-inactive.enabled'
+                            checked={hideInactive ? 1 : 0}
+                            onChange={this.setHideOption}
+                        />
+                        <Form.Check.Label>
+                          Hide temporarily disabled symbols{' '}
+                          <OverlayTrigger
+                              trigger='click'
+                              key='hide-inactive.enabled'
+                              placement='bottom'
+                              overlay={
+                                <Popover id='hide-inactive.enabled-right'>
+                                  <Popover.Content>
+                                    If enabled, the dashboard won't show coins
+                                    for which buy and sell tradings are both
+                                    temporarily disabled, but are still
+                                    been monitored.
+                                  </Popover.Content>
+                                </Popover>
+                              }>
+                            <Button
+                                variant='link'
+                                className='p-0 m-0 ml-1 text-info'>
+                              <i className='fas fa-question-circle fa-sm'></i>
+                            </Button>
+                          </OverlayTrigger>
+                        </Form.Check.Label>
+                      </Form.Check>
+                    </Form.Group>
                   </Card.Body>
                 </Accordion.Collapse>
               </Card>

--- a/public/js/OrderStats.js
+++ b/public/js/OrderStats.js
@@ -3,7 +3,8 @@
 /* eslint-disable no-undef */
 class OrderStats extends React.Component {
   render() {
-    const { orderStats } = this.props;
+
+    const { orderStats, selectedSortOption } = this.props;
 
     if (_.isEmpty(orderStats)) {
       return '';
@@ -23,6 +24,13 @@ class OrderStats extends React.Component {
             {orderStats.numberOfOpenTrades}
           </span>
         </div>
+        {(selectedSortOption.hideInactive) ? (
+          <div className='order-stat-wrapper'>
+            <span className='order-stat-label'>Some coins are hidden</span>
+          </div>
+        ) : (
+         ''
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Description

The feature allows the user to hide coins for which buy and sell tradings have been disabled, removing the clutter from the  dashboard.

## Motivation and Context

When I manage many coins, I often struggle to easily access active coins in the dashboard despite the existing sorting options. Hiding disabled coins is a way to improve the usability. This PR extends the `selectedSortOption` object with a new  `hideInactive` attribute.

2 UX features have been implemented:
- Hide inactive trades checkbox in the Sorting popup (FilterIcons.js)
- Add a label in the trading status bar (App.js) to remind inactive coins are hidden

## How Has This Been Tested?

It is working on my setup.

## Screenshots (if appropriate):
<img width="506" alt="Screenshot 2022-12-05 at 20 56 05" src="https://user-images.githubusercontent.com/1491835/205731780-a9331137-b819-4539-a26b-ba99656cf6d7.png">

<img width="692" alt="Screenshot 2022-12-05 at 21 20 14" src="https://user-images.githubusercontent.com/1491835/205735820-4f879fa0-d8c2-423b-a76d-df5b762f0f45.png">


