### PR TITLE
docs: add CHANGELOG.md with the v1.0.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 1.0.0 (2026-08-01)
+
+Complete rewrite. Shares a name and a purpose with the v0.x line and nothing else.
+
+### Features
+
+- Strategies are plugins behind a shared contract — trailing-trade, momentum, and rebalance ship, one per profile
+- Backtest a configured strategy against historical candles; every run is kept for comparison
+- Multi-account, multi-profile: one operator owns N Binance accounts, each running N profiles against its shared wallet
+- Crash-only worker with idempotent jobs, per-account Binance rate isolation, and version-aware per-symbol state commits
+- `decimal.js` money end to end, lint-enforced at the strategy boundary
+- Mobile-first PWA with a per-symbol workspace for market data, signals, orders, and manual overrides
+- Slack, Telegram, and webhook notifications behind a common provider contract
+- Technical indicator ratings computed in-process, no external scanner
+
+### Notes
+
+- No in-place upgrade from v0.x. The datastore moved to Postgres + TimescaleDB and no migration is provided — treat this as a fresh install. The v0 line is frozen at v0.0.101 (`v0-final`).
+- Binance API keys and notifier secrets are stored unencrypted in Postgres, a deliberate single-operator tradeoff. IP-allowlist your Binance key. See the auth threat model in the docs.


### PR DESCRIPTION
## Why

`v1.0.0` was tagged and released by hand rather than through release-please, so no `CHANGELOG.md` was generated. Without this file, the next release PR would create one via the `createIfMissing: true` update in release-please's node strategy, starting at `1.1.0` — and `v1.0.0` would never appear in the changelog at all.

## What

Adds `CHANGELOG.md` with a `1.0.0` entry summarising the rewrite.

The `## 1.0.0` header matches release-please's version-header regex (`\n###? v?[0-9[]`), so future releases prepend above it rather than treating the file as empty, re-creating the header and demoting the existing H1 to H2.

## Notes

- Bullets are `-` because `lint-staged` runs `prettier --write` over `*.md` on commit; release-please emits `*`. Cosmetic inconsistency only — `scripts/ci/lint.sh` runs no prettier and no workflow invokes it, so bot-authored changelog entries can't fail CI on formatting.
- Docs-only change; no behaviour affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015up5KkZqf1WNhne6UQ8LPr