### PR TITLE
fix: open trades more accurate asset indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed sorting symbols open trades first by [@uhliksk](https://github.com/uhliksk) - [#564](https://github.com/chrisleekr/binance-trading-bot/pull/564)
 - Fixed the issue that cannot export huge logs - [#561](https://github.com/chrisleekr/binance-trading-bot/pull/561), [#567](https://github.com/chrisleekr/binance-trading-bot/pull/567)
+- Fixed the balance calculation to include dust balances by [@uhliksk](https://github.com/uhliksk) - [#571](https://github.com/chrisleekr/binance-trading-bot/pull/571)
 
 Thanks [@uhliksk](https://github.com/uhliksk) for your great contributions. 💯 :heart:
 

--- a/public/js/ProfitLossWrapper.js
+++ b/public/js/ProfitLossWrapper.js
@@ -125,9 +125,14 @@ class ProfitLossWrapper extends React.Component {
             : 0;
 
         const quoteAssetTotal =
-          profitAndLoss.amount + +profitAndLoss.free + +profitAndLoss.locked;
+          profitAndLoss.estimatedBalance -
+          +profitAndLoss.profit +
+          +profitAndLoss.free +
+          +profitAndLoss.locked;
         const openTradesRatio = quoteAssetTotal
-          ? (profitAndLoss.amount / quoteAssetTotal) * 100
+          ? ((profitAndLoss.estimatedBalance - +profitAndLoss.profit) /
+              quoteAssetTotal) *
+            100
           : 0;
 
         return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Dust is counted to see real value of asset even if no trade is open.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#570 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There was inconsistency in value of asset between no open trades and when open trades exists.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by checking value when no trade is open comparing with value when there are open trades.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/37454226/210254433-086a853d-4b31-4c4a-922f-b801de7065ef.png)
