### PR TITLE
feat: add status endpoint for tradingview

### DIFF
--- a/tradingview/main.py
+++ b/tradingview/main.py
@@ -48,6 +48,9 @@ def index():
     logger.info("Response: "+str(response))
     return jsonify(response)
 
+@app.route('/status', methods=['GET'])
+def status():
+    return jsonify({'status': 'ok'})
 
 if __name__ == "__main__":
     from waitress import serve


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding `/status` endpoint to TradingView for readness probe.

## Related Issue

N/A

## Motivation and Context

Preparing helm charts.

## How Has This Been Tested?

Yes.

## Screenshots (if appropriate):

```
/app # curl http://0.0.0.0:8082/status
{"status":"ok"}
```
