### PR TITLE
fix: api error page

### DIFF
--- a/public/js/App.js
+++ b/public/js/App.js
@@ -377,12 +377,12 @@ class App extends React.Component {
       return <AppLoading />;
     }
 
-    if (this.isAccountLoaded() === false) {
-      return <APIError />;
-    }
-
     if (this.isLocked()) {
       return <LockScreen />;
+    }
+
+    if (this.isAccountLoaded() === false) {
+      return <APIError />;
     }
 
     const activeSymbols = selectedSortOption.hideInactive

--- a/public/js/App.js
+++ b/public/js/App.js
@@ -49,7 +49,7 @@ class App extends React.Component {
       selectedSortOption: {
         sortBy: 'default',
         sortByDesc: false,
-        hideInactive: false,
+        hideInactive: false
       },
       searchKeyword: '',
       isLoaded: false,
@@ -138,7 +138,7 @@ class App extends React.Component {
       searchKeyword: this.state.searchKeyword,
       sortBy: this.state.selectedSortOption.sortBy,
       sortByDesc: this.state.selectedSortOption.sortByDesc,
-      hideInactive: this.state.selectedSortOption.hideInactive,
+      hideInactive: this.state.selectedSortOption.hideInactive
     });
   }
 
@@ -319,7 +319,7 @@ class App extends React.Component {
     let selectedSortOption = {
       sortBy: 'default',
       sortByDesc: false,
-      hideInactive: false,
+      hideInactive: false
     };
 
     try {
@@ -328,7 +328,7 @@ class App extends React.Component {
       ) || {
         sortBy: 'default',
         sortByDesc: false,
-        hideInactive: false,
+        hideInactive: false
       };
     } catch (e) {}
 
@@ -385,9 +385,13 @@ class App extends React.Component {
       return <LockScreen />;
     }
 
-    const activeSymbols = (selectedSortOption.hideInactive) ?
-        symbols.filter( s => s.symbolConfiguration.buy.enabled || s.symbolConfiguration.sell.enabled )
-        : symbols
+    const activeSymbols = selectedSortOption.hideInactive
+      ? symbols.filter(
+          s =>
+            s.symbolConfiguration.buy.enabled ||
+            s.symbolConfiguration.sell.enabled
+        )
+      : symbols;
 
     const coinWrappers = activeSymbols.map((symbol, index) => {
       return (
@@ -487,8 +491,8 @@ class App extends React.Component {
                 totalProfitAndLoss={totalProfitAndLoss}
               />
               <OrderStats
-                  orderStats={orderStats}
-                  selectedSortOption={selectedSortOption}
+                orderStats={orderStats}
+                selectedSortOption={selectedSortOption}
               />
             </div>
             <Pagination>{paginationItems}</Pagination>


### PR DESCRIPTION
## Description

Before this PR, if we click on the 🔒 icon on the top right of the screen, the API error page will be shown instead of the lock screen even If I have the correct API credentials.

<img src='https://user-images.githubusercontent.com/31035020/208716806-d557cbe5-3454-433c-adf0-15a62ff940b6.png' width='400'>
<img src='https://user-images.githubusercontent.com/31035020/208716567-3fdc30f3-bc48-4e48-ab35-8bdc7f01fc05.png' width='400'>

To solve this, I only give the condition of the lock screen more priority than the API error page. 
The rest changes only for linting.

## Related Issue

Not applicable.

## Motivation and Context

## How Has This Been Tested?

Manually clicking on the 🔒 icon will redirect you to the lock screen instead of the condition of API error page

## Screenshots (if appropriate):

Not applicable.