### PR TITLE
feat: customised setting details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable changes to this project will be documented in this file.
 - Added the prefix to environment parameter for `TRADINGVIEW` related - [#616](https://github.com/chrisleekr/binance-trading-bot/pull/616)
 - Fixed the issue with minNotional - [#623](https://github.com/chrisleekr/binance-trading-bot/pull/623)
 - Add clear symbols button by [@TheSmuks](https://github.com/TheSmuks) - [#626](https://github.com/chrisleekr/binance-trading-bot/pull/626)
+- Improved customised setting details by [@rando128](https://github.com/rando128) - [#625](https://github.com/chrisleekr/binance-trading-bot/pull/625)
 
-Thanks [@TheSmuks](https://github.com/TheSmuks) for your great contributions. 💯 :heart:
+Thanks [@TheSmuks](https://github.com/TheSmuks) and [@rando128](https://github.com/rando128) for your great contributions. 💯 :heart:
 
 ## [0.0.97] - 2023-03-21
 

--- a/public/js/CoinWrapperSetting.js
+++ b/public/js/CoinWrapperSetting.js
@@ -251,7 +251,10 @@ class CoinWrapperSetting extends React.Component {
             <div className='coin-info-sub-label'>
               Buy - Last buy price removal threshold
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'buy.lastBuyPriceRemoveThreshold'
+              )}`}>
               <span className='coin-info-label'>
                 Remove last buy price under:
               </span>
@@ -316,7 +319,7 @@ class CoinWrapperSetting extends React.Component {
             <div className='coin-info-sub-label'>Buy - TradingView</div>
             <div
               className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
-                'buy.tradingview.whenStrongBuy'
+                'buy.tradingView.whenStrongBuy'
               )}`}>
               <span className='coin-info-label'>
                 Allow when recommendation is <code>Strong buy</code>:
@@ -331,7 +334,7 @@ class CoinWrapperSetting extends React.Component {
             </div>
             <div
               className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
-                'buy.tradingview.whenBuy'
+                'buy.tradingView.whenBuy'
               )}`}>
               <span className='coin-info-label'>
                 Allow when recommendation is <code>Buy</code>:

--- a/public/js/CoinWrapperSetting.js
+++ b/public/js/CoinWrapperSetting.js
@@ -20,6 +20,30 @@ class CoinWrapperSetting extends React.Component {
   isCustomised = configurationKeyName =>
     configurationKeyName !== 'configuration';
 
+  jsonValueAtPath = (obj, path) => {
+    // Extract the value of the object at the given path
+    const value = path.split('.').reduce((acc, key) => {
+      if (key.includes('[')) {
+        const index = key.match(/\d+/)[0];
+        const arrKey = key.split('[')[0];
+        return acc[arrKey][index];
+      } else {
+        if (acc && acc.hasOwnProperty(key)) return acc[key];
+        else return -1;
+      }
+    }, obj);
+    return value;
+  };
+
+  warnIfAttributeCustomised = (path, globalPath = path) => {
+    if (
+      this.jsonValueAtPath(this.props.symbolInfo.symbolConfiguration, path) !==
+      this.jsonValueAtPath(this.props.configuration, globalPath)
+    )
+      return 'text-warning';
+    else return '';
+  };
+
   render() {
     const { collapsed } = this.state;
     const { symbolInfo } = this.props;
@@ -44,7 +68,10 @@ class CoinWrapperSetting extends React.Component {
             <div className='coin-info-column coin-info-column-order'>
               <span className='coin-info-label'>Grid Trade #{i + 1}</span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                `buy.gridTrade[${i}].triggerPercentage`
+              )}`}>
               <span className='coin-info-label'>
                 Trigger percentage{' '}
                 <strong>
@@ -56,25 +83,39 @@ class CoinWrapperSetting extends React.Component {
                 {(parseFloat(grid.triggerPercentage - 1) * 100).toFixed(2)}%
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                `buy.gridTrade[${i}].stopPercentage`
+              )}`}>
               <span className='coin-info-label'>Stop percentage:</span>
               <div className='coin-info-value'>
                 {(parseFloat(grid.stopPercentage - 1) * 100).toFixed(2)}%
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                `buy.gridTrade[${i}].limitPercentage`
+              )}`}>
               <span className='coin-info-label'>Limit percentage:</span>
               <div className='coin-info-value'>
                 {(parseFloat(grid.limitPercentage - 1) * 100).toFixed(2)}%
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                `buy.gridTrade[${i}].minPurchaseAmount`,
+                `buy.gridTrade[${i}].minPurchaseAmounts.${quoteAsset}`
+              )}`}>
               <span className='coin-info-label'>Min purchase amount:</span>
               <div className='coin-info-value'>
                 {grid.minPurchaseAmount} {quoteAsset}
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                `buy.gridTrade[${i}].maxPurchaseAmount`,
+                `buy.gridTrade[${i}].maxPurchaseAmounts.${quoteAsset}`
+              )}`}>
               <span className='coin-info-label'>Max purchase amount:</span>
               <div className='coin-info-value'>
                 {grid.maxPurchaseAmount} {quoteAsset}
@@ -93,25 +134,38 @@ class CoinWrapperSetting extends React.Component {
             <div className='coin-info-column coin-info-column-order'>
               <span className='coin-info-label'>Grid Trade #{i + 1}</span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                `sell.gridTrade[${i}].triggerPercentage`
+              )}`}>
               <span className='coin-info-label'>Trigger percentage:</span>
               <div className='coin-info-value'>
                 {(parseFloat(grid.triggerPercentage - 1) * 100).toFixed(2)}%
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                `sell.gridTrade[${i}].stopPercentage`
+              )}`}>
               <span className='coin-info-label'>Stop percentage:</span>
               <div className='coin-info-value'>
                 {(parseFloat(grid.stopPercentage - 1) * 100).toFixed(2)}%
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                `sell.gridTrade[${i}].limitPercentage`
+              )}`}>
               <span className='coin-info-label'>Limit percentage:</span>
               <div className='coin-info-value'>
                 {(parseFloat(grid.limitPercentage - 1) * 100).toFixed(2)}%
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                `sell.gridTrade[${i}].quantityPercentage`,
+                `sell.gridTrade[${i}].quantityPercentages.${quoteAsset}`
+              )}`}>
               <span className='coin-info-label'>Quantity Percentage:</span>
               <div className='coin-info-value'>
                 {(parseFloat(grid.quantityPercentage) * 100).toFixed(2)}%
@@ -154,13 +208,19 @@ class CoinWrapperSetting extends React.Component {
           className={`coin-info-content-setting ${collapsed ? 'd-none' : ''}`}>
           <div className='coin-info-sub-wrapper'>
             <div className='coin-info-sub-label'>Candles</div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'candles.interval'
+              )}`}>
               <span className='coin-info-label'>Interval:</span>
               <div className='coin-info-value'>
                 {symbolConfiguration.candles.interval}
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'candles.limit'
+              )}`}>
               <span className='coin-info-label'>Limit:</span>
               <div className='coin-info-value'>
                 {symbolConfiguration.candles.limit}
@@ -170,7 +230,12 @@ class CoinWrapperSetting extends React.Component {
 
           <div className='coin-info-sub-wrapper'>
             <div className='coin-info-sub-label'>Buy</div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${
+                this.warnIfAttributeCustomised('buy.enabled')
+                  ? 'text-warning'
+                  : ''
+              }`}>
               <span className='coin-info-label'>Trading enabled:</span>
               <span className='coin-info-value'>
                 {symbolConfiguration.buy.enabled ? (
@@ -200,7 +265,10 @@ class CoinWrapperSetting extends React.Component {
             <div className='coin-info-sub-label'>
               Buy - Restriction with ATH
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'buy.athRestriction.enabled'
+              )}`}>
               <span className='coin-info-label'>Restriction Enabled:</span>
               <span className='coin-info-value'>
                 {symbolConfiguration.buy.athRestriction.enabled ? (
@@ -210,19 +278,28 @@ class CoinWrapperSetting extends React.Component {
                 )}
               </span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'buy.athRestriction.candles.interval'
+              )}`}>
               <span className='coin-info-label'>Candles - Interval:</span>
               <div className='coin-info-value'>
                 {symbolConfiguration.buy.athRestriction.candles.interval}
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'buy.athRestriction.candles.limit'
+              )}`}>
               <span className='coin-info-label'>Candles - Limit:</span>
               <div className='coin-info-value'>
                 {symbolConfiguration.buy.athRestriction.candles.limit}
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'buy.athRestriction.restrictionPercentage'
+              )}`}>
               <span className='coin-info-label'>Restriction Percentage:</span>
               <div className='coin-info-value'>
                 {(
@@ -237,7 +314,10 @@ class CoinWrapperSetting extends React.Component {
           </div>
           <div className='coin-info-sub-wrapper'>
             <div className='coin-info-sub-label'>Buy - TradingView</div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'buy.tradingview.whenStrongBuy'
+              )}`}>
               <span className='coin-info-label'>
                 Allow when recommendation is <code>Strong buy</code>:
               </span>
@@ -249,7 +329,10 @@ class CoinWrapperSetting extends React.Component {
                 )}
               </span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'buy.tradingview.whenBuy'
+              )}`}>
               <span className='coin-info-label'>
                 Allow when recommendation is <code>Buy</code>:
               </span>
@@ -265,7 +348,12 @@ class CoinWrapperSetting extends React.Component {
 
           <div className='coin-info-sub-wrapper'>
             <div className='coin-info-sub-label'>Sell</div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${
+                this.warnIfAttributeCustomised('sell.enabled')
+                  ? 'text-warning'
+                  : ''
+              }`}>
               <span className='coin-info-label'>Trading enabled:</span>
               <span className='coin-info-value'>
                 {symbolConfiguration.sell.enabled ? (
@@ -280,7 +368,10 @@ class CoinWrapperSetting extends React.Component {
 
           <div className='coin-info-sub-wrapper'>
             <div className='coin-info-sub-label'>Sell - Stop Loss</div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'sell.stopLoss.enabled'
+              )}`}>
               <span className='coin-info-label'>Stop Loss Enabled:</span>
               <span className='coin-info-value'>
                 {symbolConfiguration.sell.stopLoss.enabled ? (
@@ -290,7 +381,10 @@ class CoinWrapperSetting extends React.Component {
                 )}
               </span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'sell.stopLoss.maxLossPercentage'
+              )}`}>
               <span className='coin-info-label'>Max Loss Percentage:</span>
               <div className='coin-info-value'>
                 {(
@@ -300,7 +394,10 @@ class CoinWrapperSetting extends React.Component {
                 %
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'sell.stopLoss.disableBuyMinutes'
+              )}`}>
               <span className='coin-info-label'>Temporary disable buy:</span>
               <div className='coin-info-value'>
                 {moment
@@ -311,7 +408,10 @@ class CoinWrapperSetting extends React.Component {
                   .humanize()}
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'sell.stopLoss.orderType'
+              )}`}>
               <span className='coin-info-label'>Order Type:</span>
               <div className='coin-info-value'>
                 {symbolConfiguration.sell.stopLoss.orderType}
@@ -321,7 +421,10 @@ class CoinWrapperSetting extends React.Component {
 
           <div className='coin-info-sub-wrapper'>
             <div className='coin-info-sub-label'>Sell - TradingView</div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'sell.tradingView.forceSellOverZeroBelowTriggerPrice.whenNeutral'
+              )}`}>
               <span className='coin-info-label'>
                 Force sell when recommendation is <code>Neutral</code>:
               </span>
@@ -334,7 +437,10 @@ class CoinWrapperSetting extends React.Component {
                 )}
               </span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'sell.tradingView.forceSellOverZeroBelowTriggerPrice.whenSell'
+              )}`}>
               <span className='coin-info-label'>
                 Force sell when recommendation is <code>Sell</code>:
               </span>
@@ -347,7 +453,10 @@ class CoinWrapperSetting extends React.Component {
                 )}
               </span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'sell.tradingView.forceSellOverZeroBelowTriggerPrice.whenStrongSell'
+              )}`}>
               <span className='coin-info-label'>
                 Force sell when recommendation is <code>Strong sell</code>:
               </span>
@@ -363,10 +472,41 @@ class CoinWrapperSetting extends React.Component {
           </div>
 
           <div className='coin-info-sub-wrapper'>
+            <div className='coin-info-sub-label'>Conservative Mode</div>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'sell.conservativeMode.enabled'
+              )}`}>
+              <span className='coin-info-label'>
+                Conservative Sell Enabled:
+              </span>
+              <span className='coin-info-value'>
+                {symbolConfiguration.sell.conservativeMode.enabled ? (
+                  <i className='fas fa-toggle-on'></i>
+                ) : (
+                  <i className='fas fa-toggle-off'></i>
+                )}
+              </span>
+            </div>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'sell.conservativeMode.factor'
+              )}`}>
+              <span className='coin-info-label'>Conservative ratio:</span>
+              <div className='coin-info-value'>
+                {symbolConfiguration.sell.conservativeMode.factor}
+              </div>
+            </div>
+          </div>
+
+          <div className='coin-info-sub-wrapper'>
             <div className='coin-info-sub-label'>
               Bot Options - Auto Trigger Buy
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'botOptions.autoTriggerBuy.enabled'
+              )}`}>
               <span className='coin-info-label'>Enabled:</span>
               <span className='coin-info-value'>
                 {symbolConfiguration.botOptions.autoTriggerBuy.enabled ? (
@@ -376,7 +516,10 @@ class CoinWrapperSetting extends React.Component {
                 )}
               </span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'botOptions.autoTriggerBuy.triggerAfter'
+              )}`}>
               <span className='coin-info-label'>Trigger after:</span>
               <div className='coin-info-value'>
                 {moment
@@ -387,7 +530,10 @@ class CoinWrapperSetting extends React.Component {
                   .humanize()}
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'botOptions.autoTriggerBuy.conditions.whenLessThanATHRestriction'
+              )}`}>
               <span className='coin-info-label'>
                 Re-schedule when the current price is over ATH restriction:
               </span>
@@ -400,7 +546,10 @@ class CoinWrapperSetting extends React.Component {
                 )}
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'botOptions.autoTriggerBuy.conditions.afterDisabledPeriod'
+              )}`}>
               <span className='coin-info-label'>
                 Re-schedule when the action is disabled:
               </span>
@@ -413,7 +562,10 @@ class CoinWrapperSetting extends React.Component {
                 )}
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'botOptions.autoTriggerBuy.conditions.tradingView.overrideInterval'
+              )}`}>
               <span className='coin-info-label'>
                 TradingView Overriden Interval:
               </span>
@@ -425,7 +577,10 @@ class CoinWrapperSetting extends React.Component {
                   : 'Use TradingView'}
               </span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'botOptions.autoTriggerBuy.conditions.tradingView.whenStrongBuy'
+              )}`}>
               <span className='coin-info-label'>
                 Allow when TradingView recommendation is <code>Strong buy</code>
                 :
@@ -439,7 +594,10 @@ class CoinWrapperSetting extends React.Component {
                 )}
               </div>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'botOptions.autoTriggerBuy.conditions.tradingView.whenBuy'
+              )}`}>
               <span className='coin-info-label'>
                 Allow when TradingView recommendation is <code>Buy</code>:
               </span>
@@ -456,7 +614,10 @@ class CoinWrapperSetting extends React.Component {
 
           <div className='coin-info-sub-wrapper'>
             <div className='coin-info-sub-label'>Bot Options - TradingView</div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'botOptions.tradingView.interval'
+              )}`}>
               <span className='coin-info-label'>Interval:</span>
               <span className='coin-info-value'>
                 {symbolConfiguration.botOptions.tradingView.interval !== ''
@@ -464,7 +625,10 @@ class CoinWrapperSetting extends React.Component {
                   : symbolConfiguration.candles.interval}
               </span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'botOptions.tradingView.useOnlyWithin'
+              )}`}>
               <span className='coin-info-label'>
                 Use data only updated within:
               </span>
@@ -472,7 +636,10 @@ class CoinWrapperSetting extends React.Component {
                 {symbolConfiguration.botOptions.tradingView.useOnlyWithin}
               </span>
             </div>
-            <div className='coin-info-column coin-info-column-order'>
+            <div
+              className={`coin-info-column coin-info-column-order ${this.warnIfAttributeCustomised(
+                'botOptions.tradingView.ifExpires'
+              )}`}>
               <span className='coin-info-label'>
                 If data passed "Use data only updated within":
               </span>


### PR DESCRIPTION
## Description

This PR highlights in the coin settings view which setting differs from the global configuration. 

This is done with a new function `warnIfAttributeCustomised` that changes the CSS after comparing the symbol attribute value (`this.props.symbolInfo.symbolConfiguration`) with the global attribute value (`this.props.configuration`).

This PR also adds the conservative mode setting in the settings view, since this has not been done in PR #585.

## Motivation and Context
When playing with symbol settings, I often struggle to remember what I changed from the global settings and I end up going through a tedious comparison exercise. This feature helps identifying customised settings rapidly.

## How Has This Been Tested?
This is working on my prod setup.

## Screenshots (if appropriate):

<img width="367" alt="Screenshot 2023-04-22 at 10 52 50" src="https://user-images.githubusercontent.com/1491835/233774461-7e7aecf7-18a8-45f6-97a7-17120abccb00.png">

<img width="367" alt="Screenshot 2023-04-22 at 10 53 09" src="https://user-images.githubusercontent.com/1491835/233774574-87e23951-3636-4a52-814e-9450884972c0.png">
