### PR TITLE
chore: add docker host and port configurability of tradingview server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the stop-loss to be a higher priority than the new buy order by [@uhliksk](https://github.com/uhliksk) - [#589](https://github.com/chrisleekr/binance-trading-bot/pull/589)
 - Improved search and filtering UX by [@rando128](https://github.com/rando128) - [#591](https://github.com/chrisleekr/binance-trading-bot/pull/591)
 - Enhanced the break-even calculator by [@rando128](https://github.com/rando128) - [#597](https://github.com/chrisleekr/binance-trading-bot/pull/597), [#601](https://github.com/chrisleekr/binance-trading-bot/pull/601)
+- Updated TradingView host/port configurable  by [@rando128](https://github.com/rando128) - [#608](https://github.com/chrisleekr/binance-trading-bot/pull/608)
 
 Thanks [@uhliksk](https://github.com/uhliksk) and [@rando128](https://github.com/rando128) for your great contributions. 💯 :heart:
 

--- a/app/cronjob/trailingTradeIndicator/step/get-trading-view.js
+++ b/app/cronjob/trailingTradeIndicator/step/get-trading-view.js
@@ -1,6 +1,7 @@
 const qs = require('qs');
 const _ = require('lodash');
 const axios = require('axios');
+const config = require('config');
 const { cache } = require('../../../helpers');
 const { handleError } = require('../../../error-handler');
 
@@ -68,7 +69,11 @@ const retrieveTradingView = async (logger, symbols, interval) => {
   };
 
   try {
-    const response = await axios.get('http://tradingview:8080', {
+    const tradingviewUrl = `http://${config.get(
+      'tradingview.host'
+    )}:${config.get('tradingview.port')}`;
+
+    const response = await axios.get(tradingviewUrl, {
       params,
       paramsSerializer:
         /* istanbul ignore next */

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -33,6 +33,13 @@
     },
     "database": "BINANCE_MONGO_DATABASE"
   },
+  "tradingview": {
+    "host": "TRADINGVIEW_HOST",
+    "port": {
+      "__name": "TRADINGVIEW_PORT",
+      "__format": "number"
+    }
+  },
   "slack": {
     "enabled": {
       "__name": "BINANCE_SLACK_ENABLED",

--- a/config/default.json
+++ b/config/default.json
@@ -24,6 +24,10 @@
     "port": 27017,
     "database": "binance-bot"
   },
+  "tradingview": {
+    "host": "tradingview",
+    "port": 8080
+  },
   "slack": {
     "enabled": false,
     "webhookUrl": "",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - BINANCE_REDIS_HOST=binance-redis
       - BINANCE_REDIS_PORT=6379
       - BINANCE_REDIS_PASSWORD=secretp422
+      - TRADINGVIEW_HOST=tradingview
+      - TRADINGVIEW_PORT=8082
     ports:
       - 8080:80
     logging:
@@ -42,8 +44,9 @@ services:
       - PYTHONUNBUFFERED=1
       # https://docs.python.org/3/howto/logging.html#logging-levels
       - TRADINGVIEW_LOG_LEVEL=INFO
+      - TRADINGVIEW_PORT=8082
     ports:
-      - 8082:8080
+      - 8082:8082
     logging:
       driver: 'json-file'
       options:

--- a/tradingview/main.py
+++ b/tradingview/main.py
@@ -51,4 +51,6 @@ def index():
 
 if __name__ == "__main__":
     from waitress import serve
-    serve(app, host="0.0.0.0", port=8080)
+
+    port = os.environ.get("TRADINGVIEW_PORT", 8080)
+    serve(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
## Description

The existing docker configuration allows to use custom host and port settings for the mongo and redis servers. This PR adds `TRADINGVIEW_HOST` and `TRADINGVIEW_PORT` settings to allow running the tradingview server on a configurable port (instead of the existing hardcoded 8080 port).

This PR doesn't contain the updated image.


