### PR TITLE
feat: added docker-compose.log.yml for log viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Added multiple TradingView indicators - [#539](https://github.com/chrisleekr/binance-trading-bot/pull/539)
+- Added docker-compose.log.yml for log viewer - [#654](https://github.com/chrisleekr/binance-trading-bot/pull/654)
 
 ## [0.0.98] - 2023-04-13
 

--- a/docker-compose.log.yml
+++ b/docker-compose.log.yml
@@ -1,0 +1,20 @@
+# This YAML file is used to run a log viewer for Docker containers.
+#
+# To minimize system load, it's recommended to set BINANCE_LOG_LEVEL to ERROR in the docker-compose.server.yml or docker-compose.yml file. This will allow logging to ERROR messages only.
+#
+# For the development environment: `docker-compose -f docker-compose.yml -f docker-compose.log.yml up -d --build`
+# For the production environment: `docker-compose -f docker-compose.server.yml -f docker-compose.log.yml up -d`
+
+services:
+  dozzle:
+    container_name: dozzle
+    image: amir20/dozzle:latest
+    restart: unless-stopped
+    networks:
+      - internal
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - 8888:8080
+    environment:
+      - DOZZLE_ENABLE_ACTIONS=true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

To view the log, must access the server; the container outputs many logs. 
In addition, it is difficult to check later if any error occurs. 

To minimize system load, it's recommended to set `BINANCE_LOG_LEVEL` to `ERROR` in the `docker-compose.server.yml` or `docker-compose.yml` file. 
This will allow logging to `ERROR` messages only.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As description.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A

## Screenshots (if appropriate):
