### PR TITLE
feat(SettingIcon): Add clear symbols button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 - Fixed the issue with minNotional - [#623](https://github.com/chrisleekr/binance-trading-bot/pull/623)
 - Add clear symbols button by [@TheSmuks](https://github.com/TheSmuks) - [#626](https://github.com/chrisleekr/binance-trading-bot/pull/626)
 
+Thanks [@TheSmuks](https://github.com/TheSmuks) for your great contributions. 💯 :heart:
+
 ## [0.0.97] - 2023-03-21
 
 - Fixed sorting symbols open trades first by [@uhliksk](https://github.com/uhliksk) - [#564](https://github.com/chrisleekr/binance-trading-bot/pull/564)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Added the prefix to environment parameter for `TRADINGVIEW` related - [#616](https://github.com/chrisleekr/binance-trading-bot/pull/616)
 - Fixed the issue with minNotional - [#623](https://github.com/chrisleekr/binance-trading-bot/pull/623)
+- Add clear symbols button by [@TheSmuks](https://github.com/TheSmuks) - [#626](https://github.com/chrisleekr/binance-trading-bot/pull/626)
 
 ## [0.0.97] - 2023-03-21
 

--- a/public/css/App.css
+++ b/public/css/App.css
@@ -894,6 +894,23 @@ input[type='number'] {
 */
 
 /**
+  Start: Symbols selection
+*/
+.btn-clear-symbols {
+  background-color: #f84960;
+  color: white;
+}
+
+.btn-clear-symbols:hover {
+  box-shadow: none;
+  color: white;
+  background-color: #ff4265;
+}
+/**
+  End: Symbols selection
+*/
+
+/**
   Start: Grid Trade
 */
 .btn-add-new-grid-trade-buy {

--- a/public/js/SettingIcon.js
+++ b/public/js/SettingIcon.js
@@ -260,6 +260,12 @@ class SettingIcon extends React.Component {
 
                                 configuration.symbols = selected;
 
+                                this.handleSetValidation('symbols', true);
+
+                                if (_.isEmpty(configuration.symbols)) {
+                                  this.handleSetValidation('symbols', false);
+                                }
+
                                 const {
                                   quoteAssets,
                                   minNotionals,
@@ -317,6 +323,9 @@ class SettingIcon extends React.Component {
                               )}
                               defaultSelected={selectedSymbols}
                               placeholder='Choose symbols to monitor...'
+                              isInvalid={
+                                _.get(validation, `symbols`, true) === false
+                              }
                             />
                           </Form.Group>
                         </div>

--- a/public/js/SettingIcon.js
+++ b/public/js/SettingIcon.js
@@ -32,6 +32,7 @@ class SettingIcon extends React.Component {
     this.handleBotOptionsChange = this.handleBotOptionsChange.bind(this);
 
     this.handleSetValidation = this.handleSetValidation.bind(this);
+    this.symbolsTypeaheadRef = React.createRef();
   }
 
   getQuoteAssets(
@@ -278,6 +279,7 @@ class SettingIcon extends React.Component {
                                   minNotionals
                                 });
                               }}
+                              ref={this.symbolsTypeaheadRef}
                               size='sm'
                               options={_.keys(exchangeSymbols)}
                               renderMenuItemChildren={(
@@ -317,6 +319,21 @@ class SettingIcon extends React.Component {
                               placeholder='Choose symbols to monitor...'
                             />
                           </Form.Group>
+                        </div>
+                      </div>
+                      <div className='row'>
+                        <div className='col-12 text-right'>
+                          <button
+                            type='button'
+                            className='btn btn-sm btn-clear-symbols'
+                            onClick={e => {
+                              e.preventDefault();
+                              this.symbolsTypeaheadRef.current.clear();
+                              const { configuration } = this.state;
+                              configuration.symbols = [];
+                            }}>
+                            Clear selection
+                          </button>
                         </div>
                       </div>
                     </Card.Body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added a button to clear selected symbols in Global Settings modal.

## Motivation and Context

Why is this change required? What problem does it solve?
This is useful when users frequently experiment with different symbols and need to change the entire symbol list.
Now they can clear the symbol list with just one click instead of manually deselecting each symbol.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

1. Add symbols to the list
2. Save changes
3. Use the "Clear selection" button
4. Save changes
5. Check if the list is empty

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="943" alt="image" src="https://user-images.githubusercontent.com/60717893/234706435-1fb3a1c3-490d-4160-ada5-0205932c1fa7.png">

