### PR TITLE
fix: regression in queue init

### DIFF
--- a/app/cronjob/trailingTradeHelper/queue.js
+++ b/app/cronjob/trailingTradeHelper/queue.js
@@ -1,8 +1,8 @@
 const _ = require('lodash');
 const { executeTrailingTrade } = require('../index');
 
-let startedJobs = {};
-let finishedJobs = {};
+const startedJobs = {};
+const finishedJobs = {};
 
 /**
  * Initialize queue counters for symbols
@@ -13,13 +13,12 @@ let finishedJobs = {};
 const init = async (funcLogger, symbols) => {
   const logger = funcLogger.child({ helper: 'queue' });
 
-  startedJobs = {};
-  finishedJobs = {};
-
   await Promise.all(
     _.map(symbols, async symbol => {
-      startedJobs[symbol] = 0;
-      finishedJobs[symbol] = 0;
+      if (startedJobs[symbol] === undefined) {
+        startedJobs[symbol] = 0;
+        finishedJobs[symbol] = 0;
+      }
     })
   );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fix regression in queue init. Queue have to be initialized once only to prevent unexpected result of resetting queue counters while existing queue is still running.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Issue mentioned in #562.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Urgent patch before new version is released.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Passed the tests.

## Screenshots (if appropriate):
