### PR TITLE
fix: sorting symbols open trades first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fixed sorting symbols open trades first by [@uhliksk](https://github.com/uhliksk) - [#564](https://github.com/chrisleekr/binance-trading-bot/pull/564)
 - Fixed the issue that cannot export huge logs - [#561](https://github.com/chrisleekr/binance-trading-bot/pull/561)
+
+Thanks [@uhliksk](https://github.com/uhliksk) for your great contributions. 💯 :heart:
 
 ## [0.0.96] - 2022-12-28
 
 - Enhanced the suggested break-even amount a grid calculator by [@rando128](https://github.com/rando128) - [#555](https://github.com/chrisleekr/binance-trading-bot/pull/555), [#557](https://github.com/chrisleekr/binance-trading-bot/pull/557)
 - Fixed API error page priority by [@habibalkhabbaz](https://github.com/habibalkhabbaz) - [#556](https://github.com/chrisleekr/binance-trading-bot/pull/556)
 
-Thanks[@rando128](https://github.com/rando128) and [@habibalkhabbaz](https://github.com/habibalkhabbaz) for your great contributions. 💯 :heart:
+Thanks [@rando128](https://github.com/rando128) and [@habibalkhabbaz](https://github.com/habibalkhabbaz) for your great contributions. 💯 :heart:
 
 ## [0.0.95] - 2022-12-19
 

--- a/app/cronjob/trailingTradeHelper/__tests__/common.test.js
+++ b/app/cronjob/trailingTradeHelper/__tests__/common.test.js
@@ -2935,7 +2935,7 @@ describe('common.js', () => {
             if: {
               $eq: ['$buy.difference', null]
             },
-            then: '$symbol',
+            then: -Infinity,
             else: '$buy.difference'
           }
         }
@@ -2951,7 +2951,7 @@ describe('common.js', () => {
             if: {
               $eq: ['$buy.difference', null]
             },
-            then: '$symbol',
+            then: Infinity,
             else: '$buy.difference'
           }
         }
@@ -2967,7 +2967,7 @@ describe('common.js', () => {
             if: {
               $eq: ['$sell.currentProfitPercentage', null]
             },
-            then: '$symbol',
+            then: Infinity,
             else: '$sell.currentProfitPercentage'
           }
         }
@@ -2983,7 +2983,7 @@ describe('common.js', () => {
             if: {
               $eq: ['$sell.currentProfitPercentage', null]
             },
-            then: '$symbol',
+            then: -Infinity,
             else: '$sell.currentProfitPercentage'
           }
         }
@@ -3059,7 +3059,7 @@ describe('common.js', () => {
                   sortField: t.sortField
                 }
               },
-              { $sort: { sortField: t.sortByDesc ? -1 : 1 } },
+              { $sort: { sortField: t.sortByDesc ? -1 : 1, symbol: 1 } },
               { $skip: (pageNum - 1) * 10 },
               { $limit: 10 }
             ]

--- a/app/cronjob/trailingTradeHelper/common.js
+++ b/app/cronjob/trailingTradeHelper/common.js
@@ -979,7 +979,7 @@ const getCacheTrailingTradeSymbols = async (
         if: {
           $eq: ['$buy.difference', null]
         },
-        then: '$symbol',
+        then: sortByDesc ? -Infinity : Infinity,
         else: '$buy.difference'
       }
     };
@@ -991,7 +991,7 @@ const getCacheTrailingTradeSymbols = async (
         if: {
           $eq: ['$sell.currentProfitPercentage', null]
         },
-        then: '$symbol',
+        then: sortByDesc ? -Infinity : Infinity,
         else: '$sell.currentProfitPercentage'
       }
     };
@@ -1020,7 +1020,7 @@ const getCacheTrailingTradeSymbols = async (
         sortField
       }
     },
-    { $sort: { sortField: sortDirection } },
+    { $sort: { sortField: sortDirection, symbol: 1 } },
     { $skip: (pageNum - 1) * symbolsPerPage },
     { $limit: symbolsPerPage }
   ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fix sorting of symbols to put open trades at the beginning of list. After #496 open trades were at the end of list when descending order is selected which broke previous correct behavior.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#491 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
