### PR TITLE
chore: change tradingview env param with prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Added the prefix to environment parameter for `TRADINGVIEW_HOST` and `TRADINGVIEW_PORT` - [#616](https://github.com/chrisleekr/binance-trading-bot/pull/616)
+
 ## [0.0.97] - 2023-03-21
 
 - Fixed sorting symbols open trades first by [@uhliksk](https://github.com/uhliksk) - [#564](https://github.com/chrisleekr/binance-trading-bot/pull/564)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Added the prefix to environment parameter for `TRADINGVIEW_HOST` and `TRADINGVIEW_PORT` - [#616](https://github.com/chrisleekr/binance-trading-bot/pull/616)
+- Added the prefix to environment parameter for `TRADINGVIEW` related - [#616](https://github.com/chrisleekr/binance-trading-bot/pull/616)
 
 ## [0.0.97] - 2023-03-21
 

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -34,9 +34,9 @@
     "database": "BINANCE_MONGO_DATABASE"
   },
   "tradingview": {
-    "host": "TRADINGVIEW_HOST",
+    "host": "BINANCE_TRADINGVIEW_HOST",
     "port": {
-      "__name": "TRADINGVIEW_PORT",
+      "__name": "BINANCE_TRADINGVIEW_PORT",
       "__format": "number"
     }
   },

--- a/docker-compose.rpi.yml
+++ b/docker-compose.rpi.yml
@@ -30,7 +30,7 @@ services:
     restart: unless-stopped
     environment:
       # https://docs.python.org/3/howto/logging.html#logging-levels
-      - TRADINGVIEW_LOG_LEVEL=INFO
+      - BINANCE_TRADINGVIEW_LOG_LEVEL=INFO
     logging:
       driver: 'json-file'
       options:
@@ -48,7 +48,8 @@ services:
     volumes:
       - redis_data:/data
       - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
-    command: redis-server /usr/local/etc/redis/redis.conf --requirepass secretp422
+    command:
+      redis-server /usr/local/etc/redis/redis.conf --requirepass secretp422
 
   binance-mongo:
     container_name: binance-mongo

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -30,7 +30,7 @@ services:
     restart: unless-stopped
     environment:
       # https://docs.python.org/3/howto/logging.html#logging-levels
-      - TRADINGVIEW_LOG_LEVEL=INFO
+      - BINANCE_TRADINGVIEW_LOG_LEVEL=INFO
     logging:
       driver: 'json-file'
       options:
@@ -47,7 +47,8 @@ services:
     volumes:
       - redis_data:/data
       - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
-    command: redis-server /usr/local/etc/redis/redis.conf --requirepass secretp422
+    command:
+      redis-server /usr/local/etc/redis/redis.conf --requirepass secretp422
 
   binance-mongo:
     container_name: binance-mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       # https://docs.python.org/3/howto/logging.html#logging-levels
-      - TRADINGVIEW_LOG_LEVEL=INFO
+      - BINANCE_TRADINGVIEW_LOG_LEVEL=INFO
       - BINANCE_TRADINGVIEW_PORT=8082
     ports:
       - 8082:8082

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       - BINANCE_REDIS_HOST=binance-redis
       - BINANCE_REDIS_PORT=6379
       - BINANCE_REDIS_PASSWORD=secretp422
-      - TRADINGVIEW_HOST=tradingview
-      - TRADINGVIEW_PORT=8082
+      - BINANCE_TRADINGVIEW_HOST=tradingview
+      - BINANCE_TRADINGVIEW_PORT=8082
     ports:
       - 8080:80
     logging:
@@ -44,7 +44,7 @@ services:
       - PYTHONUNBUFFERED=1
       # https://docs.python.org/3/howto/logging.html#logging-levels
       - TRADINGVIEW_LOG_LEVEL=INFO
-      - TRADINGVIEW_PORT=8082
+      - BINANCE_TRADINGVIEW_PORT=8082
     ports:
       - 8082:8082
     logging:
@@ -65,7 +65,8 @@ services:
     volumes:
       - redis_data:/data
       - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
-    command: redis-server /usr/local/etc/redis/redis.conf --requirepass secretp422
+    command:
+      redis-server /usr/local/etc/redis/redis.conf --requirepass secretp422
 
   binance-mongo:
     container_name: binance-mongo

--- a/tradingview/main.py
+++ b/tradingview/main.py
@@ -52,7 +52,7 @@ def index():
 if __name__ == "__main__":
     from waitress import serve
 
-    port_str = os.environ.get("TRADINGVIEW_PORT", "8080")
+    port_str = os.environ.get("BINANCE_TRADINGVIEW_PORT", "8080")
     try:
         port = int(port_str)
     except ValueError:

--- a/tradingview/main.py
+++ b/tradingview/main.py
@@ -9,7 +9,7 @@ from tradingview_ta import get_multiple_analysis
 app = Flask(__name__)
 
 logger = logging.getLogger('')
-logger.setLevel(os.environ.get("TRADINGVIEW_LOG_LEVEL", logging.DEBUG))
+logger.setLevel(os.environ.get("BINANCE_TRADINGVIEW_LOG_LEVEL", logging.DEBUG))
 sh = logging.StreamHandler(sys.stdout)
 sh.setFormatter(colorlog.ColoredFormatter(
     '%(log_color)s [%(asctime)s] %(levelname)s [%(filename)s.%(funcName)s:%(lineno)d] %(message)s', datefmt='%a, %d %b %Y %H:%M:%S'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In the last release, new env params are added to allow setting trading view configurations. And there was an existing env param that was not following the naming conventions. 

However, some env params conflict with the environment parameter in Kubernetes if the service name is ‘tradingview’, which is common to set.

It's good practice to follow previous naming conventions. In addition, prevent clashes by adding prefixes.

Impacted environment parameters:

- TRADINGVIEW_HOST -> BINANCE_TRADINGVIEW_HOST
- TRADINGVIEW_PORT -> BINANCE_TRADINGVIEW_PORT
- TRADINGVIEW_LOG_LEVEL -> BINANCE_TRADINGVIEW_LOG_LEVEL

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
