### PR TITLE
feat: support tld configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Added support for binance api TLD configuration
 - Added to support frontend port configuration - [#670](https://github.com/chrisleekr/binance-trading-bot/pull/670)
 
 ## [0.0.99] - 2024-11-04

--- a/app/helpers/binance.js
+++ b/app/helpers/binance.js
@@ -5,6 +5,9 @@ const Binance = require('binance-api-node').default;
 const binanceOptions = {};
 
 if (config.get('mode') === 'live') {
+  const url = `api.binance.${config.get('tld')}`
+  binanceOptions.httpBase = `https://${url}`;
+  binanceOptions.wsBase = `wss://${url}/ws`;
   binanceOptions.apiKey = config.get('binance.live.apiKey');
   binanceOptions.apiSecret = config.get('binance.live.secretKey');
 } else {

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,6 +1,7 @@
 {
   "mode": "BINANCE_MODE",
   "tz": "BINANCE_TZ",
+  "tld": "BINANCE_TLD",
   "demoMode": {
     "__name": "BINANCE_DEMO_MODE",
     "__description": "Set a boolean to configure the bot in demo mode. If set as true, the bot will not allow updating configurations via the frontend.",

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
   "mode": "test",
   "tz": "Australia/Melbourne",
+  "tld": "com",
   "appName": "Binance Trading Bot",
   "demoMode": false,
   "frontend": {


### PR DESCRIPTION
feat: support tld config

## Description

Added support for configuring the binance api connection's top-level domain

## Related Issue

Issue [#668](https://github.com/chrisleekr/binance-trading-bot/issues/688)

## Motivation and Context

See above issue.

## How Has This Been Tested?

By using my US based API key and running with `BINANCE_TLD=us` in the .env file

## Screenshots (if appropriate):

N/A