### PR TITLE
Reset global configuration button + vs code tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Dev",
+      "type": "shell",
+      "command": "docker-compose down; docker-compose -f ${workspaceFolder}/docker-compose.yml up -d --build",
+      "problemMatcher": []
+    },
+    {
+      "label": "Run",
+      "type": "shell",
+      "command": "docker-compose down; docker-compose -f ${workspaceFolder}/docker-compose.server.yml up -d --build",
+      "problemMatcher": []
+    },
+    {
+      "label": "Stop",
+      "type": "shell",
+      "command": "docker-compose down",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- Added support for binance api TLD configuration
+- Added a button to reset the global configuration
+- Added 3 vs code tasks for running in test/live mode needed for testing tld
+- Added support for binance api TLD configuration - [#689](https://github.com/chrisleekr/binance-trading-bot/pull/689)
 - Added to support frontend port configuration - [#670](https://github.com/chrisleekr/binance-trading-bot/pull/670)
 
 ## [0.0.99] - 2024-11-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Added support for binance api TLD configuration
 - Added to support frontend port configuration - [#670](https://github.com/chrisleekr/binance-trading-bot/pull/670)
 
 ## [0.0.99] - 2024-11-04

--- a/app/cronjob/trailingTradeHelper/configuration.js
+++ b/app/cronjob/trailingTradeHelper/configuration.js
@@ -134,6 +134,21 @@ const getGlobalConfiguration = async logger => {
 };
 
 /**
+ * Reset global configuration
+ * @param {*} logger
+ * @returns
+ */
+const resetGlobalConfiguration = async (logger) => {
+  const orgConfigValue = _.cloneDeep(config.get('jobs.trailingTrade'));
+
+  orgConfigValue.symbols = Object.values(orgConfigValue.symbols);
+
+  const result = await saveGlobalConfiguration(logger, orgConfigValue);
+
+  return result;
+};
+
+/**
  * Get symbol configuration from mongodb
  *
  * @param {*} logger
@@ -976,6 +991,7 @@ const getConfiguration = async (logger, symbol = null) => {
 
 module.exports = {
   saveGlobalConfiguration,
+  resetGlobalConfiguration,
 
   getGlobalConfiguration,
   getSymbolConfiguration,

--- a/app/frontend/webserver/handlers/index.js
+++ b/app/frontend/webserver/handlers/index.js
@@ -9,6 +9,7 @@ const { handleSymbolDelete } = require('./symbol-delete');
 const { handleBackupGet } = require('./backup-get');
 const { handleRestorePost } = require('./restore-post');
 const { handle404 } = require('./404');
+const { handleResetConfigGet } = require('./reset-config-get');
 
 const setHandlers = async (logger, app, { loginLimiter }) => {
   await handleAuth(logger, app, { loginLimiter });
@@ -21,6 +22,7 @@ const setHandlers = async (logger, app, { loginLimiter }) => {
   await handleSymbolDelete(logger, app);
   await handleBackupGet(logger, app);
   await handleRestorePost(logger, app);
+  await handleResetConfigGet(logger, app);
   await handle404(logger, app);
 };
 

--- a/app/frontend/webserver/handlers/reset-config-get.js
+++ b/app/frontend/webserver/handlers/reset-config-get.js
@@ -1,0 +1,31 @@
+const {
+  verifyAuthenticated
+} = require('../../../cronjob/trailingTradeHelper/common');
+const {
+  resetGlobalConfiguration
+} = require('../../../cronjob/trailingTradeHelper/configuration');
+
+const handleResetConfigGet = async (funcLogger, app) => {
+  const logger = funcLogger.child({
+    method: 'GET',
+    endpoint: '/reset-config-get'
+  });
+
+  app.route('/reset-config').get(async (req, res) => {
+    const authToken = req.header('X-AUTH-TOKEN');
+
+    // Verify authentication
+    const isAuthenticated = await verifyAuthenticated(logger, authToken);
+
+    if (isAuthenticated === false) {
+      logger.info('Not authenticated');
+      return res.sendStatus(403);
+    }
+
+    await resetGlobalConfiguration(logger);
+
+    return res.sendStatus(200);
+  });
+};
+
+module.exports = { handleResetConfigGet };

--- a/app/helpers/binance.js
+++ b/app/helpers/binance.js
@@ -5,6 +5,9 @@ const Binance = require('binance-api-node').default;
 const binanceOptions = {};
 
 if (config.get('mode') === 'live') {
+  const url = `api.binance.${config.get('tld')}`
+  binanceOptions.httpBase = `https://${url}`;
+  binanceOptions.wsBase = `wss://${url}/ws`;
   binanceOptions.apiKey = config.get('binance.live.apiKey');
   binanceOptions.apiSecret = config.get('binance.live.secretKey');
 } else {

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,6 +1,7 @@
 {
   "mode": "BINANCE_MODE",
   "tz": "BINANCE_TZ",
+  "tld": "BINANCE_TLD",
   "demoMode": {
     "__name": "BINANCE_DEMO_MODE",
     "__description": "Set a boolean to configure the bot in demo mode. If set as true, the bot will not allow updating configurations via the frontend.",

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
   "mode": "test",
   "tz": "Australia/Melbourne",
+  "tld": "com",
   "appName": "Binance Trading Bot",
   "demoMode": false,
   "frontend": {

--- a/public/index.html
+++ b/public/index.html
@@ -173,6 +173,12 @@
     <script
       type="text/babel"
       src="./js/SettingIconActionRestoreSuccessModal.js"></script>
+    <script
+      type="text/babel"
+      src="./js/SettingIconActionResetConfirmModal.js"></script>
+    <script
+      type="text/babel"
+      src="./js/SettingIconActionResetSuccessModal.js"></script>
     <script type="text/babel" src="./js/SettingIconActions.js"></script>
     <script type="text/babel" src="./js/SettingIconGridSell.js"></script>
     <script type="text/babel" src="./js/SettingIconGridBuy.js"></script>

--- a/public/js/SettingIconActionResetConfirmModal.js
+++ b/public/js/SettingIconActionResetConfirmModal.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/jsx-no-undef */
+/* eslint-disable no-undef */
+class SettingIconActionResetConfirmModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      resetting: false
+    };
+    this.triggerReset = this.triggerReset.bind(this);
+  }
+
+  triggerReset() {
+    const authToken = localStorage.getItem('authToken') || '';
+
+    this.setState({
+      resetting: true
+    });
+
+    return axios
+      .get('/reset-config', {
+        headers: {
+          'X-AUTH-TOKEN': authToken
+        }
+      })
+      .then(response => {
+        this.setState({
+          resetting: false
+        });
+        if (response.status === 200) {
+          console.log('Reset success.');
+          this.props.handleModalShow('reset-success');
+        }
+        this.props.handleModalClose('restore-confirm');
+      })
+      .catch(e => console.error(e));
+  }
+
+  render() {
+    const { resetting } = this.state;
+
+    return (
+      <Modal
+        show={this.props.showResetConfirmModal}
+        onHide={() => this.props.handleModalClose('reset-confirm')}
+        size='md'>
+        <Modal.Header className='pt-1 pb-1'>
+          <Modal.Title>
+            <span className='text-primary'>
+              <i className='fas fa-cloud-upload-alt'></i>&nbsp; Reset config
+            </span>
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Warning: You are about to reset the configuration. Resetting the
+          config will undo any changes you may have made.
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button
+            variant='secondary'
+            size='sm'
+            onClick={() => this.props.handleModalClose('reset-confirm')}>
+            Cancel
+          </Button>
+          <Button
+            variant='success'
+            size='sm'
+            disabled={resetting}
+            onClick={() => this.triggerReset()}>
+            {resetting ? (
+              <Spinner
+                animation='border'
+                role='status'
+                className='mr-2'
+                style={{ width: '1rem', height: '1rem' }}>
+                <span className='sr-only'>Resetting...</span>
+              </Spinner>
+            ) : (
+              ''
+            )}
+            Reset
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}

--- a/public/js/SettingIconActionResetSuccessModal.js
+++ b/public/js/SettingIconActionResetSuccessModal.js
@@ -1,0 +1,35 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/jsx-no-undef */
+/* eslint-disable no-undef */
+class SettingIconActionResetSuccessModal extends React.Component {
+  refreshWindow() {
+    window.location.reload(true);
+  }
+
+  render() {
+    return (
+      <Modal
+        show={this.props.showResetSuccessModal}
+        onHide={() => this.props.handleModalClose('reset-success')}
+        size='md'>
+        <Modal.Header className='pt-1 pb-1'>
+          <Modal.Title>
+            <span className='text-primary'>
+              <i className='fas fa-cloud-upload-alt'></i>&nbsp; Successfully
+              reset the configuration
+            </span>
+          </Modal.Title>
+        </Modal.Header>
+
+        <Modal.Footer>
+          <Button
+            variant='success'
+            size='sm'
+            onClick={() => this.refreshWindow()}>
+            Refresh
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}

--- a/public/js/SettingIconActions.js
+++ b/public/js/SettingIconActions.js
@@ -8,13 +8,17 @@ class SettingIconActions extends React.Component {
     this.modalToStateMap = {
       'backup-confirm': 'showBackupConfirmModal',
       'restore-confirm': 'showRestoreConfirmModal',
-      'restore-success': 'showRestoreSuccessModal'
+      'restore-success': 'showRestoreSuccessModal',
+      'reset-confirm': 'showResetConfirmModal',
+      'reset-success': 'showResetSuccessModal'
     };
 
     this.state = {
       showBackupConfirmModal: false,
       showRestoreConfirmModal: false,
-      showRestoreSuccessModal: false
+      showRestoreSuccessModal: false,
+      showResetConfirmModal: false,
+      showResetSuccessModal: false
     };
 
     this.handleModalShow = this.handleModalShow.bind(this);
@@ -52,6 +56,17 @@ class SettingIconActions extends React.Component {
           handleModalClose={this.handleModalClose}
         />
 
+        <SettingIconActionResetConfirmModal
+          showResetConfirmModal={this.state.showResetConfirmModal}
+          handleModalShow={this.handleModalShow}
+          handleModalClose={this.handleModalClose}
+        />
+
+        <SettingIconActionResetSuccessModal
+          showResetSuccessModal={this.state.showResetSuccessModal}
+          handleModalClose={this.handleModalClose}
+        />
+
         <Accordion defaultActiveKey='0'>
           <Card className='mt-1'>
             <Card.Header className='px-2 py-1'>
@@ -80,8 +95,17 @@ class SettingIconActions extends React.Component {
                       variant='primary'
                       size='sm'
                       type='button'
+                      className='mr-2'
                       onClick={() => this.handleModalShow('restore-confirm')}>
                       Restore Database
+                    </Button>
+
+                    <Button
+                      variant='primary'
+                      size='sm'
+                      type='button'
+                      onClick={() => this.handleModalShow('reset-confirm')}>
+                      Reset Config
                     </Button>
                   </div>
                 </div>


### PR DESCRIPTION
Reset global configuration button + vs code tasks

## Description

- Added a button to reset the global configuration
- Added 3 vs code tasks for running in test/live mode needed for testing tld

Comes after PR [#689](https://github.com/chrisleekr/binance-trading-bot/pull/689)

## Related Issue

Issue [#97](https://github.com/chrisleekr/binance-trading-bot/issues/97)

## Motivation and Context

See issue above.

## How Has This Been Tested?

By configuring the bot and resetting it.

## Screenshots (if appropriate):

![reset-config](https://github.com/user-attachments/assets/a577ac7f-d55d-47c7-84f6-bb32680d7cd4)
