### PR TITLE
fix: stop loss with highest priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the open orders to be cancelled when the current price is higher/lower than the order price by [@uhliksk](https://github.com/uhliksk) - [#569](https://github.com/chrisleekr/binance-trading-bot/pull/569)
 - Improved queue processing by replacing Bull queue to customised queue system by [@uhliksk](https://github.com/uhliksk) - [#562](https://github.com/chrisleekr/binance-trading-bot/pull/562), [#581](https://github.com/chrisleekr/binance-trading-bot/pull/581), [#588](https://github.com/chrisleekr/binance-trading-bot/pull/588)
 - Added conservative sell strategy, which can reduce the sell trigger price as the grid gets deeper by [@rando128](https://github.com/rando128) - [#585](https://github.com/chrisleekr/binance-trading-bot/pull/585)
+- Fixed the stop-loss to be a higher priority than the new buy order by [@uhliksk](https://github.com/uhliksk) - [#589](https://github.com/chrisleekr/binance-trading-bot/pull/589)
 
 Thanks [@uhliksk](https://github.com/uhliksk) and [@rando128](https://github.com/rando128) for your great contributions. 💯 :heart:
 

--- a/app/cronjob/trailingTrade/step/__tests__/determine-action.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/determine-action.test.js
@@ -1145,6 +1145,111 @@ describe('determine-action.js', () => {
               });
             });
           });
+
+          describe(
+            `isLowerThanStopLossTriggerPrice - sell stop loss is enabled ` +
+              `and when current price is less than stop loss trigger price`,
+            () => {
+              beforeEach(async () => {
+                // Set action is enabled
+                mockIsActionDisabled = jest.fn().mockResolvedValue({
+                  isDisabled: false
+                });
+
+                // Set buy open orders and open trades
+                mockGetNumberOfBuyOpenOrders = jest.fn().mockResolvedValue(3);
+                mockGetNumberOfOpenTrades = jest.fn().mockResolvedValue(5);
+
+                jest.mock('../../../trailingTradeHelper/common', () => ({
+                  isActionDisabled: mockIsActionDisabled,
+                  getNumberOfBuyOpenOrders: mockGetNumberOfBuyOpenOrders,
+                  getNumberOfOpenTrades: mockGetNumberOfOpenTrades,
+                  getAPILimit: mockGetAPILimit,
+                  isExceedingMaxOpenTrades: mockIsExceedingMaxOpenTrades
+                }));
+
+                // Set there is no grid trade order
+                mockGetGridTradeOrder = jest.fn().mockResolvedValue(null);
+
+                jest.mock('../../../trailingTradeHelper/order', () => ({
+                  getGridTradeOrder: mockGetGridTradeOrder
+                }));
+
+                rawData = _.cloneDeep(orgRawData);
+
+                // Set balance less than minimum notional value
+                rawData.baseAssetBalance.total = 0.0003;
+
+                rawData.symbolConfiguration.botOptions.orderLimit = {
+                  enabled: true,
+                  maxBuyOpenOrders: 5,
+                  maxOpenTrades: 10
+                };
+
+                rawData.symbolConfiguration.buy = {
+                  athRestriction: {
+                    enabled: true
+                  },
+                  // Set the current index to 2nd
+                  currentGridTradeIndex: 1,
+                  currentGridTrade: {
+                    triggerPercentage: 1,
+                    stopPercentage: 1.025,
+                    limitPercentage: 1.026,
+                    maxPurchaseAmount: 10,
+                    executed: false,
+                    executedOrder: null
+                  }
+                };
+
+                // Enable sell stop loss
+                rawData.symbolConfiguration.sell.stopLoss = {
+                  enabled: true,
+                  maxLossPercentage: 0.95
+                };
+
+                // Set ATH restriction is higher than the current price
+                rawData.buy = {
+                  currentPrice: 28000,
+                  triggerPrice: 28000,
+                  athRestrictionPrice: 28001
+                };
+
+                // When stop loss trigger price is less than the current price,
+                // then do not try to buy. Let it sell by stop loss.
+                rawData.sell = {
+                  currentPrice: 28000,
+                  triggerPrice: 30900,
+                  lastBuyPrice: 30000,
+                  stopLossTriggerPrice: 28500
+                };
+
+                step = require('../determine-action');
+
+                result = await step.execute(loggerMock, rawData);
+              });
+
+              it('should not determine the action because it should be sold by the stop loss', () => {
+                expect(result).toMatchObject({
+                  action: 'not-determined',
+                  baseAssetBalance: {
+                    total: 0.0003
+                  },
+                  buy: {
+                    currentPrice: 28000,
+                    triggerPrice: 28000,
+                    athRestrictionPrice: 28001
+                  },
+                  sell: {
+                    currentPrice: 28000,
+                    lastBuyPrice: 30000,
+                    triggerPrice: 30900,
+                    stopLossTriggerPrice: 28500
+                  }
+                });
+              });
+            }
+          );
         }
       );
 

--- a/app/cronjob/trailingTrade/step/__tests__/handle-open-orders.test.js
+++ b/app/cronjob/trailingTrade/step/__tests__/handle-open-orders.test.js
@@ -615,7 +615,7 @@ describe('handle-open-orders.js', () => {
           it('returns expected value', () => {
             expect(result).toStrictEqual({
               symbol: 'BTCUSDT',
-              action: 'buy',
+              action: 'buy-order-cancelled',
               openOrders: [
                 {
                   symbol: 'BTCUSDT',
@@ -846,7 +846,7 @@ describe('handle-open-orders.js', () => {
           it('returns expected value', () => {
             expect(result).toStrictEqual({
               symbol: 'BTCUSDT',
-              action: 'buy',
+              action: 'buy-order-cancelled',
               openOrders: [
                 {
                   symbol: 'BTCUSDT',

--- a/app/cronjob/trailingTrade/step/determine-action.js
+++ b/app/cronjob/trailingTrade/step/determine-action.js
@@ -11,6 +11,30 @@ const {
 const { getGridTradeOrder } = require('../../trailingTradeHelper/order');
 
 /**
+ * Check whether current price is lower or equal than stop loss trigger price
+ *
+ * @param {*} data
+ * @returns
+ */
+const isLowerThanStopLossTriggerPrice = data => {
+  const {
+    symbolConfiguration: {
+      sell: {
+        stopLoss: { enabled: sellStopLossEnabled }
+      }
+    },
+    sell: {
+      currentPrice: sellCurrentPrice,
+      stopLossTriggerPrice: sellStopLossTriggerPrice
+    }
+  } = data;
+
+  return (
+    sellStopLossEnabled === true && sellCurrentPrice <= sellStopLossTriggerPrice
+  );
+};
+
+/**
  * Check whether can buy or not
  *
  *  - current price must be less than trigger price.
@@ -27,7 +51,11 @@ const canBuy = data => {
     buy: { currentPrice: buyCurrentPrice, triggerPrice: buyTriggerPrice }
   } = data;
 
-  return buyCurrentPrice <= buyTriggerPrice && currentGridTrade !== null;
+  return (
+    buyCurrentPrice <= buyTriggerPrice &&
+    currentGridTrade !== null &&
+    !isLowerThanStopLossTriggerPrice(data)
+  );
 };
 
 /**
@@ -183,30 +211,6 @@ const isHigherThanSellTriggerPrice = data => {
   } = data;
 
   return sellCurrentPrice >= sellTriggerPrice;
-};
-
-/**
- * Check whether current price is lower or equal than stop loss trigger price
- *
- * @param {*} data
- * @returns
- */
-const isLowerThanStopLossTriggerPrice = data => {
-  const {
-    symbolConfiguration: {
-      sell: {
-        stopLoss: { enabled: sellStopLossEnabled }
-      }
-    },
-    sell: {
-      currentPrice: sellCurrentPrice,
-      stopLossTriggerPrice: sellStopLossTriggerPrice
-    }
-  } = data;
-
-  return (
-    sellStopLossEnabled === true && sellCurrentPrice <= sellStopLossTriggerPrice
-  );
 };
 
 /**

--- a/app/cronjob/trailingTrade/step/handle-open-orders.js
+++ b/app/cronjob/trailingTrade/step/handle-open-orders.js
@@ -43,7 +43,6 @@ const execute = async (logger, rawData) => {
     if (order.side.toLowerCase() === 'buy') {
       if (await isExceedingMaxOpenTrades(logger, data)) {
         // Cancel the initial buy order if max. open trades exceeded
-        data.action = 'buy-order-cancelled';
         logger.info(
           { data, saveLog: true },
           `The current number of open trades has reached the maximum number of open trades. ` +
@@ -68,6 +67,9 @@ const execute = async (logger, rawData) => {
           data.action = 'buy-order-checking';
         } else {
           data.buy.openOrders = [];
+
+          // Set action as buy order cancelled
+          data.action = 'buy-order-cancelled';
 
           data.accountInfo = await getAccountInfoFromAPI(logger);
         }
@@ -112,8 +114,8 @@ const execute = async (logger, rawData) => {
           // Reset buy open orders
           data.buy.openOrders = [];
 
-          // Set action as buy
-          data.action = 'buy';
+          // Set action as buy order cancelled
+          data.action = 'buy-order-cancelled';
 
           data.accountInfo = await getAccountInfoFromAPI(logger);
         }

--- a/public/js/QuoteAssetGridTradeArchiveIcon.js
+++ b/public/js/QuoteAssetGridTradeArchiveIcon.js
@@ -220,7 +220,11 @@ class QuoteAssetGridTradeArchiveIcon extends React.Component {
                 parseFloat(row.stopLossQuoteQty).toFixed(quoteAssetTickSize)
               }
               className={`text-center align-middle ${
-                row.totalSellQuoteQty === 0 ? 'text-muted' : ''
+                row.totalSellQuoteQty === 0
+                  ? 'text-muted'
+                  : row.stopLossQuoteQty === 0
+                  ? ''
+                  : 'text-danger'
               }`}>
               {parseFloat(row.totalSellQuoteQty).toFixed(quoteAssetTickSize)}{' '}
               {quoteAsset}

--- a/public/js/SymbolGridTradeArchiveIcon.js
+++ b/public/js/SymbolGridTradeArchiveIcon.js
@@ -214,7 +214,11 @@ class SymbolGridTradeArchiveIcon extends React.Component {
                 parseFloat(row.stopLossQuoteQty).toFixed(quoteAssetTickSize)
               }
               className={`text-center align-middle ${
-                row.totalSellQuoteQty === 0 ? 'text-muted' : ''
+                row.totalSellQuoteQty === 0
+                  ? 'text-muted'
+                  : row.stopLossQuoteQty === 0
+                  ? ''
+                  : 'text-danger'
               }`}>
               {parseFloat(row.totalSellQuoteQty).toFixed(quoteAssetTickSize)}{' '}
               {quoteAsset}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Stop-loss is higher priority than buy order.
- Added stop-loss highlighting in closed trades.
- It will still allow to finish already opened buy order before stop-loss is triggered to check if stop-loss is unavoidable.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#424

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I was highly motivated when it lost -0.77% with stop-loss set to -0.1% (Max loss percentage 0.999). It was much higher overshoot than what I'm able to accept as tolerable margin of error. It should not overshoot even on so tight percentages.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Validated by tests but also in production.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/37454226/212501300-05fd5203-832f-45be-ba3a-605d88d6bef5.png)