### PR TITLE
fix: cancel orders when current price is over order price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Fixed sorting symbols open trades first by [@uhliksk](https://github.com/uhliksk) - [#564](https://github.com/chrisleekr/binance-trading-bot/pull/564)
 - Fixed the issue that cannot export huge logs - [#561](https://github.com/chrisleekr/binance-trading-bot/pull/561), [#567](https://github.com/chrisleekr/binance-trading-bot/pull/567)
 - Fixed the balance calculation to include dust balances by [@uhliksk](https://github.com/uhliksk) - [#571](https://github.com/chrisleekr/binance-trading-bot/pull/571)
+- Fixed the open orders to be cancelled when the current price is higher/lower than the order price  by [@uhliksk](https://github.com/uhliksk) - [#569](https://github.com/chrisleekr/binance-trading-bot/pull/569)
 
 Thanks [@uhliksk](https://github.com/uhliksk) for your great contributions. 💯 :heart:
 

--- a/app/cronjob/trailingTrade/step/__tests__/handle-open-orders.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/handle-open-orders.test.js
@@ -518,7 +518,7 @@ describe('handle-open-orders.js', () => {
         });
       });
 
-      describe('when stop price is higher or equal than current limit price', () => {
+      describe('when stop price is higher than current limit price', () => {
         describe('when cancelling order is failed', () => {
           beforeEach(async () => {
             slackMock.sendMessage = jest.fn().mockResolvedValue(true);
@@ -770,6 +770,258 @@ describe('handle-open-orders.js', () => {
         });
       });
 
+      describe('when the current price higher than buy order price', () => {
+        describe('when cancelling order is failed', () => {
+          beforeEach(async () => {
+            slackMock.sendMessage = jest.fn().mockResolvedValue(true);
+
+            mockCancelOrder = jest.fn().mockResolvedValue(false);
+
+            jest.mock('../../../trailingTradeHelper/common', () => ({
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
+              saveOverrideAction: mockSaveOverrideAction,
+              isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
+              cancelOrder: mockCancelOrder,
+              refreshOpenOrdersAndAccountInfo:
+                mockRefreshOpenOrdersAndAccountInfo
+            }));
+
+            step = require('../handle-open-orders');
+
+            rawData = {
+              symbol: 'BTCUSDT',
+              isLocked: false,
+              featureToggle: {
+                notifyDebug: false
+              },
+              action: 'not-determined',
+              openOrders: [
+                {
+                  symbol: 'BTCUSDT',
+                  orderId: 46838,
+                  price: '1799.58000000',
+                  stopPrice: '1800.1000',
+                  type: 'STOP_LOSS_LIMIT',
+                  side: 'BUY'
+                }
+              ],
+              buy: {
+                currentPrice: 1810,
+                openOrders: [
+                  {
+                    symbol: 'BTCUSDT',
+                    orderId: 46838,
+                    price: '1799.58000000',
+                    stopPrice: '1800.1000',
+                    type: 'STOP_LOSS_LIMIT',
+                    side: 'BUY'
+                  }
+                ]
+              },
+              sell: {
+                currentPrice: 1810,
+                openOrders: []
+              },
+              symbolInfo: {
+                quoteAsset: 'USDT'
+              }
+            };
+
+            result = await step.execute(loggerMock, rawData);
+          });
+
+          it('triggers cancelOrder', () => {
+            expect(mockCancelOrder).toHaveBeenCalledWith(
+              loggerMock,
+              'BTCUSDT',
+              {
+                orderId: 46838,
+                price: '1799.58000000',
+                side: 'BUY',
+                stopPrice: '1800.1000',
+                symbol: 'BTCUSDT',
+                type: 'STOP_LOSS_LIMIT'
+              }
+            );
+          });
+
+          it('triggers refreshOpenOrdersAndAccountInfo', () => {
+            expect(mockRefreshOpenOrdersAndAccountInfo).toHaveBeenCalledWith(
+              loggerMock,
+              'BTCUSDT'
+            );
+          });
+
+          it('does not trigger slack.sendMessage', () => {
+            expect(slackMock.sendMessage).not.toHaveBeenCalled();
+          });
+
+          it('triggers saveOverrideAction', () => {
+            expect(mockSaveOverrideAction).toHaveBeenCalledWith(
+              loggerMock,
+              'BTCUSDT',
+              {
+                action: 'buy',
+                actionAt: expect.any(String),
+                triggeredBy: 'buy-cancelled',
+                notify: false,
+                checkTradingView: true
+              },
+              'The bot will place a buy order in the next tick because could not retrieve the cancelled order result.'
+            );
+          });
+
+          it('does not trigger getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).not.toHaveBeenCalled();
+          });
+
+          it('returns expected value', () => {
+            expect(result).toStrictEqual({
+              symbol: 'BTCUSDT',
+              isLocked: false,
+              featureToggle: {
+                notifyDebug: false
+              },
+              action: 'buy-order-checking',
+              openOrders: [
+                {
+                  openOrders: 'retrieved'
+                }
+              ],
+              buy: {
+                currentPrice: 1810,
+                openOrders: [
+                  {
+                    buyOpenOrders: 'retrived'
+                  }
+                ]
+              },
+              sell: { currentPrice: 1810, openOrders: [] },
+              symbolInfo: {
+                quoteAsset: 'USDT'
+              },
+              accountInfo: {
+                accountInfo: 'updated'
+              }
+            });
+          });
+        });
+
+        describe('when cancelling order is succeed', () => {
+          beforeEach(async () => {
+            jest.mock('../../../trailingTradeHelper/common', () => ({
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
+              saveOverrideAction: mockSaveOverrideAction,
+              isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
+              cancelOrder: mockCancelOrder,
+              refreshOpenOrdersAndAccountInfo:
+                mockRefreshOpenOrdersAndAccountInfo
+            }));
+
+            step = require('../handle-open-orders');
+
+            rawData = {
+              symbol: 'BTCUSDT',
+              isLocked: false,
+              action: 'not-determined',
+              openOrders: [
+                {
+                  symbol: 'BTCUSDT',
+                  orderId: 46838,
+                  origQty: '0.00001',
+                  price: '1799.58000000',
+                  stopPrice: '1800.1000',
+                  type: 'STOP_LOSS_LIMIT',
+                  side: 'BUY'
+                }
+              ],
+              buy: {
+                currentPrice: 1810,
+                openOrders: [
+                  {
+                    symbol: 'BTCUSDT',
+                    orderId: 46838,
+                    origQty: '0.00001',
+                    price: '1799.58000000',
+                    stopPrice: '1800.1000',
+                    type: 'STOP_LOSS_LIMIT',
+                    side: 'BUY'
+                  }
+                ]
+              },
+              sell: {
+                currentPrice: 1810,
+                openOrders: []
+              },
+              symbolInfo: {
+                quoteAsset: 'USDT'
+              },
+              quoteAssetBalance: {
+                free: 50,
+                locked: 0.0179958
+              }
+            };
+
+            result = await step.execute(loggerMock, rawData);
+          });
+
+          it('triggers cancelOrder', () => {
+            expect(mockCancelOrder).toHaveBeenCalledWith(
+              loggerMock,
+              'BTCUSDT',
+              {
+                orderId: 46838,
+                origQty: '0.00001',
+                price: '1799.58000000',
+                side: 'BUY',
+                stopPrice: '1800.1000',
+                symbol: 'BTCUSDT',
+                type: 'STOP_LOSS_LIMIT'
+              }
+            );
+          });
+
+          it('does not trigger refreshOpenOrdersAndAccountInfo', () => {
+            expect(mockRefreshOpenOrdersAndAccountInfo).not.toHaveBeenCalled();
+          });
+
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalledWith(loggerMock);
+          });
+
+          it('returns expected value', () => {
+            expect(result).toStrictEqual({
+              symbol: 'BTCUSDT',
+              isLocked: false,
+              action: 'buy',
+              openOrders: [
+                {
+                  symbol: 'BTCUSDT',
+                  orderId: 46838,
+                  origQty: '0.00001',
+                  price: '1799.58000000',
+                  stopPrice: '1800.1000',
+                  type: 'STOP_LOSS_LIMIT',
+                  side: 'BUY'
+                }
+              ],
+              buy: { currentPrice: 1810, openOrders: [] },
+              sell: { currentPrice: 1810, openOrders: [] },
+              symbolInfo: {
+                quoteAsset: 'USDT'
+              },
+              quoteAssetBalance: {
+                free: 50,
+                locked: 0.0179958
+              },
+              accountInfo: {
+                account: 'updated'
+              }
+            });
+          });
+        });
+      });
+
       describe('when order trade limit is not reached and stop price is less than current limit price', () => {
         beforeEach(async () => {
           mockIsExceedingMaxOpenTrades = jest.fn().mockResolvedValue(false);
@@ -869,7 +1121,7 @@ describe('handle-open-orders.js', () => {
     });
 
     describe('when order is sell', () => {
-      describe('when stop price is less or equal than current limit price', () => {
+      describe('when stop price is less than current limit price', () => {
         describe('when cancel order is failed', () => {
           beforeEach(async () => {
             slackMock.sendMessage = jest.fn().mockResolvedValue(true);
@@ -1087,6 +1339,240 @@ describe('handle-open-orders.js', () => {
               ],
               buy: { limitPrice: 1800, openOrders: [] },
               sell: { limitPrice: 1801, openOrders: [] },
+              symbolInfo: {
+                baseAsset: 'BTC',
+                quoteAsset: 'USDT'
+              },
+              baseAssetBalance: {
+                free: 0,
+                locked: 0.00001
+              },
+              accountInfo: {
+                account: 'updated'
+              }
+            });
+          });
+        });
+      });
+
+      describe('when the current price less than sell order price', () => {
+        describe('when cancel order is failed', () => {
+          beforeEach(async () => {
+            slackMock.sendMessage = jest.fn().mockResolvedValue(true);
+
+            mockCancelOrder = jest.fn().mockResolvedValue(false);
+
+            jest.mock('../../../trailingTradeHelper/common', () => ({
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
+              saveOverrideAction: mockSaveOverrideAction,
+              isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
+              cancelOrder: mockCancelOrder,
+              refreshOpenOrdersAndAccountInfo:
+                mockRefreshOpenOrdersAndAccountInfo
+            }));
+            step = require('../handle-open-orders');
+
+            rawData = {
+              symbol: 'BTCUSDT',
+              isLocked: false,
+              featureToggle: {
+                notifyDebug: false
+              },
+              action: 'not-determined',
+              openOrders: [
+                {
+                  symbol: 'BTCUSDT',
+                  orderId: 46838,
+                  price: '1799.58000000',
+                  stopPrice: '1800.1000',
+                  type: 'STOP_LOSS_LIMIT',
+                  side: 'SELL'
+                }
+              ],
+              buy: {
+                currentPrice: 1799,
+                openOrders: []
+              },
+              sell: {
+                currentPrice: 1799,
+                openOrders: [
+                  {
+                    symbol: 'BTCUSDT',
+                    orderId: 46838,
+                    price: '1799.58000000',
+                    stopPrice: '1800.1000',
+                    type: 'STOP_LOSS_LIMIT',
+                    side: 'SELL'
+                  }
+                ]
+              },
+              symbolInfo: {
+                quoteAsset: 'USDT'
+              }
+            };
+
+            result = await step.execute(loggerMock, rawData);
+          });
+
+          it('triggers cancelOrder', () => {
+            expect(mockCancelOrder).toHaveBeenCalledWith(
+              loggerMock,
+              'BTCUSDT',
+              {
+                orderId: 46838,
+                price: '1799.58000000',
+                side: 'SELL',
+                stopPrice: '1800.1000',
+                symbol: 'BTCUSDT',
+                type: 'STOP_LOSS_LIMIT'
+              }
+            );
+          });
+
+          it('triggers refreshOpenOrdersAndAccountInfo', () => {
+            expect(mockRefreshOpenOrdersAndAccountInfo).toHaveBeenCalledWith(
+              loggerMock,
+              'BTCUSDT'
+            );
+          });
+
+          it('does not trigger slack.sendMessage', () => {
+            expect(slackMock.sendMessage).not.toHaveBeenCalled();
+          });
+
+          it('returns expected value', () => {
+            expect(result).toStrictEqual({
+              symbol: 'BTCUSDT',
+              isLocked: false,
+              featureToggle: {
+                notifyDebug: false
+              },
+              action: 'sell-order-checking',
+              openOrders: [
+                {
+                  openOrders: 'retrieved'
+                }
+              ],
+              buy: { currentPrice: 1799, openOrders: [] },
+              sell: {
+                currentPrice: 1799,
+                openOrders: [
+                  {
+                    sellOpenOrders: 'retrived'
+                  }
+                ]
+              },
+              symbolInfo: {
+                quoteAsset: 'USDT'
+              },
+              accountInfo: {
+                accountInfo: 'updated'
+              }
+            });
+          });
+        });
+
+        describe('when cancel order is succeed', () => {
+          beforeEach(async () => {
+            jest.mock('../../../trailingTradeHelper/common', () => ({
+              getAccountInfoFromAPI: mockGetAccountInfoFromAPI,
+              saveOverrideAction: mockSaveOverrideAction,
+              isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades,
+              cancelOrder: mockCancelOrder,
+              refreshOpenOrdersAndAccountInfo:
+                mockRefreshOpenOrdersAndAccountInfo
+            }));
+
+            step = require('../handle-open-orders');
+
+            rawData = {
+              symbol: 'BTCUSDT',
+              isLocked: false,
+              action: 'not-determined',
+              openOrders: [
+                {
+                  symbol: 'BTCUSDT',
+                  orderId: 46838,
+                  origQty: '0.00001',
+                  price: '1799.58000000',
+                  stopPrice: '1800.1000',
+                  type: 'STOP_LOSS_LIMIT',
+                  side: 'SELL'
+                }
+              ],
+              buy: {
+                currentPrice: 1799,
+                openOrders: []
+              },
+              sell: {
+                currentPrice: 1799,
+                openOrders: [
+                  {
+                    symbol: 'BTCUSDT',
+                    orderId: 46838,
+                    origQty: '0.00001',
+                    price: '1799.58000000',
+                    stopPrice: '1800.1000',
+                    type: 'STOP_LOSS_LIMIT',
+                    side: 'SELL'
+                  }
+                ]
+              },
+              symbolInfo: {
+                baseAsset: 'BTC',
+                quoteAsset: 'USDT'
+              },
+              baseAssetBalance: {
+                free: 0,
+                locked: 0.00001
+              }
+            };
+
+            result = await step.execute(loggerMock, rawData);
+          });
+
+          it('triggers cancelOrder', () => {
+            expect(mockCancelOrder).toHaveBeenCalledWith(
+              loggerMock,
+              'BTCUSDT',
+              {
+                orderId: 46838,
+                origQty: '0.00001',
+                price: '1799.58000000',
+                side: 'SELL',
+                stopPrice: '1800.1000',
+                symbol: 'BTCUSDT',
+                type: 'STOP_LOSS_LIMIT'
+              }
+            );
+          });
+
+          it('does not trigger refreshOpenOrdersAndAccountInfo', () => {
+            expect(mockRefreshOpenOrdersAndAccountInfo).not.toHaveBeenCalled();
+          });
+
+          it('triggers getAccountInfoFromAPI', () => {
+            expect(mockGetAccountInfoFromAPI).toHaveBeenCalledWith(loggerMock);
+          });
+
+          it('returns expected value', () => {
+            expect(result).toStrictEqual({
+              symbol: 'BTCUSDT',
+              isLocked: false,
+              action: 'sell',
+              openOrders: [
+                {
+                  symbol: 'BTCUSDT',
+                  orderId: 46838,
+                  origQty: '0.00001',
+                  price: '1799.58000000',
+                  stopPrice: '1800.1000',
+                  type: 'STOP_LOSS_LIMIT',
+                  side: 'SELL'
+                }
+              ],
+              buy: { currentPrice: 1799, openOrders: [] },
+              sell: { currentPrice: 1799, openOrders: [] },
               symbolInfo: {
                 baseAsset: 'BTC',
                 quoteAsset: 'USDT'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Cancel order when current price is over order price.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#566 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Sometimes the market is very volatile which can cause while buy order is put the price will raise so much the buy order is not executed and stay there until price is dropped again. This is bad because sell order can't be processed while buy order is active and you can miss opportunity to sell.

Same thing with sell order when market drop rapidly and sell order is not executed then you can miss opportunity to buy low or even to trigger stop-loss because you can't sell when anothern sell order is active.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test provided in __tests__.

## Screenshots (if appropriate):
