### PR TITLE
fix: next-buy-grid missing for completed buy grids

### DIFF
--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -366,11 +366,15 @@ class CoinWrapperBuySignal extends React.Component {
 
       const nextGridAmount = nextGridQty * currentPrice;
 
-      const executedBuyGrids = gridTrade.filter(trade => trade.executed).length;
+      const firstNonExecutedTradeIndex = gridTrade.findIndex(
+        trade => trade.executed === false
+      );
 
-      const hasManualTrade = currentGridTradeIndex !== executedBuyGrids;
+      const hasManualTrade = firstNonExecutedTradeIndex < currentGridTradeIndex;
 
-      const isSingleSellGrid = symbolConfiguration.sell.currentGridTradeIndex >=0 & sellGridTrade.length == 1;
+      const isSingleSellGrid =
+        (symbolConfiguration.sell.currentGridTradeIndex >= 0) &
+        (sellGridTrade.length === 1);
 
       return (nextGridAmount > 0) & !hasManualTrade & isSingleSellGrid ? (
         <React.Fragment key={'coin-wrapper-buy-next-grid-row-' + symbol}>


### PR DESCRIPTION
## Description

The suggested breakeven section of PR #554 is not shown if the buy grid is completed. This PR properly handles the distinction between manual trades (that are currently not supported by the next-buy-grid feature) and buy grids that have all grid trades completed.

## How Has This Been Tested?

Issue detected on my production server and fix now working.

## Screenshots (if appropriate):
Exemple of grid state that would be missing the breakeven section if this fix is not applied:

<img width="355" alt="Screenshot 2022-12-22 at 19 25 24" src="https://user-images.githubusercontent.com/1491835/209202295-0e5b2693-7713-4349-a7a2-25e352f54526.png">


