### PR TITLE
feat: price equivalents in breakeven calculator

### DIFF
--- a/public/js/CoinWrapperBuySignal.js
+++ b/public/js/CoinWrapperBuySignal.js
@@ -342,14 +342,10 @@ class CoinWrapperBuySignal extends React.Component {
       const sellGridTrade = symbolConfiguration.sell.gridTrade;
 
       const currentPrice = parseFloat(buy.currentPrice);
+
       const lastBuyPrice = parseFloat(sell.lastBuyPrice);
 
-      if (
-        isNaN(lastBuyPrice) ||
-        sellGridTrade.length !== 1 ||
-        currentPrice >= lastBuyPrice
-      )
-        return '';
+      if (isNaN(lastBuyPrice) || sellGridTrade.length !== 1) return '';
 
       const totalBoughtQty = gridTrade
         .filter(trade => trade.executed)
@@ -376,7 +372,7 @@ class CoinWrapperBuySignal extends React.Component {
         (symbolConfiguration.sell.currentGridTradeIndex >= 0) &
         (sellGridTrade.length === 1);
 
-      return (nextGridAmount > 0) & !hasManualTrade & isSingleSellGrid ? (
+      return !hasManualTrade && isSingleSellGrid ? (
         <React.Fragment key={'coin-wrapper-buy-next-grid-row-' + symbol}>
           <div className='coin-info-column coin-info-column-price'>
             <span className='coin-info-label'>
@@ -388,7 +384,9 @@ class CoinWrapperBuySignal extends React.Component {
               />
             </span>
             <span className='coin-info-value'>
-              {nextGridAmount.toFixed(precision)} {quoteAsset}
+              {nextGridAmount > 0
+                ? `${nextGridAmount.toFixed(precision)} ${quoteAsset}`
+                : 'N/A'}
             </span>
           </div>
         </React.Fragment>

--- a/public/js/SymbolGridCalculator.js
+++ b/public/js/SymbolGridCalculator.js
@@ -106,10 +106,12 @@ class SymbolGridCalculator extends React.Component {
     const buyTrigger =
       parseFloat(this.state.scenario.buyTrigger) || currentBuyPercentage;
 
+    const buyPriceEquivalent = lastBuyPrice * parseFloat(buyTrigger);
+
     const sellTrigger =
       parseFloat(this.state.scenario.sellTrigger) || currentSellPercentage;
 
-    const priceEquivalent = currentPrice * parseFloat(sellTrigger);
+    const sellPriceEquivalent = currentPrice * parseFloat(sellTrigger);
 
     const differenceFromCurrentPrice =
       (100 * (buyTrigger * lastBuyPrice - currentPrice)) / currentPrice;
@@ -152,9 +154,12 @@ class SymbolGridCalculator extends React.Component {
                   onChange={this.handleInputChange}
                 />
                 <Form.Text className='ml-2 text-muted'>
+                  Equivalent market price:{' '}
+                  {buyPriceEquivalent.toFixed(precision)} <br />
                   Difference from current price:{' '}
-                  {differenceFromCurrentPrice.toFixed(3)}% — Buy trigger with
-                  current price: {currentBuyPercentage.toFixed(3)}
+                  {differenceFromCurrentPrice.toFixed(3)}%<br />
+                  Buy trigger with current price:{' '}
+                  {currentBuyPercentage.toFixed(3)}
                 </Form.Text>
               </Form.Group>
               <Form.Group className='mb-2'>
@@ -174,7 +179,7 @@ class SymbolGridCalculator extends React.Component {
                 />
                 <Form.Text className='ml-2 text-muted'>
                   {currentSellPercentage
-                    ? `Equivalent market price: ${priceEquivalent.toFixed(
+                    ? `Equivalent market price: ${sellPriceEquivalent.toFixed(
                         precision
                       )}`
                     : '\u00A0'}
@@ -196,7 +201,7 @@ class SymbolGridCalculator extends React.Component {
                     {' '}
                     {sellTrigger === 1
                       ? ' - '
-                      : breakevenAmount.toFixed(2)}{' '}
+                      : breakevenAmount.toFixed(precision)}{' '}
                     {quoteAsset}
                   </code>
                   , would allow you to break-even if the market price rebounds


### PR DESCRIPTION
## Description

Small improvements on the grid calculator introduced in PR #554:
- The equivalent market prices are now shown both for the rebound and buy trigger percentages
- The calculator is now accessible as long as there is a first buy grid executed. None valid recommendations are rendered as `N/A `

## Related Issue
The first enhancement is in response to @peweb [request](https://github.com/chrisleekr/binance-trading-bot/pull/554#issuecomment-1385075405)

## How Has This Been Tested?
This is working on my production server.

## Screenshots (if appropriate):
**Equivalent prices:**
<img width="486" alt="Screenshot 2023-02-03 at 18 36 36" src="https://user-images.githubusercontent.com/1491835/216670624-777d1bda-0ad2-4ea8-ac94-4528ebaf932b.png">

**N/A indicator:**
<img width="359" alt="Screenshot 2023-02-03 at 18 40 15" src="https://user-images.githubusercontent.com/1491835/216670738-88395089-3d8f-4a3c-bead-1bbb24f2359c.png">


