### PR TITLE
fix: undefined symbol reset to global setting

### DIFF
--- a/public/js/SymbolSettingIcon.js
+++ b/public/js/SymbolSettingIcon.js
@@ -1018,7 +1018,7 @@ class SymbolSettingIcon extends React.Component {
               />
 
               <SymbolSettingIconActions
-                symbolInfo={this.symbolInfo}
+                symbolInfo={this.props.symbolInfo}
                 sendWebSocket={this.props.sendWebSocket}
               />
             </Modal.Body>


### PR DESCRIPTION
## Description

- Fix undefined symbol when reset Customize Setting to Global Setting

## Related Issue

N/A

## Motivation and Context

- I want to reset symbol setting to Global setting, but it fails and shows "Restarting undefined websockets..."
- Receive some error notifications:
> (06:54:51.679) Uncaught Exception:
If you see this, kindly report it to: https://github.com/chrisleekr/binance-trading-bot/issues/new?assignees=&labels=bug&template=bug_report.md&title=
Code: undefined
Message: Cannot read property 'toLowerCase' of undefined
Stack: TypeError: Cannot read property 'toLowerCase' of undefined
    at /srv/node_modules/binance-api-node/dist/websocket.js:398:72
    at Array.map (<anonymous>)
    at Object.miniTicker (/srv/node_modules/binance-api-node/dist/websocket.js:397:62)
    at setupTickersWebsocket (/srv/dist/server.js:1:4145)
    at async Promise.all (index 2)
    at async /srv/dist/server.js:1:131303
Current API Usage: 82

> (06:25:47.876) Execution failed:
Job: Trailing Trade
Code: undefined
Message: Cannot read property 'filters' of undefined
Stack: TypeError: Cannot read property 'filters' of undefined
    at getSymbolInfo (/srv/app/cronjob/trailingTradeHelper/common.js:554:16)
    at async execute (/srv/app/cronjob/trailingTrade/step/get-symbol-info.js:16:22)
    at async /srv/app/cronjob/trailingTrade.js:149:14
    at async errorHandlerWrapper (/srv/app/error-handler.js:77:5)
    at async Object.execute [as processFn] (/srv/app/cronjob/trailingTrade.js:34:3)
    at async executeJob (/srv/app/cronjob/trailingTradeHelper/queue.js:67:5)
    at async Object.execute (/srv/app/cronjob/trailingTradeHelper/queue.js:122:20)
- Current API Usage: 40

## How Has This Been Tested?

- An issue detected on my production server, I have fixed it and tested on both development and production servers

## Screenshots (if appropriate):
Before:
![Symbol-Undefined](https://github.com/user-attachments/assets/6e5edb7e-d847-495b-b9ae-15437d528cf3)

After:
![Fixed-Symbol-Undefined](https://github.com/user-attachments/assets/019bc3fe-7eaf-4c7a-861a-9c4310c64592)