### PR TITLE
fix: hide calculator for partially executed sells

### DIFF
--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -366,11 +366,13 @@ class CoinWrapperBuySignal extends React.Component {
 
       const nextGridAmount = nextGridQty * currentPrice;
 
-      const executedGrids = gridTrade.filter(trade => trade.executed).length;
+      const executedBuyGrids = gridTrade.filter(trade => trade.executed).length;
 
-      const hasManualTrade = currentGridTradeIndex !== executedGrids;
+      const hasManualTrade = currentGridTradeIndex !== executedBuyGrids;
 
-      return (nextGridAmount > 0) & !hasManualTrade ? (
+      const isSingleSellGrid = symbolConfiguration.sell.currentGridTradeIndex >=0 & sellGridTrade.length == 1;
+
+      return (nextGridAmount > 0) & !hasManualTrade & isSingleSellGrid ? (
         <React.Fragment key={'coin-wrapper-buy-next-grid-row-' + symbol}>
           <div className='coin-info-column coin-info-column-price'>
             <span className='coin-info-label'>


### PR DESCRIPTION
## Description

I came across an unforeseen grid situation that breaks the calculator introduced in PR #554. 

In the example below, the grid got partially executed, leaving the symbolConfiguration to an undefined `symbolConfiguration.sell.gridTrade`. 
![partial](https://user-images.githubusercontent.com/1491835/208640932-1d767927-2bdf-439b-83bc-f794b597b395.png)

This bug fix hides the calculator for partially executed sell grids.

## How Has This Been Tested?

Running on my production server.

