### PR TITLE
fix(web): hold scroll position while loading and polling, and gate phantom alert metrics

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "import", "oxc"],
+  "plugins": ["typescript", "import", "oxc", "react"],
   "categories": { "correctness": "error" },
   "env": { "node": true, "es2024": true },
   "ignorePatterns": [
@@ -26,6 +26,8 @@
       }
     ],
     "import/no-cycle": ["error", { "maxDepth": 10 }],
+    "react/no-unstable-nested-components": "error",
+    "react/exhaustive-deps": "off",
     "no-restricted-imports": [
       "error",
       {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Directory grouping (`packages/strategy/*`) is filesystem-only; **npm names stay 
 
 ## Linting
 
-**oxlint** is the single lint path (`.oxlintrc.json`, one whole-repo pass so `import/no-cycle` sees the full graph): `correctness` + `typescript`/`import` plugins, plus repo invariants via `overrides` — strategy/indicator **purity** (`no-restricted-globals`/`-imports`) and the **decimal.js boundary**. Invariants oxlint can't express are `scripts/ci/*.sh` gates run from `lint.sh`: `no-plugin-leak` (invariant 1), `no-arbitrary-color-token`, `no-phantom-env-var`, `no-invalid-mermaid`, `no-undeclared-workspace-import`. See `docs/contributing/coding-rules.md`.
+**oxlint** is the single lint path (`.oxlintrc.json`, one whole-repo pass so `import/no-cycle` sees the full graph): `correctness` + `typescript`/`import`/`oxc`/`react` plugins, plus repo invariants via `overrides` — strategy/indicator **purity** (`no-restricted-globals`/`-imports`) and the **decimal.js boundary**. `react` is on for `react/no-unstable-nested-components` (a component declared inside another's render body remounts its subtree every render, which clamps `scrollTop` on WebKit); enabling the plugin also arms every `react` **correctness** rule, so `react/exhaustive-deps` is explicitly `off` pending triage of its pre-existing violations. Invariants oxlint can't express are `scripts/ci/*.sh` gates run from `lint.sh`: `no-plugin-leak` (invariant 1), `no-arbitrary-color-token`, `no-phantom-env-var`, `no-invalid-mermaid`, `no-undeclared-workspace-import`, `no-dropped-lint-rule` (asserts the resolved oxlint config still arms the rules carrying an invariant). See `docs/contributing/coding-rules.md`.
 
 ## Quality gates (CI must enforce)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,6 +11,7 @@ colors:
   surface-alt: '#1a1a1a'
   border: '#2a2a2a'
   border-strong: '#3a3a3a'
+  skeleton: '#303030'
   text: '#e8e8e8'
   text-emphasis: '#ffffff'
   text-muted: '#9a9aa0'
@@ -124,6 +125,7 @@ v2 superseded **v1 "Operator Console"**; v1's _behavioural_ rules carry forward 
 | `surface-alt` | `#1a1a1a` | Raised input fill, zebra row, hover. |
 | `border` | `#2a2a2a` | Hairline panel borders / dividers. |
 | `border-strong` | `#3a3a3a` | Emphasised dividers, off-track switch. |
+| `skeleton` | `#303030` | Loading-placeholder fill. Separate from `surface-alt`, which also paints zebra rows and hover — a placeholder only has to be perceivable, not readable. |
 | `text` | `#e8e8e8` | Default body and numeric text. |
 | `text-emphasis` | `#ffffff` | Emphasised values. |
 | `text-muted` | `#9a9aa0` | Labels, captions, metadata. (Lifted vs the mock's `#888` for legibility.) |

--- a/apps/web/__tests__/app-css.test.ts
+++ b/apps/web/__tests__/app-css.test.ts
@@ -27,4 +27,35 @@ describe('app.css', () => {
     });
     expect(offenders.map(([, s]) => (s ?? '').trim())).toEqual([]);
   });
+
+  it('exposes --skeleton in both themes and as a Tailwind colour utility', () => {
+    const dark = /:root,\s*\[data-theme='dark'\]\s*\{([^}]*)\}/.exec(css)?.[1] ?? '';
+    const light = /\[data-theme='light'\]\s*\{([^}]*)\}/.exec(css)?.[1] ?? '';
+    expect(dark).toMatch(/--skeleton:/);
+    expect(light).toMatch(/--skeleton:/);
+    // Without this mapping Tailwind emits no `bg-skeleton`, every placeholder
+    // bar paints transparent, and the loading screens go invisible again.
+    expect(css).toMatch(/--color-skeleton:\s*var\(--skeleton\)/);
+  });
+
+  it('insets the pending screen wherever its parent supplies no padding', () => {
+    // Styled on data-route-pending, not the test id: a test id is meant to be
+    // safe to rename, and renaming this one would silently drop the padding on
+    // the screen shown for every hard page load.
+    expect(css).toMatch(/:is\(#root, main:not\(\.p-4\)\) > \[data-route-pending\]/);
+    const component = readFileSync(resolve(process.cwd(), 'src/app/route-pending.tsx'), 'utf8');
+    expect(component).toContain('data-route-pending');
+  });
+
+  it('the boot placeholder literals still match the dark tokens they copy', () => {
+    // index.html paints before the token stylesheet applies, so those values
+    // must be literals; this is what bounds the copy when the theme moves.
+    const html = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
+    const token = (name: string): string | undefined =>
+      new RegExp(`--${name}:\\s*(#[0-9a-f]{6})`, 'i').exec(css)?.[1];
+    expect(html).toContain(`background: ${token('bg')}`);
+    expect(html).toContain(`background: ${token('bg-elevated')}`);
+    expect(html).toContain(`border: 1px solid ${token('border')}`);
+    expect(html).toContain(`solid ${token('accent')}`);
+  });
 });

--- a/apps/web/__tests__/error-boundary.test.tsx
+++ b/apps/web/__tests__/error-boundary.test.tsx
@@ -10,25 +10,32 @@ function Boom({ shouldThrow }: { shouldThrow: boolean }) {
   return <p>healthy</p>;
 }
 
+// Built outside the harness so the render prop is not re-declared per render.
+// `react/no-unstable-nested-components` flags component definitions in props as
+// well as in a render body, and exempts only prop names matching its
+// `propNamePattern` default (`render*`) — `fallback` is not one. ErrorBoundary
+// calls the fallback rather than mounting it, so this is a lint accommodation,
+// not a correctness fix; hoisting keeps the gate strict for production code
+// rather than opening `allowAsProps` for the whole repo.
+const recoverFallback = (stopThrowing: () => void) => (error: Error, reset: () => void) => (
+  <div>
+    <p data-testid="fallback-msg">{error.message}</p>
+    <button
+      type="button"
+      onClick={() => {
+        stopThrowing();
+        reset();
+      }}
+    >
+      recover
+    </button>
+  </div>
+);
+
 function ToggleHarness() {
   const [shouldThrow, setShouldThrow] = useState(true);
   return (
-    <ErrorBoundary
-      fallback={(error, reset) => (
-        <div>
-          <p data-testid="fallback-msg">{error.message}</p>
-          <button
-            type="button"
-            onClick={() => {
-              setShouldThrow(false);
-              reset();
-            }}
-          >
-            recover
-          </button>
-        </div>
-      )}
-    >
+    <ErrorBoundary fallback={recoverFallback(() => setShouldThrow(false))}>
       <Boom shouldThrow={shouldThrow} />
     </ErrorBoundary>
   );

--- a/apps/web/__tests__/index-route.test.tsx
+++ b/apps/web/__tests__/index-route.test.tsx
@@ -5,7 +5,7 @@ import {
   createRouter,
   RouterProvider,
 } from '@tanstack/react-router';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -134,6 +134,25 @@ describe('Home route /', () => {
   afterEach(() => {
     window.localStorage.clear();
     vi.restoreAllMocks();
+  });
+
+  it('holds a scrollable placeholder while the aggregate loads', async () => {
+    // The shell drops <main>'s scroll on this route, so the loading branch has
+    // to carry the scroller and enough height itself. Without that there is
+    // nothing under a thumb to drag for the length of the fetch and the app
+    // reads as frozen on a phone.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => undefined)),
+    );
+    setUp(undefined);
+    const loading = await screen.findByTestId('dashboard-loading');
+    expect(loading.className).toContain('overflow-y-auto');
+    expect(loading.className).toContain('flex-1');
+    // Four panels, one announcement.
+    expect(loading.querySelectorAll('section')).toHaveLength(4);
+    expect(within(loading).getAllByRole('status')).toHaveLength(1);
+    vi.unstubAllGlobals();
   });
 
   it('hides the profile roster when scoped to a single profile', async () => {

--- a/apps/web/__tests__/market-trend-card.test.tsx
+++ b/apps/web/__tests__/market-trend-card.test.tsx
@@ -183,6 +183,42 @@ describe('<MarketTrendCard>', () => {
     }
   });
 
+  // The countdown re-renders this card once a second. If that render rebuilds
+  // the card's subtree instead of updating it, ~300px leaves the dashboard
+  // scroller for a frame, the browser clamps `scrollTop` to the shorter
+  // content, and the height coming back does not restore it — an operator
+  // reading the bottom of the overview is dragged upward every second. Node
+  // identity across a tick is what proves the subtree survived.
+  it('keeps its DOM subtree across the once-a-second countdown re-render', async () => {
+    vi.useFakeTimers();
+    try {
+      const t0 = 1_700_000_000_000;
+      vi.setSystemTime(t0);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => jsonResponse(freshTrend(t0 - 30_000))),
+      );
+      renderCard();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const cardBefore = screen.getByTestId('market-trend-card');
+      const verdictBefore = screen.getByTestId('market-trend-verdict');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      // The countdown must actually have advanced, or identity holds vacuously.
+      expect(screen.getByTestId('market-trend-age')).toHaveTextContent('Next update in ~29s');
+      expect(screen.getByTestId('market-trend-card')).toBe(cardBefore);
+      expect(screen.getByTestId('market-trend-verdict')).toBe(verdictBefore);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('flips to Checking… exactly at the cron-period boundary', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/web/__tests__/page-skeleton.test.tsx
+++ b/apps/web/__tests__/page-skeleton.test.tsx
@@ -1,0 +1,55 @@
+// The loading placeholders exist to give a loading page real height: this app
+// has no document scroll, so a zero-height loading state leaves a touch landing
+// on something with no scroll range and the app reads as frozen. These tests
+// pin what makes them safe to render a page-full of — one announcement, no
+// motion for readers who opted out — and the bar counts that carry the height.
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { LoadingRows, PanelStackSkeleton, TableSkeleton } from '@/shared/components/page-skeleton';
+import { Skeleton } from '@/shared/components/ui/skeleton';
+
+const bars = (root: Element): number => root.querySelectorAll('[data-skeleton-bar]').length;
+
+describe('skeleton placeholders', () => {
+  it('hides individual bars from assistive tech and drops the pulse under reduced motion', () => {
+    const { container } = render(<Skeleton className="h-4 w-10" />);
+    const bar = container.firstElementChild;
+    expect(bar?.getAttribute('aria-hidden')).toBe('true');
+    expect(bar?.className).toContain('motion-reduce:animate-none');
+  });
+
+  it('announces a stack of rows exactly once', () => {
+    const { container } = render(<LoadingRows rows={6} />);
+    // One live region for the whole block. A `role="status"` per bar would make
+    // a screen reader walk a wall of empty boxes.
+    expect(screen.getAllByRole('status')).toHaveLength(1);
+    // Each field row is a label bar plus an input bar.
+    expect(bars(container)).toBe(12);
+  });
+
+  it('renders one panel per shape entry, with that entry as its field count', () => {
+    const { container } = render(<PanelStackSkeleton shape={[2, 5]} />);
+    const panels = [...container.querySelectorAll('section')];
+    expect(panels).toHaveLength(2);
+    // Two header bars per panel, then two bars per field row.
+    expect(bars(panels[0]!)).toBe(2 + 2 * 2);
+    expect(bars(panels[1]!)).toBe(2 + 2 * 5);
+  });
+
+  it('announces a whole stack once, not once per panel', () => {
+    // A four-panel page would otherwise read "Loading" four times.
+    render(<PanelStackSkeleton shape={[3, 3, 3, 3]} />);
+    expect(screen.getAllByRole('status')).toHaveLength(1);
+  });
+
+  it('reserves a page-worth of table rows', () => {
+    const { container } = render(<TableSkeleton rows={4} />);
+    // A header band of three bars, then three per row: the loaded table's box
+    // is already the right size when the data lands, so nothing under the thumb
+    // jumps.
+    expect(bars(container)).toBe(3 + 3 * 4);
+    expect(screen.getAllByRole('status')).toHaveLength(1);
+  });
+});

--- a/apps/web/__tests__/route-pending.test.tsx
+++ b/apps/web/__tests__/route-pending.test.tsx
@@ -1,7 +1,12 @@
 // The router keeps the previous route mounted until a navigation's loaders
 // resolve. After sign-in that left the login form on screen through the whole
 // account+dashboard fetch. A global defaultPendingComponent replaces it with a
-// full-screen loading screen once the navigation passes pendingMs.
+// loading screen once the navigation passes pendingMs.
+//
+// The pending screen is in flow, not a `fixed inset-0` overlay — the first test
+// below pins the reason that is safe (the router hides the outgoing match
+// itself), and the last one pins that it stays in flow, so the shell chrome is
+// reachable during a slow load.
 
 import { QueryClientProvider } from '@tanstack/react-query';
 import {
@@ -88,9 +93,12 @@ describe('route pending screen', () => {
 
     void router.navigate({ to: '/slow' });
 
-    // During the pending navigation the router hides the previous route
-    // (display:none) and the pending screen covers the view — so the login form
-    // is no longer visible.
+    // The outgoing route is hidden by React, not by the pending screen's
+    // stacking: each match renders inside a Suspense boundary that is reused
+    // across the transition, and re-suspending a populated boundary hides the
+    // committed nodes with `display: none !important`. That is what keeps the
+    // sign-in form off screen, so the pending screen does not have to cover the
+    // viewport to do its job.
     await waitFor(() => expect(screen.getByTestId('route-pending')).toBeInTheDocument());
     expect(screen.getByTestId('login-marker')).not.toBeVisible();
 
@@ -103,5 +111,21 @@ describe('route pending screen', () => {
   it('wires the pending screen into the real app router', () => {
     expect(appRouter.options.defaultPendingComponent).toBe(RoutePending);
     expect(appRouter.options.defaultPendingMs).toBe(150);
+  });
+
+  // A proxy for the real property, which is "has scroll range under the thumb".
+  // happy-dom does no layout, so height cannot be measured here; these classes
+  // are what produce it.
+  it('renders in flow as a scroll container, so the shell chrome stays reachable', () => {
+    render(<RoutePending />);
+    const pending = screen.getByTestId('route-pending');
+    // `fixed inset-0` would cover the top bar, ticker, health bar and nav for
+    // the length of a slow load, leaving the operator nothing to tap.
+    expect(pending.className).not.toMatch(/\bfixed\b/);
+    // The shell makes <main> a non-scrolling flex column on the full-screen
+    // routes, so the pending screen has to own a scroller there or a touch
+    // lands on something with no range and the app reads as frozen.
+    expect(pending.className).toMatch(/\boverflow-y-auto\b/);
+    expect(pending.className).toMatch(/\bflex-1\b/);
   });
 });

--- a/apps/web/__tests__/symbol-candle-chart-overlays.test.tsx
+++ b/apps/web/__tests__/symbol-candle-chart-overlays.test.tsx
@@ -67,6 +67,21 @@ beforeEach(() => {
 });
 
 describe('SymbolCandleChart overlay/candle effect split', () => {
+  it('leaves the page scroll alone: no touch-drag or wheel handling on the canvas', async () => {
+    render(<SymbolCandleChart candles={candlesA} overlays={{}} loadModule={loadStub} />);
+    await waitFor(() => expect(createChart).toHaveBeenCalledTimes(1));
+    // All three default to on. Left on, the canvas calls preventDefault on the
+    // gestures meant to scroll the page, and on a phone it is a large enough
+    // target that the page simply stops moving wherever a thumb lands.
+    expect(createChart).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        handleScroll: { vertTouchDrag: false, mouseWheel: false },
+        handleScale: { mouseWheel: false },
+      }),
+    );
+  });
+
   it('an overlay-only change repaints lines/markers without rebuilding the chart', async () => {
     const overlays1: ChartOverlays = {
       priceLines: [{ price: '49000.00', label: 'ENTRY', tone: 'entry' }],

--- a/apps/web/__tests__/use-scroll-anchor.test.tsx
+++ b/apps/web/__tests__/use-scroll-anchor.test.tsx
@@ -71,12 +71,45 @@ function reflow(): void {
   flushRaf();
 }
 
+// Real touch events carry a `touches` list of the points still on the glass,
+// and the hook reads its length rather than latching a boolean. happy-dom's
+// Event has no such field, so supply it — a synthetic event without one would
+// let these tests pass against a hook that ignored multi-touch entirely.
+function useClock(): void {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  // The hook treats a 0 timestamp as the epoch, i.e. long idle. Start the clock
+  // well past it so a never-touched scroller is idle from the first frame,
+  // rather than depending on vitest defaulting the fake clock to wall time.
+  vi.setSystemTime(1_700_000_000_000);
+}
+
+function touchEvent(type: 'touchstart' | 'touchend' | 'touchcancel', fingers: number): Event {
+  const event = new Event(type);
+  Object.defineProperty(event, 'touches', { value: { length: fingers } });
+  return event;
+}
+
 function Harness(): React.JSX.Element {
   const ref = useScrollAnchor<HTMLDivElement>();
   return (
     <div ref={ref} data-testid="scroller">
       <section data-testid="content">
         <div data-testid="b">B</div>
+      </section>
+    </div>
+  );
+}
+
+// One hook instance, two different scroller nodes — the ref callback is handed
+// null and then the replacement, which is what a route swapping its scroll
+// container does. Distinct keys so React really replaces the element.
+function SwapHarness({ swapped }: { swapped: boolean }): React.JSX.Element {
+  const ref = useScrollAnchor<HTMLDivElement>();
+  const suffix = swapped ? 'b' : 'a';
+  return (
+    <div key={suffix} ref={ref} data-testid={`scroller-${suffix}`}>
+      <section>
+        <div data-testid={`b-${suffix}`}>B</div>
       </section>
     </div>
   );
@@ -166,24 +199,458 @@ describe('useScrollAnchor', () => {
   });
 
   it('re-anchors against the reader position after a scroll before correcting', () => {
-    const { scroller, b } = mount();
-    trackScrollTop(scroller);
-    seed(scroller, b);
-    reflow(); // baseline anchor = B at 5px
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow(); // baseline anchor = B at 5px
 
-    // Reader scrolls: B is now 2px below the top edge. The scroll listener must
-    // re-capture that new offset.
-    stubRect(b, { top: 2, bottom: 102, width: 100, height: 100 });
-    scroller.dispatchEvent(new Event('scroll'));
-    flushRaf();
+      // Reader scrolls: B is now 2px below the top edge. The scroll listener must
+      // re-capture that new offset.
+      stubRect(b, { top: 2, bottom: 102, width: 100, height: 100 });
+      scroller.dispatchEvent(new Event('scroll'));
+      flushRaf();
 
-    // A reflow above pushes B down to 42px.
-    stubRect(b, { top: 42, bottom: 142, width: 100, height: 100 });
-    reflow();
+      // Let the scroll settle: corrections stay off while the position is still
+      // the reader's, so the reflow below has to land on a quiet scroller.
+      vi.advanceTimersByTime(500);
 
-    // Correction is measured against the post-scroll baseline (2), not the
-    // original (5): delta = 42 - 2 = 40.
-    expect(scroller.scrollTop).toBe(40);
+      // A reflow above pushes B down to 42px.
+      stubRect(b, { top: 42, bottom: 142, width: 100, height: 100 });
+      reflow();
+
+      // Correction is measured against the post-scroll baseline (2), not the
+      // original (5): delta = 42 - 2 = 40.
+      expect(scroller.scrollTop).toBe(40);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A scrollTop write only nudges the reader when the compositor is not already
+  // driving the position. Mid-drag on WebKit it cancels the fling instead, which
+  // is what a reader on iOS feels as the page yanking itself around.
+  //
+  // The wait past SETTLE_MS is what makes this test about the finger rather than
+  // the settle window: a resting finger emits no scroll events, so after 120ms
+  // only the touch count can still hold corrections off. Without it the test
+  // passes against a hook with no finger tracking at all.
+  it('does not correct while a finger rests, however long it stays down', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow(); // baseline anchor = B at 5px
+
+      scroller.dispatchEvent(touchEvent('touchstart', 1));
+      vi.advanceTimersByTime(500);
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // touchend fires once per point lifted, not once per gesture, and reports the
+  // points still down. Treating the first one as the end of the gesture would
+  // let a correction land mid-pinch.
+  it('keeps holding when one finger of a two-finger gesture lifts', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      scroller.dispatchEvent(touchEvent('touchstart', 2));
+      scroller.dispatchEvent(touchEvent('touchend', 1));
+      vi.advanceTimersByTime(500);
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not correct during the momentum that outlives the touch', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      scroller.dispatchEvent(touchEvent('touchstart', 1));
+      scroller.dispatchEvent(new Event('touchmove'));
+      scroller.dispatchEvent(touchEvent('touchend', 0));
+      // The fling is still emitting scroll events; each one re-arms the window.
+      for (let i = 0; i < 5; i += 1) {
+        vi.advanceTimersByTime(50);
+        scroller.dispatchEvent(new Event('scroll'));
+        flushRaf();
+      }
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resumes correcting once the scroll goes quiet', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      scroller.dispatchEvent(touchEvent('touchstart', 1));
+      scroller.dispatchEvent(touchEvent('touchend', 0));
+      vi.advanceTimersByTime(500);
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(40);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The browser takes the gesture away on an orientation change, an app switch
+  // or palm rejection, and touchend never arrives. Without touchcancel wired to
+  // the same handler the count latches and the shim goes dead for the lifetime
+  // of the page — silently, since a dead shim looks exactly like a still one.
+  it('releases the hold when the browser cancels the gesture', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      scroller.dispatchEvent(touchEvent('touchstart', 1));
+      scroller.dispatchEvent(touchEvent('touchcancel', 0));
+      vi.advanceTimersByTime(500);
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(40);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The defect this shim exists for IS a browser-initiated scroll: shrinking
+  // content makes the browser clamp scrollTop, and that clamp emits a scroll
+  // event of its own, dispatched before the rAF that runs the correction
+  // (verified in WebKit). Reading it as the reader taking over would make the
+  // shim stand down for its primary case and re-anchor at the drifted position,
+  // turning a one-frame clamp into permanent drift.
+  it('still corrects when the scroll event came from the browser, not the reader', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      // No touch, no wheel: nothing the reader did produced this.
+      scroller.dispatchEvent(new Event('scroll'));
+      flushRaf();
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(40);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The mirror of the case above: with a gesture behind it, the same scroll
+  // event must suspend corrections. Pins the gate to "was this the reader?"
+  // rather than "ignore scroll events".
+  it('stands down for a wheel scroll, which is the reader driving', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      scroller.dispatchEvent(new Event('wheel'));
+      scroller.dispatchEvent(new Event('scroll'));
+      flushRaf();
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Without this the shim reads the scroll event its own correction emits as the
+  // reader taking over, suspends itself, and re-anchors at the drifted position —
+  // turning one absorbed reflow into permanent drift on the next one.
+  it('does not treat its own correction as reader activity', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      // A gesture that has just ended is the only window where this guard can
+      // matter: past SETTLE_MS so corrections are back on, still within
+      // GESTURE_MS so scroll events are credited to the reader.
+      scroller.dispatchEvent(touchEvent('touchstart', 1));
+      scroller.dispatchEvent(new Event('touchmove'));
+      scroller.dispatchEvent(touchEvent('touchend', 0));
+      vi.advanceTimersByTime(200);
+
+      // First reflow: B drops 20px, the shim corrects.
+      stubRect(b, { top: 25, bottom: 125, width: 100, height: 100 });
+      reflow();
+      expect(scroller.scrollTop).toBe(20);
+      // The write's own scroll event lands on the next frame.
+      scroller.dispatchEvent(new Event('scroll'));
+      flushRaf();
+
+      // A second reflow immediately after must still be corrected.
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+      expect(scroller.scrollTop).toBe(40);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A tap is not a scroll. Marking reader activity on touchstart suppressed
+  // corrections for the settle window after every button press, and credited
+  // the browser's clamp to the reader for a second and a half after it — so a
+  // poll landing just after any tap went uncorrected.
+  it('does not stand down for a tap that never became a drag', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      // Down and up with no touchmove between: a tap, not a drag.
+      scroller.dispatchEvent(touchEvent('touchstart', 1));
+      scroller.dispatchEvent(touchEvent('touchend', 0));
+
+      // The tap changed layout, so the browser clamps and emits a scroll event
+      // of its own. Crediting that to the reader — which is what marking the
+      // tap as activity would do — leaves the clamp uncorrected for good.
+      scroller.dispatchEvent(new Event('scroll'));
+      flushRaf();
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(40);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A hard flick on iOS can outlast GESTURE_MS, and momentum emits no input
+  // events at all — only scroll events. The unbroken-run term is what keeps the
+  // credit alive for as long as the fling actually lasts; without it the shim
+  // starts writing scrollTop into a live fling and cancels it.
+  it('keeps holding through momentum that outlasts the gesture window', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      scroller.dispatchEvent(touchEvent('touchstart', 1));
+      scroller.dispatchEvent(new Event('touchmove'));
+      scroller.dispatchEvent(touchEvent('touchend', 0));
+
+      // 2s of fling — well past GESTURE_MS — with nothing but scroll events.
+      for (let i = 0; i < 40; i += 1) {
+        vi.advanceTimersByTime(50);
+        scroller.dispatchEvent(new Event('scroll'));
+        flushRaf();
+      }
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Keys land on the focused element, so the listener sits on the document and
+  // sees ordinary typing. A character in a filter field scrolls nothing —
+  // crediting it would disarm corrections for GESTURE_MS on exactly the routes
+  // that have both text inputs and polling panels.
+  // Each of the two guards is isolated: an arrow key IS a scroll key but moves
+  // the caret inside a field, and a character is not a scroll key wherever it
+  // lands. A test that fails only when both are removed would let either one be
+  // deleted silently.
+  it.each([
+    { label: 'an arrow key inside a text field', key: 'ArrowDown', inField: true },
+    { label: 'a character typed outside any field', key: 'a', inField: false },
+  ])('does not stand down for $label', ({ key, inField }) => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      const field = document.createElement('input');
+      document.body.appendChild(field);
+      const typed = new Event('keydown', { bubbles: true });
+      Object.defineProperty(typed, 'key', { value: key });
+      (inField ? field : document.body).dispatchEvent(typed);
+
+      // The browser clamps and emits its own scroll event.
+      scroller.dispatchEvent(new Event('scroll'));
+      flushRaf();
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(40);
+      field.remove();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stands down for a PageDown that actually scrolls the page', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      const pressed = new Event('keydown', { bubbles: true });
+      Object.defineProperty(pressed, 'key', { value: 'PageDown' });
+      document.body.dispatchEvent(pressed);
+
+      scroller.dispatchEvent(new Event('scroll'));
+      flushRaf();
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Pins the far edge of GESTURE_MS. Without it any positive value passes, and a
+  // single wheel notch could credit every later scroll event for the session.
+  it('stops crediting scrolls to the reader once the gesture has aged out', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      scroller.dispatchEvent(new Event('wheel'));
+      vi.advanceTimersByTime(2_000);
+      scroller.dispatchEvent(new Event('scroll'));
+      flushRaf();
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(40);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The browser fires touchend at the node the touch started on, and a poll can
+  // remove that node mid-gesture, so the event never reaches the scroller.
+  // Unbounded, that one lost event would hold corrections off forever.
+  it('gives up on a finger that has been down implausibly long', () => {
+    useClock();
+    try {
+      const { scroller, b } = mount();
+      trackScrollTop(scroller);
+      seed(scroller, b);
+      reflow();
+
+      scroller.dispatchEvent(touchEvent('touchstart', 1));
+      vi.advanceTimersByTime(11_000); // past TOUCH_STALE_MS; no touchend ever came
+
+      stubRect(b, { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(scroller.scrollTop).toBe(40);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The layout-stability e2e probe selects the scroller by this marker. Nothing
+  // in CI runs that spec, so without this test the marker could be dropped and
+  // the probe would silently measure the wrong element.
+  it('marks its scroller so the layout-stability probe can find it', () => {
+    const { scroller, unmount } = mount();
+    expect(scroller.dataset['scrollAnchor']).toBe('');
+    unmount();
+    expect(scroller.dataset['scrollAnchor']).toBeUndefined();
+  });
+
+  // The refs live on the hook instance, not the node, so a route that swaps its
+  // scroller element (a loading branch giving way to a loaded one) keeps them.
+  // A finger down on the old node would otherwise hold the new one's
+  // corrections off. Remounting the whole component would NOT show this — that
+  // gets fresh refs and passes either way.
+  it('does not carry a held finger across a scroller swap', () => {
+    useClock();
+    try {
+      const view = render(<SwapHarness swapped={false} />);
+      const first = view.getByTestId('scroller-a');
+      trackScrollTop(first);
+      seed(first, view.getByTestId('b-a'));
+      reflow();
+
+      // Finger down on the old scroller, never lifted.
+      first.dispatchEvent(touchEvent('touchstart', 1));
+
+      view.rerender(<SwapHarness swapped />);
+      const second = view.getByTestId('scroller-b');
+      trackScrollTop(second);
+      seed(second, view.getByTestId('b-b'));
+      reflow();
+
+      stubRect(view.getByTestId('b-b'), { top: 45, bottom: 145, width: 100, height: 100 });
+      reflow();
+
+      expect(second.scrollTop).toBe(40);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('does not write scroll when the captured anchor is removed', () => {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -10,9 +10,81 @@
     <!-- External (not inline) so the strict CSP `script-src 'self'` allows it;
          runs before paint to avoid a theme flash. See public/theme-init.js. -->
     <script src="/theme-init.js"></script>
+    <!-- Boot placeholder styling. Inline and literal, not theme tokens: the
+         token stylesheet is pulled in by the app bundle and is not applied yet
+         at first paint, which is the only moment this markup is on screen.
+         Values track --bg-elevated / --border / --accent in styles/app.css.
+         Inline styling is CSP-safe here because style-src allows
+         'unsafe-inline'; inline scripting is not, hence theme-init.js. -->
+    <style>
+      /* Paints its own canvas: the page background comes from a Tailwind
+         utility on <body>, which lives in that same not-yet-applied
+         stylesheet. */
+      .boot {
+        min-height: 100svh;
+        background: #0e0e0e;
+      }
+      .boot-bar {
+        height: 48px;
+        background: #141414;
+        border-bottom: 2px solid #ffcc00;
+      }
+      .boot-body {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        padding: 16px;
+      }
+      .boot-panel {
+        height: 220px;
+        background: #141414;
+        border: 1px solid #2a2a2a;
+        animation: boot-pulse 2s ease-in-out infinite;
+      }
+      /* Light values are sRGB approximations of the light theme's oklch tokens.
+         The bar keeps its accent rule: border-color is a four-side shorthand
+         and would grey out the bottom edge. */
+      [data-theme='light'] .boot {
+        background: #fcfcfc;
+      }
+      [data-theme='light'] .boot-bar {
+        background: #f7f7f7;
+        border-bottom-color: #e0a838;
+      }
+      [data-theme='light'] .boot-panel {
+        background: #f7f7f7;
+        border-color: #e0e0e0;
+      }
+      @keyframes boot-pulse {
+        50% {
+          opacity: 0.5;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .boot-panel {
+          animation: none;
+        }
+      }
+    </style>
   </head>
   <body class="bg-[var(--bg)] text-[var(--fg)]">
-    <div id="root"></div>
+    <!-- Shown from first paint until React's first commit clears #root. The
+         router's root beforeLoad has to resolve before React renders anything,
+         so on a slow link this container sat empty for seconds: a blank page
+         with no scroll range, which on iOS reads as a frozen app rather than a
+         loading one. Deliberately taller than a phone viewport so a touch has
+         somewhere to drag while the operator waits. -->
+    <div id="root">
+      <div class="boot" role="status" aria-label="Loading">
+        <div class="boot-bar"></div>
+        <div class="boot-body">
+          <div class="boot-panel"></div>
+          <div class="boot-panel"></div>
+          <div class="boot-panel"></div>
+          <div class="boot-panel"></div>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/src/app/route-pending.tsx
+++ b/apps/web/src/app/route-pending.tsx
@@ -1,24 +1,40 @@
-import { Loader2 } from 'lucide-react';
-
-import { t } from '@/shared/lib/i18n';
+import { PageSkeleton } from '@/shared/components/page-skeleton';
 
 /**
  * Global route pending screen, shown once a navigation's loaders pass the
- * router's pendingMs threshold. Fixed and full-screen so it fully covers
- * whatever route is still mounted underneath during the transition. Without it
- * the router keeps the previous route on screen while loaders run, which left
- * the sign-in form visible for the whole post-login account+dashboard fetch.
+ * router's pendingMs threshold.
+ *
+ * In flow, not a `fixed inset-0` overlay. The overlay was there to stop the
+ * outgoing route showing through — after sign-in the form stayed on screen for
+ * the whole account+dashboard fetch — but nothing needs covering: the router
+ * renders each match inside a Suspense boundary it reuses across the outgoing
+ * and incoming route, and React hides the already-committed nodes with
+ * `display: none !important` (`hideInstance` in react-dom) while that boundary
+ * shows this fallback. Covering the viewport only cost the operator the top
+ * bar, ticker, health bar and nav for the length of a slow load; in flow they
+ * stay visible and tappable.
+ *
+ * It owns a scroller, and the skeleton inside is taller than a phone viewport.
+ * This app has no document scroll to fall back on, so a loading screen with no
+ * scroll range leaves a touch landing on something that cannot move, and the
+ * app reads as frozen rather than busy. `flex-1 min-h-0` matters on the
+ * full-screen routes, where the shell makes `<main>` a non-scrolling flex
+ * column and each route supplies its own scroller; on the normal routes
+ * `<main>` already scrolls and this box simply grows to its content.
  */
 export function RoutePending() {
   return (
+    // The skeleton owns the live region; a second one here would announce the
+    // same load twice.
     <div
-      className="bg-bg text-muted-fg fixed inset-0 z-50 flex flex-col items-center justify-center gap-3"
-      role="status"
-      aria-live="polite"
+      className="min-h-0 w-full flex-1 overflow-y-auto overscroll-contain"
+      // Styling hook, separate from the test id: app.css insets this box where
+      // its parent supplies no padding, and a test id is meant to be safe to
+      // rename.
+      data-route-pending=""
       data-testid="route-pending"
     >
-      <Loader2 className="h-6 w-6 animate-spin" aria-hidden="true" />
-      <p className="text-sm">{t('common.loading')}</p>
+      <PageSkeleton />
     </div>
   );
 }

--- a/apps/web/src/features/account/components/ai-provider-card.tsx
+++ b/apps/web/src/features/account/components/ai-provider-card.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/features/account/api/ai-provider';
 
 import type { AiProvider } from '@app/contracts';
+import { LoadingRows } from '@/shared/components/page-skeleton';
 
 const SELECT_CLASS =
   'border-border bg-bg-elevated text-fg w-full rounded-md border px-3 py-2 text-sm sm:w-72';
@@ -105,7 +106,7 @@ export function AiProviderCard(): React.JSX.Element {
       testId="ai-provider-card"
     >
       <div className="space-y-4">
-        {q.isLoading ? <p className="text-muted-fg text-sm">Loading…</p> : null}
+        {q.isLoading ? <LoadingRows /> : null}
 
         <div className="space-y-1">
           <Label htmlFor="ai-provider-select">Provider</Label>

--- a/apps/web/src/features/account/components/backup-settings-card.tsx
+++ b/apps/web/src/features/account/components/backup-settings-card.tsx
@@ -144,7 +144,10 @@ export function BackupSettingsCard(): React.JSX.Element {
   if (status === null) {
     return (
       <Panel title="Automatic backups">
-        <LoadingRows />
+        {/* Sized against the loaded card — three status rows, a four-control
+            form, then the recent-backups list — so the panels below it do not
+            slide down when the fetch lands. */}
+        <LoadingRows rows={12} />
       </Panel>
     );
   }

--- a/apps/web/src/features/account/components/backup-settings-card.tsx
+++ b/apps/web/src/features/account/components/backup-settings-card.tsx
@@ -20,6 +20,7 @@ import { Switch } from '@/shared/components/ui/switch';
 import { errorMessage } from '@/shared/lib/api';
 import { humaniseAge } from '@/shared/lib/format-time';
 import { fetchBackupConfig, putBackupConfig } from '@/features/account/api/backup-config';
+import { LoadingRows } from '@/shared/components/page-skeleton';
 
 // Mirror the server bounds (`BackupConfigPut`) so the client catches an
 // out-of-range value before the round trip. The server 422 remains the backstop.
@@ -143,7 +144,7 @@ export function BackupSettingsCard(): React.JSX.Element {
   if (status === null) {
     return (
       <Panel title="Automatic backups">
-        <p className="text-muted-fg text-sm">Loading…</p>
+        <LoadingRows />
       </Panel>
     );
   }

--- a/apps/web/src/features/account/components/ops-health-panel.tsx
+++ b/apps/web/src/features/account/components/ops-health-panel.tsx
@@ -11,6 +11,7 @@ import { Panel } from '@/shared/components/panel';
 import { Alert, AlertDescription, AlertTitle } from '@/shared/components/ui/alert';
 import { formatLastTick } from '@/shared/lib/format-tick';
 import { cn } from '@/shared/lib/cn';
+import { LoadingRows } from '@/shared/components/page-skeleton';
 
 const POLL_MS = 30_000;
 
@@ -39,7 +40,7 @@ export function OpsHealthPanel(): React.JSX.Element {
       }
     >
       <div className="space-y-3">
-        {q.isLoading ? <p className="text-muted-fg text-sm">Loading…</p> : null}
+        {q.isLoading ? <LoadingRows /> : null}
 
         {q.error ? (
           <Alert variant="danger">

--- a/apps/web/src/features/account/components/ops-notify-card.tsx
+++ b/apps/web/src/features/account/components/ops-notify-card.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/features/account/api/ops-notify';
 
 import { ACCOUNT_NOTIFY_EVENT_CATALOG, type OpsNotifyConfig } from '@app/contracts';
+import { LoadingRows } from '@/shared/components/page-skeleton';
 
 /**
  * The ops-alert card. Owns the ops-config query and the patch mutation; renders
@@ -50,7 +51,7 @@ export function OpsNotifyCard(): React.JSX.Element {
       testId="ops-notify-card"
     >
       <div className="space-y-3">
-        {q.isLoading ? <p className="text-muted-fg text-sm">Loading…</p> : null}
+        {q.isLoading ? <LoadingRows /> : null}
 
         <ActionBanner banner={banner} />
 

--- a/apps/web/src/features/account/routes/account.orphan-orders.tsx
+++ b/apps/web/src/features/account/routes/account.orphan-orders.tsx
@@ -32,6 +32,7 @@ import { useTimezone } from '@/shared/context/timezone-context';
 
 import { isRestingSell } from '@app/contracts';
 import type { OrphanOrderView } from '@app/contracts';
+import { PanelStackSkeleton } from '@/shared/components/page-skeleton';
 
 const lastChecked = (computedAtMs: number | null, timeZone: string): string =>
   computedAtMs === null
@@ -97,7 +98,7 @@ function OrphanOrdersPage(): React.JSX.Element {
         with it.
       </p>
 
-      {query.isLoading ? <p className="text-sm">Loading…</p> : null}
+      {query.isLoading ? <PanelStackSkeleton shape={[4]} /> : null}
       {query.error ? (
         <Alert variant="danger">
           <AlertTitle>Failed to load</AlertTitle>

--- a/apps/web/src/features/backtest/components/equity-area-chart.tsx
+++ b/apps/web/src/features/backtest/components/equity-area-chart.tsx
@@ -95,7 +95,18 @@ export function EquityAreaChart({
     void load()
       .then((mod) => {
         if (cancelled || !container) return;
-        const c = mod.createChart(container, { height, autoSize: true, ...CHART_LAYOUT });
+        // These default to on, which lets the canvas swallow the page's vertical
+        // scroll wherever it sits under the pointer or thumb. Both mouseWheel
+        // flags, not just the scale one: the wheel handler bails early only when
+        // both axes are opted out, so a trackpad's incidental horizontal delta
+        // still reached preventDefault.
+        const c = mod.createChart(container, {
+          height,
+          autoSize: true,
+          ...CHART_LAYOUT,
+          handleScroll: { vertTouchDrag: false, mouseWheel: false },
+          handleScale: { mouseWheel: false },
+        });
         chart = c;
         const series = c.addSeries(mod.AreaSeries, { lineColor, topColor, bottomColor });
         // Collapse to ascending-unique seconds (lightweight-charts rejects

--- a/apps/web/src/features/dashboard/components/equity-pnl-card.tsx
+++ b/apps/web/src/features/dashboard/components/equity-pnl-card.tsx
@@ -16,6 +16,7 @@ import { patchProfile } from '@/features/profile/api/profiles-mutations';
 import { formatMoneyAmount, formatPercent } from '@/shared/lib/format';
 import { formatDate, formatInstant } from '@/shared/lib/format-time';
 import { useTimezone } from '@/shared/context/timezone-context';
+import { LoadingRows } from '@/shared/components/page-skeleton';
 
 interface ChartPoint {
   tsMs: number;
@@ -176,7 +177,7 @@ export function EquityPnlCard({ profileId }: { profileId: string }): React.JSX.E
       {isError ? (
         <p className="text-down text-sm">Could not load the profit history.</p>
       ) : isPending ? (
-        <p className="text-muted-fg text-sm">Loading…</p>
+        <LoadingRows />
       ) : series.length === 0 ? (
         <p className="text-muted-fg text-sm">
           No profit history yet — the first point is recorded within 15 minutes of the worker

--- a/apps/web/src/features/dashboard/components/market-trend-card.tsx
+++ b/apps/web/src/features/dashboard/components/market-trend-card.tsx
@@ -165,6 +165,32 @@ function BreadthRow({
 }
 
 /**
+ * The card's outer frame, shared by the loading, warming and loaded branches.
+ *
+ * Module scope is load-bearing, not style. Declared inside the component its
+ * identity changes every render, so React tears the whole subtree down and
+ * rebuilds it rather than updating in place. The countdown below re-renders
+ * once a second, and each teardown briefly removed this card's full height from
+ * the dashboard scroller — long enough for the browser to clamp `scrollTop` to
+ * the shorter content, and never restored when the height came back. An
+ * operator reading the bottom of the overview was pulled upward once a second.
+ */
+function Shell({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <section
+      className="@container space-y-2"
+      aria-label="Market trend"
+      data-testid="market-trend-card"
+    >
+      <h2 className="text-muted-fg text-[11px] font-semibold uppercase tracking-wider">
+        Market trend
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+/**
  * Render the market-trend card. Loading and warming (no snapshot yet) collapse
  * to a single muted line so the dashboard never flashes a zeroed band.
  */
@@ -183,19 +209,6 @@ export function MarketTrendCard(): React.JSX.Element | null {
     const id = setInterval(() => setNowMs(Date.now()), 1000);
     return () => clearInterval(id);
   }, []);
-
-  const Shell = ({ children }: { children: React.ReactNode }) => (
-    <section
-      className="@container space-y-2"
-      aria-label="Market trend"
-      data-testid="market-trend-card"
-    >
-      <h2 className="text-muted-fg text-[11px] font-semibold uppercase tracking-wider">
-        Market trend
-      </h2>
-      {children}
-    </section>
-  );
 
   if (q.isLoading) {
     return (

--- a/apps/web/src/features/dashboard/routes/index.tsx
+++ b/apps/web/src/features/dashboard/routes/index.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, ShieldAlert } from 'lucide-react';
 
 import { cn } from '@/shared/lib/cn';
 import { PnlValue } from '@/shared/components/pnl-value';
+import { PanelStackSkeleton } from '@/shared/components/page-skeleton';
 import { RouteErrorCard } from '@/shared/components/route-error-card';
 import { Badge } from '@/shared/components/ui/badge';
 import { Button } from '@/shared/components/ui/button';
@@ -77,10 +78,20 @@ export function DashboardOverview({ focusedProfileId }: { focusedProfileId: stri
   // Guard the first paint. Without it `data` is undefined during load, the
   // empty-state check below is skipped, and the full layout renders with
   // profiles=[] — a zeroed dashboard flashed before real numbers arrive.
+  //
+  // The placeholder carries the loaded view's scroller and padding, not just
+  // its own text: the shell drops <main>'s scroll on this route, so a loading
+  // branch that skips them leaves nothing scrollable under a thumb for the
+  // length of the fetch. Shape mirrors the real stack — KPI strip, equity,
+  // positions, symbol table.
   if (isLoading) {
     return (
-      <section className="space-y-6" aria-label={t('nav.home')}>
-        <p className="text-muted-fg text-sm">{t('home.loading')}</p>
+      <section
+        className="min-h-0 flex-1 overflow-y-auto p-4"
+        aria-label={t('nav.home')}
+        data-testid="dashboard-loading"
+      >
+        <PanelStackSkeleton shape={[2, 3, 5, 6]} />
       </section>
     );
   }

--- a/apps/web/src/features/notifications/components/event-subscriptions.tsx
+++ b/apps/web/src/features/notifications/components/event-subscriptions.tsx
@@ -15,6 +15,7 @@ import { ApiError } from '@/shared/lib/api';
 import { fetchProfile, patchProfile, profileQueryKey } from '@/features/profile/api/profile';
 
 import { PROFILE_NOTIFY_EVENT_CATALOG, type ProfileNotifyEvents } from '@app/contracts';
+import { LoadingRows } from '@/shared/components/page-skeleton';
 
 /**
  * The subscription section. Self-contained: owns the profile query (for the
@@ -51,7 +52,7 @@ export function EventSubscriptions({
       testId="event-subscriptions"
     >
       <div className="space-y-3">
-        {profile.isLoading ? <p className="text-muted-fg text-sm">Loading…</p> : null}
+        {profile.isLoading ? <LoadingRows /> : null}
 
         <ActionBanner banner={banner} />
 

--- a/apps/web/src/features/profile/components/api-key-panel.tsx
+++ b/apps/web/src/features/profile/components/api-key-panel.tsx
@@ -26,6 +26,7 @@ import { useTimezone } from '@/shared/context/timezone-context';
 import { ApiKeyGuidance } from '@/features/profile/components/api-key-guidance';
 import { apiKeyQueryKey, fetchApiKey, putApiKey } from '@/features/profile/api/api-keys';
 import { useActiveAccountId } from '@/shared/lib/account-scope';
+import { LoadingRows } from '@/shared/components/page-skeleton';
 
 /**
  * Self-contained Binance API-key editor. Renders the load/error states, the
@@ -92,7 +93,7 @@ export function ApiKeyPanel(): React.JSX.Element {
       testId="api-key-panel"
     >
       <div className="space-y-4">
-        {apiKey.isLoading ? <p className="text-sm">Loading…</p> : null}
+        {apiKey.isLoading ? <LoadingRows /> : null}
 
         {apiKey.error ? (
           <Alert variant="danger">

--- a/apps/web/src/features/profile/components/audit-log-panel.tsx
+++ b/apps/web/src/features/profile/components/audit-log-panel.tsx
@@ -34,6 +34,7 @@ import {
 import { recommendationLabel } from '@/shared/lib/technicals-format';
 
 import { titleCase } from '@app/contracts';
+import { TableSkeleton } from '@/shared/components/page-skeleton';
 
 /**
  * Event kinds whose payload carries a single `symbol`. When an audit row
@@ -332,7 +333,7 @@ export function AuditLogPanel({
         </div>
       </div>
 
-      {list.isLoading ? <p className="text-muted-fg text-sm">Loading…</p> : null}
+      {list.isLoading ? <TableSkeleton /> : null}
 
       {list.error ? (
         <Alert variant="danger">

--- a/apps/web/src/features/profile/components/enablement-policy-panel.tsx
+++ b/apps/web/src/features/profile/components/enablement-policy-panel.tsx
@@ -21,6 +21,7 @@ import { Input } from '@/shared/components/ui/input';
 import { Label } from '@/shared/components/ui/label';
 import { Switch } from '@/shared/components/ui/switch';
 import { Panel } from '@/shared/components/panel';
+import { PanelStackSkeleton } from '@/shared/components/page-skeleton';
 
 interface NumberFieldProps {
   readonly id: string;
@@ -122,7 +123,9 @@ export function EnablementPolicyPanel({
     value: EnablementPolicy['monitor'][K],
   ): void => setForm((f) => (f ? { ...f, monitor: { ...f.monitor, [key]: value } } : f));
 
-  if (!form) return <p className="text-muted-fg text-sm">Loading…</p>;
+  // Two panels land here — the quality-check essentials and the advanced
+  // thresholds — so stand in for both rather than a lone row of bars.
+  if (!form) return <PanelStackSkeleton shape={[5, 4]} />;
 
   return (
     <div className="space-y-6" data-testid="enablement-policy-panel">

--- a/apps/web/src/features/profile/components/profile-config-panel.tsx
+++ b/apps/web/src/features/profile/components/profile-config-panel.tsx
@@ -50,6 +50,7 @@ import {
 } from '@/features/symbol/preview/account-wire';
 import { fetchExchangeInfo } from '@/features/symbol/api/exchange-info';
 import { queryDefaults } from '@/shared/lib/query-client';
+import { PanelStackSkeleton } from '@/shared/components/page-skeleton';
 
 /**
  * Self-contained profile-config editor. Renders the load/error/ready states for
@@ -184,7 +185,9 @@ export function ProfileConfigPanel({
 
   return (
     <div className="space-y-6" data-testid="profile-config-panel">
-      {profile.isLoading ? <p className="text-muted-fg text-xs tracking-wide">Loading…</p> : null}
+      {/* Shape mirrors what lands here: strategy picker, diagnostics, then the
+          generated config form's groups. */}
+      {profile.isLoading ? <PanelStackSkeleton shape={[1, 3, 5, 4]} /> : null}
 
       {profile.error ? (
         <Alert variant="danger">

--- a/apps/web/src/features/profile/components/profile-general-panel.tsx
+++ b/apps/web/src/features/profile/components/profile-general-panel.tsx
@@ -44,6 +44,7 @@ import { Input } from '@/shared/components/ui/input';
 import { Label } from '@/shared/components/ui/label';
 import { ApiError } from '@/shared/lib/api';
 import { t } from '@/shared/lib/i18n';
+import { PanelStackSkeleton } from '@/shared/components/page-skeleton';
 
 type ProfileRow = DashboardAggregateResponse['profiles'][number];
 
@@ -61,7 +62,7 @@ export function ProfileGeneralPanel({
   // Mirror the gate panel: a brief Loading line while the aggregate resolves,
   // then nothing if the profile is genuinely absent.
   if (!row) {
-    return aggregate.isLoading ? <p className="text-muted-fg text-sm">Loading…</p> : null;
+    return aggregate.isLoading ? <PanelStackSkeleton shape={[1, 3, 2, 3]} /> : null;
   }
   // The account's other profiles are the candidate handoff targets when this
   // profile is deleted with live exposure. Derived from the same aggregate the

--- a/apps/web/src/features/profile/components/trade-archive-panel.tsx
+++ b/apps/web/src/features/profile/components/trade-archive-panel.tsx
@@ -58,6 +58,7 @@ import {
 } from '@/features/profile/api/archive';
 
 import type { ArchivePeriod, TradeArchiveResponse, UnreconstructableReason } from '@app/contracts';
+import { TableSkeleton } from '@/shared/components/page-skeleton';
 
 /** Plain-language reason a coin's closed P/L can't be reconstructed from Binance history. */
 function glossUnreconstructable(reason: UnreconstructableReason): string {
@@ -504,7 +505,7 @@ export function TradeArchivePanel({ profileId }: { profileId: string }): React.J
         </section>
       ) : null}
 
-      {list.isLoading ? <p className="text-muted-fg text-sm">Loading…</p> : null}
+      {list.isLoading ? <TableSkeleton /> : null}
 
       {list.error ? (
         <Alert variant="danger">

--- a/apps/web/src/features/symbol/components/symbol-candle-chart.tsx
+++ b/apps/web/src/features/symbol/components/symbol-candle-chart.tsx
@@ -367,6 +367,17 @@ export function SymbolCandleChart({
             vertLines: { color: CHART_COLORS.border },
             horzLines: { color: CHART_COLORS.border },
           },
+          // The canvas sits inside the page scroller, and lightweight-charts
+          // defaults these to on: it then consumes vertical drags and wheel
+          // ticks that were meant to scroll the page. On a phone the canvas is a
+          // large target, so the page simply stops scrolling wherever a thumb
+          // lands on it. Both mouseWheel flags have to go, not just the scale
+          // one: the wheel handler only bails early when BOTH axes are opted
+          // out, so a trackpad's incidental horizontal delta still reached
+          // preventDefault. With both off no wheel listener is attached at all.
+          // Drag-to-pan and pinch zoom stay on.
+          handleScroll: { vertTouchDrag: false, mouseWheel: false },
+          handleScale: { mouseWheel: false },
         });
         const fmt = priceFormatRef.current;
         const series = chart.addSeries(mod.CandlestickSeries, {

--- a/apps/web/src/features/symbol/components/symbol-config-panel.tsx
+++ b/apps/web/src/features/symbol/components/symbol-config-panel.tsx
@@ -43,6 +43,7 @@ import {
 import { queryDefaults } from '@/shared/lib/query-client';
 import { ActionBanner, type ActionBannerState } from '@/shared/components/action-banner';
 import { errorMessage } from '@/shared/lib/api';
+import { PanelStackSkeleton } from '@/shared/components/page-skeleton';
 
 /**
  * Self-contained symbol-config editor. Renders the load/error/ready states for
@@ -130,7 +131,9 @@ export function SymbolConfigPanel({
 
   return (
     <div className="space-y-6" data-testid="symbol-config-panel">
-      {!ready && !loadError ? <p className="text-sm">Loading…</p> : null}
+      {/* Shape mirrors what lands here: the reserve card, then the override
+          form's groups. */}
+      {!ready && !loadError ? <PanelStackSkeleton shape={[2, 5, 4]} /> : null}
 
       {loadError ? (
         <Alert variant="danger">

--- a/apps/web/src/features/symbol/components/symbol-workspace.tsx
+++ b/apps/web/src/features/symbol/components/symbol-workspace.tsx
@@ -69,6 +69,7 @@ import type {
   SymbolLogEntry,
   SymbolStateResponse,
 } from '@app/contracts';
+import { PanelStackSkeleton } from '@/shared/components/page-skeleton';
 
 // Per-tab bodies are lazy so each tab's chunk (and its socket subscriptions,
 // for market) loads only when that tab first activates.
@@ -352,7 +353,7 @@ function SymbolWorkspaceInner({
           content flows at its own height. A bounded flex-1 box here would clip
           tall content. */}
       <div className="space-y-4 p-4">
-        <Suspense fallback={<p className="text-muted-fg text-sm">Loading…</p>}>
+        <Suspense fallback={<PanelStackSkeleton shape={[4, 3]} />}>
           {activeTab === 'trade' ? (
             <WorkspaceTradeTab
               profileId={profileId}

--- a/apps/web/src/shared/components/page-skeleton.tsx
+++ b/apps/web/src/shared/components/page-skeleton.tsx
@@ -1,0 +1,147 @@
+// Loading placeholders that mirror the real page furniture: a PageHeader-sized
+// title block followed by Panel-shaped boxes carrying the same border,
+// elevation and internal rhythm as `Panel`. Mirroring the finished layout
+// rather than showing a bare frame or a lone spinner is what lets the operator
+// read where things will land before the data arrives.
+//
+// Height is the point, not the decoration. The shell owns the only scroll
+// surface and the document itself never scrolls, so a loading screen with no
+// height leaves nothing under the thumb to drag: on a phone the app reads as
+// frozen for the whole fetch rather than as busy. These blocks give the
+// scroller a real range from the first frame.
+
+import { Skeleton } from '@/shared/components/ui/skeleton';
+import { t } from '@/shared/lib/i18n';
+
+/**
+ * The announcement every placeholder carries. Exactly one per loading surface:
+ * the bars themselves are `aria-hidden`, and a live region per bar (or per
+ * panel in a stack) would make a screen reader read "Loading" once for every
+ * box on the page.
+ */
+function LoadingStatus({ children }: { readonly children: React.ReactNode }): React.JSX.Element {
+  return (
+    <div role="status" aria-live="polite">
+      <span className="sr-only">{t('common.loading')}</span>
+      {children}
+    </div>
+  );
+}
+
+/** Bare field-row bars. Silent — a caller above supplies the announcement. */
+function FieldRows({ rows }: { readonly rows: number }): React.JSX.Element {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: rows }, (_, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <Skeleton className="h-3 w-24 shrink-0" />
+          <Skeleton className="h-8 flex-1" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Field-row placeholders for a surface that already draws its own frame.
+ * Use inside a `Panel` in place of a one-line "Loading…", which occupies no
+ * height and so leaves the page unscrollable for the length of the fetch.
+ */
+export function LoadingRows({ rows = 3 }: { readonly rows?: number }): React.JSX.Element {
+  return (
+    <LoadingStatus>
+      <FieldRows rows={rows} />
+    </LoadingStatus>
+  );
+}
+
+/**
+ * A Panel-shaped placeholder: header block, hairline, then `rows` field rows.
+ * Silent on its own — stacks announce once, via `PanelStackSkeleton`.
+ */
+function PanelSkeleton({ rows }: { readonly rows: number }): React.JSX.Element {
+  return (
+    <section className="border-border bg-bg-elevated border">
+      <div className="space-y-2 px-4 py-3">
+        <Skeleton className="h-4 w-40 max-w-full" />
+        <Skeleton className="h-3 w-64 max-w-full" />
+      </div>
+      <div className="border-border border-t p-4">
+        <FieldRows rows={rows} />
+      </div>
+    </section>
+  );
+}
+
+/**
+ * A list surface: the same bordered box the loaded tables draw, with a header
+ * band and `rows` row bars on hairlines. Row height tracks the real table's, so
+ * the box a page-worth of results will occupy is already reserved.
+ */
+export function TableSkeleton({ rows = 8 }: { readonly rows?: number }): React.JSX.Element {
+  return (
+    <LoadingStatus>
+      <div className="border-border rounded-md border">
+        <div className="border-border flex items-center gap-4 border-b px-3 py-2">
+          <Skeleton className="h-3 w-20 shrink-0" />
+          <Skeleton className="h-3 flex-1" />
+          <Skeleton className="h-3 w-16 shrink-0" />
+        </div>
+        {Array.from({ length: rows }, (_, i) => (
+          <div
+            key={i}
+            className="border-border flex items-center gap-4 border-b px-3 py-3 last:border-b-0"
+          >
+            <Skeleton className="h-3 w-24 shrink-0" />
+            <Skeleton className="h-3 flex-1" />
+            <Skeleton className="h-3 w-12 shrink-0" />
+          </div>
+        ))}
+      </div>
+    </LoadingStatus>
+  );
+}
+
+// Uneven row counts on purpose: equal blocks read as a rendering glitch, a
+// varied stack reads as content. Four panels clear a 667px phone viewport, so
+// the scroller has somewhere to go while the operator waits.
+const DEFAULT_SHAPE = [3, 4, 2, 3];
+
+/**
+ * The panel stack a page body renders once loaded. `shape` is one entry per
+ * real panel, its value that panel's field count — describe the surface being
+ * stood in for rather than accepting the generic default, or the placeholder
+ * lands the operator's eye somewhere the content will not be.
+ */
+export function PanelStackSkeleton({
+  shape = DEFAULT_SHAPE,
+}: {
+  readonly shape?: readonly number[];
+}): React.JSX.Element {
+  return (
+    <LoadingStatus>
+      <div className="space-y-6">
+        {shape.map((rows, i) => (
+          <PanelSkeleton key={i} rows={rows} />
+        ))}
+      </div>
+    </LoadingStatus>
+  );
+}
+
+/**
+ * Whole-page placeholder: PageHeader-sized title block plus a panel stack.
+ * Used where the route is not yet known (the router's pending screen), so it
+ * takes no shape — a generic page is the most that can be said there.
+ */
+export function PageSkeleton(): React.JSX.Element {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <Skeleton className="h-6 w-52 max-w-full" />
+        <Skeleton className="h-3 w-72 max-w-full" />
+      </header>
+      <PanelStackSkeleton />
+    </div>
+  );
+}

--- a/apps/web/src/shared/components/ui/skeleton.tsx
+++ b/apps/web/src/shared/components/ui/skeleton.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/shared/lib/cn';
+
+/**
+ * One placeholder block, sized by the caller.
+ *
+ * Decorative by contract: it carries `aria-hidden`, so the surface that owns
+ * the loading state announces once via `role="status"` instead of a screen
+ * reader walking a wall of empty boxes.
+ *
+ * The pulse is dropped under `prefers-reduced-motion`. A full page of
+ * synchronised pulsing is the vestibular trigger that accessibility guidance on
+ * skeleton screens warns about, and the layout still reads without it.
+ */
+export function Skeleton({ className }: { readonly className?: string }): React.JSX.Element {
+  return (
+    <div
+      aria-hidden="true"
+      // Stable hook so tests can count bars without walking wrapper nesting.
+      data-skeleton-bar=""
+      className={cn('bg-skeleton animate-pulse motion-reduce:animate-none', className)}
+    />
+  );
+}

--- a/apps/web/src/shared/lib/i18n.ts
+++ b/apps/web/src/shared/lib/i18n.ts
@@ -71,7 +71,6 @@ const en: Readonly<Record<string, string>> = {
   'profile.switcher.all': 'All profiles',
   'profile.switcher.kill_switch': 'Kill switch active on at least one profile',
   'home.heading': 'Overview',
-  'home.loading': 'Loading dashboard…',
   'home.summary.unrealised': 'Unrealised P/L',
   'home.summary.practice': 'Testnet (practice)',
   'home.summary.positions': 'Open positions',

--- a/apps/web/src/shared/lib/use-scroll-anchor.ts
+++ b/apps/web/src/shared/lib/use-scroll-anchor.ts
@@ -4,6 +4,57 @@ import { useCallback, useEffect, useRef } from 'react';
 // layout jitter not worth a scroll write (and risks a feedback wobble).
 const MIN_DELTA_PX = 0.5;
 
+// How long after the last reader-driven scroll event the position is still
+// treated as theirs. WebKit runs scrolling on the compositor, so writing
+// `scrollTop` while a drag or its momentum is live does not nudge the reader —
+// it cancels the fling and snaps them back to the last offset the main thread
+// observed. Corrections wait for the scroll to go quiet instead.
+const SETTLE_MS = 120;
+
+// A correction of our own makes the browser emit a scroll event. Events this
+// close behind a write are ours, not the reader's; counting them would let the
+// shim suspend itself and bake the drift it was about to remove into the next
+// anchor.
+const SELF_WRITE_WINDOW_MS = 50;
+
+// How long after the reader's last drag, wheel notch or scrolling key a scroll
+// event is still credited to them. This is a floor, not the whole story: iOS
+// momentum can outlast it, and the unbroken-run term in `onScroll` is what
+// carries the credit for as long as the fling actually lasts.
+const GESTURE_MS = 1_500;
+
+// A finger that has produced no touch event for this long is a `touchend` we
+// never received, not a live gesture: the browser fires it at the node the
+// touch started on, and this app's polling can remove that node mid-gesture, so
+// the event has no path back to the scroller. Unbounded, one lost event would
+// hold corrections off for the lifetime of the page — a dead shim looks exactly
+// like a still one, so it must degrade rather than wedge.
+const TOUCH_STALE_MS = 10_000;
+
+// Keys the browser scrolls with. A typed character is not one of them, and
+// crediting it would let the next clamp bake its drift in for GESTURE_MS — the
+// same mistake as treating a tap as a drag.
+const SCROLL_KEYS = new Set([
+  ' ',
+  'PageUp',
+  'PageDown',
+  'Home',
+  'End',
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+]);
+
+/** In a field these move the caret; the page does not scroll. */
+function isTextEntry(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el) return false;
+  if (el.isContentEditable) return true;
+  const tag = el.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
 // Hit-test the top of the scroller's viewport for the element painted there.
 // elementFromPoint, not a box-descent over children: content routinely
 // overflows a height-clamped flex ancestor (`min-h-0 flex-1`) whose own box
@@ -20,14 +71,33 @@ function topVisibleLeaf(scroller: HTMLElement): Element | null {
 }
 
 /**
- * Scroll-anchoring shim for WebKit/Safari, which has never shipped
- * `overflow-anchor`. When polled content above the viewport reflows (the app
+ * Scroll-anchoring shim for WebKit/Safari. `overflow-anchor` has reached
+ * Technology Preview and the Safari 27 beta, but no stable Safari release ships
+ * it and no iOS Safari release supports it (caniuse.com/css-overflow-anchor,
+ * checked 2026-08); once it lands on iOS this hook can be deleted in favour of
+ * the native property. When polled content above the viewport reflows (the app
  * refetches on a timer across every screen), WebKit keeps the raw `scrollTop`
  * and the reader is shoved off their spot — most visibly, someone reading at
  * the bottom is bounced upward on the next tick — while Blink silently holds
  * the visual position. This reproduces Blink's behaviour: capture the top-most
  * visible element's offset from the scroller's top edge, and after each reflow
  * nudge `scrollTop` so that element stays put.
+ *
+ * Corrections only ever run while the reader's own scrolling is idle. A write
+ * landing mid-drag or mid-momentum is worse than the drift it removes: on
+ * WebKit the compositor owns the position then, so the write kills the fling
+ * and teleports the reader. The cost is that a reflow arriving mid-flick goes
+ * uncorrected — the reader is already moving, so it is not a position they were
+ * holding. "Idle" is measured against gestures, not scroll events: a clamp
+ * emits a scroll event of its own, and standing down for that would disable the
+ * shim exactly when it is needed.
+ *
+ * Known gap: a scrollbar-thumb drag emits no touch, wheel or key event, so it
+ * is not recognised as the reader and a reflow during one is still corrected.
+ * That is desktop-only, where scrolling is not compositor-driven and a write
+ * nudges rather than cancels, so it costs a small jump rather than a killed
+ * fling. Accepted over listening for `pointerdown`, which fires on every tap
+ * and would re-open the far worse case of taps suppressing corrections.
  *
  * Returns one ref callback for the scroll container (the element with
  * `overflow-y: scroll|auto`). Content below the viewport growing or shrinking
@@ -41,6 +111,13 @@ export function useScrollAnchor<T extends HTMLElement = HTMLElement>(): (node: T
   const mutationObs = useRef<MutationObserver | null>(null);
   const captureRaf = useRef(0);
   const restoreRaf = useRef(0);
+  // Reader-owned-scroll tracking. `lastScrollAt` starts at 0 (the epoch) so a
+  // scroller that has never been touched is idle from the first frame.
+  const touchCount = useRef(0);
+  const lastTouchAt = useRef(0);
+  const lastScrollAt = useRef(0);
+  const lastInputAt = useRef(0);
+  const selfWriteAt = useRef(0);
 
   const capture = useCallback(() => {
     const scroller = scrollerRef.current;
@@ -53,6 +130,18 @@ export function useScrollAnchor<T extends HTMLElement = HTMLElement>(): (node: T
     }
   }, []);
 
+  /** A finger genuinely still on the glass, not a `touchend` that went missing. */
+  const fingerDown = useCallback(
+    () => touchCount.current > 0 && Date.now() - lastTouchAt.current < TOUCH_STALE_MS,
+    [],
+  );
+
+  /** True while a finger is down or the scroll it threw is still settling. */
+  const readerOwnsScroll = useCallback(
+    () => fingerDown() || Date.now() - lastScrollAt.current < SETTLE_MS,
+    [fingerDown],
+  );
+
   const restore = useCallback(() => {
     const scroller = scrollerRef.current;
     const anchor = anchorRef.current;
@@ -60,12 +149,21 @@ export function useScrollAnchor<T extends HTMLElement = HTMLElement>(): (node: T
       capture();
       return;
     }
+    // Re-anchor to wherever the reader currently is and leave the position
+    // alone; correcting now would fight the gesture rather than absorb a reflow.
+    if (readerOwnsScroll()) {
+      capture();
+      return;
+    }
     const newTop = anchor.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
     const delta = newTop - anchorTopRef.current;
-    if (Math.abs(delta) > MIN_DELTA_PX) scroller.scrollTop += delta;
+    if (Math.abs(delta) > MIN_DELTA_PX) {
+      selfWriteAt.current = Date.now();
+      scroller.scrollTop += delta;
+    }
     // Re-anchor from the settled layout so the next reflow measures against it.
     capture();
-  }, [capture]);
+  }, [capture, readerOwnsScroll]);
 
   // Both observers fire mid-frame; defer to a rAF so a multi-node React commit
   // coalesces into one pass and we read the settled layout before paint.
@@ -85,28 +183,117 @@ export function useScrollAnchor<T extends HTMLElement = HTMLElement>(): (node: T
     });
   }, [restore]);
 
+  const onScroll = useCallback(() => {
+    const now = Date.now();
+    const isSelfWrite = now - selfWriteAt.current <= SELF_WRITE_WINDOW_MS;
+    // A scroll event is not proof the reader scrolled. When content above the
+    // viewport shrinks the browser clamps `scrollTop` and emits one too — and
+    // that clamp is the exact reflow this shim exists to undo, dispatched (as
+    // the scroll step of the update-the-rendering cycle) before the rAF that
+    // runs `restore`. Crediting it to the reader would make the shim stand down
+    // for its own primary case and re-anchor at the drifted position, turning a
+    // one-frame clamp into permanent drift. Only a scroll with a gesture behind
+    // it is theirs.
+    // Three things count as the reader: a finger on the glass, a recent
+    // drag/wheel/key, or an unbroken run of scroll events already credited to
+    // them. The last term is what carries iOS momentum, which emits no input
+    // events at all and can outlast any fixed window — and a lone clamp cannot
+    // start such a run, because its own first event is never credited.
+    const gestureDriven =
+      fingerDown() ||
+      now - lastInputAt.current < GESTURE_MS ||
+      now - lastScrollAt.current < SETTLE_MS;
+    if (!isSelfWrite && gestureDriven) lastScrollAt.current = now;
+    // Keep the anchor fresh as the reader scrolls, so the next reflow measures
+    // against where they actually are.
+    scheduleCapture();
+  }, [fingerDown, scheduleCapture]);
+
+  /**
+   * Proof the reader is moving the content: a drag or a wheel notch. A tap is
+   * deliberately none of these — it emits no `touchmove`, and counting one
+   * would suppress corrections after every button press.
+   */
+  const onInput = useCallback(() => {
+    lastInputAt.current = Date.now();
+  }, []);
+
+  /**
+   * Keyboard scrolling. Keys land on the focused element rather than the
+   * scroller, so this is bound at the document — which means it sees ordinary
+   * typing too, and must ignore it: a character in a filter field scrolls
+   * nothing, and crediting it would disarm corrections for GESTURE_MS.
+   */
+  const onKey = useCallback((event: Event) => {
+    const key = event as KeyboardEvent;
+    if (!SCROLL_KEYS.has(key.key) || isTextEntry(key.target)) return;
+    lastInputAt.current = Date.now();
+  }, []);
+
+  // `touches` excludes the point that just ended, so on any touch event it is
+  // the number of fingers still down. Reading the count off the event rather
+  // than latching a boolean keeps lifting one finger of a pinch from ending the
+  // gesture. This handler marks presence only, never activity: see `onInput`.
+  const onTouch = useCallback((event: Event) => {
+    touchCount.current = (event as TouchEvent).touches.length;
+    lastTouchAt.current = Date.now();
+  }, []);
+
+  const detach = useCallback(
+    (node: T) => {
+      node.removeEventListener('scroll', onScroll);
+      node.removeEventListener('wheel', onInput);
+      node.removeEventListener('touchmove', onInput);
+      node.removeEventListener('touchstart', onTouch);
+      node.removeEventListener('touchend', onTouch);
+      node.removeEventListener('touchcancel', onTouch);
+      // Keys land on the focused element, which is rarely inside the scroller,
+      // so this one is bound at the document.
+      node.ownerDocument.removeEventListener('keydown', onKey);
+      delete node.dataset['scrollAnchor'];
+      // A scroller swapped out mid-gesture must not leave the next one holding
+      // a finger that was never lifted.
+      touchCount.current = 0;
+      lastTouchAt.current = 0;
+      lastScrollAt.current = 0;
+      lastInputAt.current = 0;
+      selfWriteAt.current = 0;
+    },
+    [onScroll, onInput, onKey, onTouch],
+  );
+
   useEffect(
     () => () => {
       mutationObs.current?.disconnect();
       if (captureRaf.current) cancelAnimationFrame(captureRaf.current);
       if (restoreRaf.current) cancelAnimationFrame(restoreRaf.current);
-      scrollerRef.current?.removeEventListener('scroll', scheduleCapture);
+      if (scrollerRef.current) detach(scrollerRef.current);
     },
-    [scheduleCapture],
+    [detach],
   );
 
   return useCallback(
     (node: T | null) => {
       mutationObs.current?.disconnect();
       mutationObs.current = null;
-      scrollerRef.current?.removeEventListener('scroll', scheduleCapture);
+      if (scrollerRef.current) detach(scrollerRef.current);
 
       scrollerRef.current = node;
       if (!node) return;
 
-      // Keep the anchor fresh as the reader scrolls, so the next reflow measures
-      // against where they actually are. Passive: never blocks the scroll.
-      node.addEventListener('scroll', scheduleCapture, { passive: true });
+      // Names the scroller this hook owns. A page can hold several scrollable
+      // boxes (panels with their own max-height), and only this one is anchored,
+      // so the layout-stability e2e gate needs to find it rather than guess.
+      node.dataset['scrollAnchor'] = '';
+
+      // Passive: never blocks the scroll.
+      node.addEventListener('scroll', onScroll, { passive: true });
+      node.addEventListener('wheel', onInput, { passive: true });
+      node.addEventListener('touchmove', onInput, { passive: true });
+      node.addEventListener('touchstart', onTouch, { passive: true });
+      node.addEventListener('touchend', onTouch, { passive: true });
+      node.addEventListener('touchcancel', onTouch, { passive: true });
+      node.ownerDocument.addEventListener('keydown', onKey, { passive: true });
 
       // Trigger: a poll re-renders a panel = a DOM mutation in the scroller's
       // subtree, and that reflow is what we must absorb. A ResizeObserver on a
@@ -121,6 +308,6 @@ export function useScrollAnchor<T extends HTMLElement = HTMLElement>(): (node: T
       }
       capture();
     },
-    [capture, scheduleCapture, scheduleRestore],
+    [capture, detach, onScroll, onInput, onKey, onTouch, scheduleRestore],
   );
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -26,6 +26,11 @@
   --muted: #141414;
   --border: #2a2a2a; /* hairline panel borders / dividers */
   --border-strong: #3a3a3a;
+  /* Loading placeholder fill. Its own token, not surface-alt: that one also
+     paints zebra rows and hover, so tuning placeholder brightness there would
+     drag those with it. Sits ~1.5:1 against the panel surface — a placeholder
+     only has to be perceivable, not readable. */
+  --skeleton: #303030;
   --accent: #ffcc00; /* amber yellow: selection / active nav / commit */
   --accent-fg: #000000; /* black ink on yellow, never white */
   --primary: #00e070; /* signal green: go / positive action */
@@ -55,6 +60,7 @@
   --muted: oklch(95% 0 0);
   --border: oklch(88% 0 0);
   --border-strong: oklch(80% 0 0);
+  --skeleton: oklch(90% 0 0);
   /* Amber accent darkened for white canvas; ink stays dark. */
   --accent: oklch(75% 0.16 85);
   --accent-fg: oklch(15% 0 0);
@@ -84,6 +90,7 @@
   --color-muted: var(--muted);
   --color-border: var(--border);
   --color-border-strong: var(--border-strong);
+  --color-skeleton: var(--skeleton);
   --color-accent: var(--accent);
   --color-accent-fg: var(--accent-fg);
   --color-primary: var(--primary);
@@ -137,6 +144,17 @@
        any scroll container was reloading the SPA and dropping in-page state on
        mobile. `none` also removes the overscroll glow. */
     overscroll-behavior: none;
+  }
+  /* The route pending screen is padless so it sits flush inside a route that
+     already owns its padding, and insets itself where nothing else does. Two
+     such parents: #root, when the ROOT route is the pending one (every hard
+     page load, since its beforeLoad resolves the onboarding check) and the
+     shell is not mounted yet; and <main> on the full-screen routes, where the
+     shell drops its own p-4 because those routes are full-bleed. Without this
+     the panels sit flush against the edges and jump inward 1rem the moment the
+     real content commits. */
+  :is(#root, main:not(.p-4)) > [data-route-pending] {
+    padding: 1rem;
   }
   /* Tabular figures + slashed zero only where numbers live — applied via the
      mono utility so prose keeps proportional spacing. */

--- a/deploy/observability/alerts.yml
+++ b/deploy/observability/alerts.yml
@@ -8,7 +8,9 @@
 # Read the "no alert coverage today" block at the bottom before you rely on
 # this file: it lists the failure modes these rules do NOT watch.
 #
-# Every name an `expr:` reads has to be a series this repo emits.
+# Every name an `expr:` reads has to resolve: either a series this repo emits,
+# or one of the few Prometheus-generated series the gate allowlists by exact
+# name (`up`, which no target writes — see WorkerDown below).
 # `promtool check rules` validates PromQL syntax only, so a rule over a
 # metric nothing writes parses clean and then evaluates empty forever: it
 # never fires and never errors, which is indistinguishable from a healthy

--- a/deploy/observability/alerts.yml
+++ b/deploy/observability/alerts.yml
@@ -3,13 +3,24 @@
 # These rules ship with the repo so operators can drop them into their
 # Prometheus stack and have a sane default alert posture without
 # inventing thresholds. Alertmanager / PagerDuty / Slack receiver
-# wiring is operator-owned (see deploy/README.md).
+# wiring is operator-owned (see docs/operations/deploy.md, "Alert rules").
+#
+# Read the "no alert coverage today" block at the bottom before you rely on
+# this file: it lists the failure modes these rules do NOT watch.
+#
+# Every name an `expr:` reads has to be a series this repo emits.
+# `promtool check rules` validates PromQL syntax only, so a rule over a
+# metric nothing writes parses clean and then evaluates empty forever: it
+# never fires and never errors, which is indistinguishable from a healthy
+# rule that has simply not tripped. `scripts/ci/no-phantom-alert-metric.sh`
+# checks each name against the worker metric catalogue and the prom-client
+# call sites, and fails the build on one that nothing emits.
 #
 # Severity convention:
-#   - critical: pages immediately (worker is offline, queue is wedged,
-#     Binance weight exhausted, DB pool starved).
-#   - warning: investigate within the working day (cache-miss rate
-#     elevated, WS reconnect storms).
+#   - critical: pages immediately (worker is offline, Binance weight
+#     exhausted).
+#   - warning: investigate within the working day. No shipped rule sits at
+#     this level today; the convention stands for rules an operator adds.
 #
 # Lint: `bash scripts/ci/promtool-lint.sh` (CI runs this on every push).
 
@@ -18,8 +29,13 @@ groups:
     interval: 30s
     rules:
       - alert: WorkerDown
-        # The worker exposes an `up{job="worker"}` series via /metrics.
-        # If the scrape fails for 2 minutes the worker is offline; v1.0
+        # `up` is synthesised by Prometheus, one series per scrape target:
+        # 1 when the scrape succeeded, 0 when it failed. The worker never
+        # writes it, and `job` is not ours either — it is whatever
+        # `job_name` the operator gives the worker in their scrape_config.
+        # This rule is INERT unless that job is named `worker`; see
+        # docs/operations/deploy.md for the scrape config it assumes.
+        # A failed scrape for 2 minutes means the worker is offline; v1.0
         # has a single replica so this is page-level.
         expr: up{job="worker"} == 0
         for: 2m
@@ -29,83 +45,75 @@ groups:
           summary: 'Worker scrape down for 2m'
           description: 'No /metrics scrape from job=worker for 2 minutes. v1.0 is single-replica, so trading is halted until the worker recovers.'
 
-      - alert: HighTickFailureRate
-        # Tick failures are tracked by the strategy executor. A 5%
-        # rate over 10 minutes is well above the noise floor (single
-        # rejected order or transient Binance hiccup); sustained at
-        # 5% means a code-level bug or a Binance protocol change.
-        expr: |
-          sum(rate(tick_failures_total[10m])) / sum(rate(tick_total[10m])) > 0.05
-        for: 10m
-        labels:
-          severity: critical
-        annotations:
-          summary: 'Tick failure rate > 5% for 10m'
-          description: 'Strategy tick() failed on >5% of attempts for the last 10 minutes. Inspect worker logs and recent strategy/notifier deploys.'
-
       - alert: BinanceWeightExhausted
-        # The executor records `binance_weight_used_1m` from the
-        # X-MBX-USED-WEIGHT-1M response header. Binance bans on >1200;
-        # 1000 is the safe ceiling we want to alert on so the operator
-        # can intervene before a ban. The bare metric (rather than
-        # `max_over_time`) lets `for: 2m` measure sustained pressure
-        # instead of letting one spike satisfy the window.
-        expr: binance_weight_used_1m > 1000
+        # The tick handler records the X-MBX-USED-WEIGHT-1M response header
+        # as `binance_api_weight` (gauge, labelled by profileId). Binance
+        # bans on >1200; 1000 is the safe ceiling we want to alert on so the
+        # operator can intervene before a ban. The bare metric (rather than
+        # `max_over_time`) lets `for: 2m` measure sustained pressure instead
+        # of letting one spike satisfy the window.
+        #
+        # Deliberately unaggregated. The header reports weight for the whole
+        # API key, so every profile under one account samples the SAME
+        # account-wide counter: `sum` would multiply it by the number of
+        # actively trading profiles and fire far below the real ceiling.
+        # Aggregating with `max` reads correctly but drops profileId, the
+        # only label saying which profile drives the load (no accountId
+        # label is exported). Left unaggregated, each profile over the
+        # ceiling becomes its own alert instance carrying that label, and
+        # Alertmanager `group_by` collapses the duplicates.
+        #
+        # KNOWN HAZARD, no in-repo fix today: this alert can stay firing
+        # after the condition clears. `binance_api_weight` is a prom-client
+        # gauge child written per profile on the tick success path, and
+        # nothing ever removes it, so prom-client keeps exporting that
+        # profile's last sample for the life of the process. A profile that
+        # stops ticking (disabled, disposed, every symbol paused) freezes its
+        # gauge at whatever it last read, and if that was above the ceiling
+        # the page stays open until the worker restarts. Treat a firing
+        # instance whose profile you have since disabled as stale, and check
+        # the weight in the UI before acting on it.
+        #
+        # Do NOT try to fix this by ANDing in a tick-activity series. Every
+        # tick failure path returns or throws before the metric is recorded,
+        # so tick activity measures tick SUCCESS: a Binance ban fails every
+        # REST call, the activity series goes flat, and the guard would send
+        # a RESOLVED notification in the middle of the ban. A page that
+        # falsely reports recovery is worse than one that sticks. The real
+        # fix is emitter-side, removing the gauge child when a profile is
+        # disabled or disposed, which needs a `forget()` on MetricsSink that
+        # does not exist yet. Tracked in #777.
+        expr: binance_api_weight > 1000
         for: 2m
         labels:
           severity: critical
         annotations:
           summary: 'Binance request weight > 1000/min'
-          description: 'Trading load exceeds the Binance weight budget. Reduce profile cadence or pause symbols.'
-
-  # Technicals alerts removed when the FastAPI scanner was replaced by
-  # in-process compute (`apps/worker/src/crons/technicals-compute.ts` +
-  # `packages/indicators/rating`). The prior `technicals_breaker_state`,
-  # `technicals_last_success_timestamp_seconds`, and `technicals_cache_*`
-  # metrics were emitted by the deleted Python service; new alerts can
-  # be wired against the worker's fetch-status receipt
-  # (`technicals:compute:status:<interval>` Redis key) when needed.
-
-  - name: binance-trading-bot.infra
-    interval: 30s
-    rules:
-      - alert: QueueBacklog
-        # BullMQ exposes wait queue depth per queue. A 1000-job
-        # backlog sustained for 5 minutes means the worker cannot
-        # keep up; the executor's chainByKey serialises per profile
-        # so a backlog implies a structural slowdown. The bare
-        # metric (rather than `max_over_time`) lets `for: 5m`
-        # measure sustained backlog rather than firing on a spike.
-        expr: bullmq_queue_wait_jobs > 1000
-        for: 5m
-        labels:
-          severity: critical
-        annotations:
-          summary: 'BullMQ wait queue > 1000 jobs for 5m'
-          description: 'Queue {{ $labels.queue }} is backlogged. Inspect worker tick latency and BullMQ stalled-job count.'
-
-      - alert: DBPoolStarved
-        # pg pool exposes idle/total. <5% idle means clients are
-        # waiting for connections; sustained means a slow query is
-        # holding a connection or the pool is undersized.
-        expr: |
-          (pg_pool_idle / pg_pool_total) < 0.05
-        for: 5m
-        labels:
-          severity: critical
-        annotations:
-          summary: 'Postgres pool idle ratio < 5% for 5m'
-          description: 'Connection contention against Postgres. Check for long-running queries; consider raising pool size if load grew.'
-
-      - alert: WSDisconnectsHigh
-        # Repeated reconnects against Binance WS chew through the
-        # `listenKey` budget and leak partial state. >5 disconnects
-        # in 15 minutes is well above the single network-blip floor.
-        expr: |
-          sum(increase(binance_ws_disconnects_total[15m])) > 5
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: 'Binance WS disconnects > 5 in 15m'
-          description: 'WebSocket reconnect rate is elevated. Check apps/worker logs and the operator-side egress network.'
+          description: 'Trading load exceeds the Binance weight budget on profile {{ $labels.profileId }}. Reduce profile cadence or pause symbols.'
+# NO ALERT COVERAGE TODAY.
+#
+# Four rules were removed because the series each one read is emitted
+# nowhere in this repo, so each evaluated empty forever and could never
+# fire. Removing them costs no coverage; it stops the file implying
+# coverage that never existed. Until the metric named beside each one is
+# emitted, that failure mode reaches the operator only through the UI or
+# the container logs, never through a page.
+#
+#   - HighTickFailureRate wanted `tick_failures_total` / `tick_total`. The
+#     worker counts throttled ticks (`tick_throttled_*`) but has no attempt
+#     or failure counter, so no tick error rate is derivable. Tracked in
+#     #773.
+#   - QueueBacklog wanted `bullmq_queue_wait_jobs`. Nothing exports BullMQ
+#     queue depth. Tracked in #774.
+#   - DBPoolStarved wanted `pg_pool_idle` / `pg_pool_total`. The pg pool
+#     exports no gauges. Tracked in #775.
+#   - WSDisconnectsHigh wanted `binance_ws_disconnects_total`. Binance WS
+#     reconnects are logged, never counted. Tracked in #776.
+#
+# Technicals alerts were removed earlier for a different reason: the
+# FastAPI scanner that emitted `technicals_breaker_state`,
+# `technicals_last_success_timestamp_seconds` and `technicals_cache_*` was
+# replaced by in-process compute (`apps/worker/src/crons/technicals-compute.ts`
+# plus `packages/indicators/rating`). Its replacement writes a fetch-status
+# receipt to the `technicals:compute:status:<interval>` Redis key, which a
+# future rule can read once a metric exports it.

--- a/docs/contributing/coding-rules.md
+++ b/docs/contributing/coding-rules.md
@@ -125,3 +125,43 @@ Pick the kind and labels from what the call site means, not from the name:
 - A call site that passes no tags declares `labelNames: []`. Declaring a label the caller never supplies stamps it `unknown` on every series and invents a dimension the metric does not have.
 
 Names are checked; **labels are not**. `record()` resolves each declared label as `tags?.[key] ?? 'unknown'`, so renaming a tag key at a call site (`stream` → `streamKey`) still compiles: the metric exports `audit_stream_length{stream="unknown"}` and every profile collapses into one series. Nothing catches that today — check the labels by hand when you edit a call site.
+
+### Alert rules may only name metrics we emit
+
+Every metric named in an `expr:` in `deploy/observability/alerts.yml` must be a series this repo actually emits. `no-phantom-alert-metric.sh` enforces it, and `lint.sh` runs it immediately before `promtool-lint.sh`.
+
+The two gates catch different faults and the order matters. `promtool check rules` validates PromQL **syntax**; it has no view of which series exist, so a rule over a metric nothing writes passes it, then evaluates to an empty vector forever. Such a rule never fires and never errors, which looks exactly like a healthy rule that has not tripped — the operator believes they are covered and is not. Name existence therefore has to fail first, or the author reads a syntax verdict and stops.
+
+The allowed set is assembled from the code rather than a list in the gate, so a new sink is covered the day it lands:
+
+- the worker catalogue — the `MetricName` union and the `CATALOG` keys, parsed separately and diffed against each other, since TypeScript already couples them and a divergence means the parser regressed;
+- every `new Counter/Gauge/Histogram/Summary({ name: … })` under `apps/**` and `packages/**`, which picks up the api HTTP sink and the `@app/observability` registry without either path being named in the gate. The scan window closes at that call's own `})`, never at a character count: a fixed window can run past the call and adopt an unrelated `name:` literal as a declared metric, which is fail-open and would stop a real phantom being reported;
+- `_count` / `_sum` / `_bucket` off a name declared `kind: 'histogram'`, and `_count` / `_sum` off a `summary`, because Prometheus derives those and only for those kinds. A counter or gauge derives nothing, so `decision_count_sum` is still a phantom even though `decision_count` is real;
+- two exact-match sets for series no repo code declares: Prometheus' synthesised `up`, and the `process_*` / `nodejs_*` metrics `collectDefaultMetrics` registers. Both match exactly and never by prefix, so `up_wrong` is still reported. `nodejs_gc_duration_seconds` carries a kind alongside its name because it is the one default metric prom-client registers as a Histogram, so its derived series are real.
+
+Only `expr:` values are scanned — annotations legitimately carry `{{ $labels.profileId }}` and prose. Tokenising is subtractive (strip quoted strings, label matchers, range selectors, grouping label lists, `offset`/`@` modifiers, then numeric literals, and read what survives), so a parse miss over-reports and fails the build instead of skipping a name.
+
+Two YAML shapes are handled rather than skipped, because in both the subtractive order would erase the name before it was read and the rule would pass as if it named nothing: a fully quoted `expr:` scalar (unwrapped first, `''` and `\"` escapes included) and a `{__name__="x"}` matcher (harvested before the brace strip). A regex or negated `__name__` matcher cannot be resolved to a concrete series at all, so it is a hard error rather than a silent skip. Flow-style rule entries (`- {alert: …, expr: …}`) are rejected the same way: they match neither key pattern while keeping the head and expr counts balanced, so the consistency assert would not notice them.
+
+Five vacuity floors fail the gate rather than pass it: zero catalogue names, zero constructed names, zero rules, zero exprs, and **any single expr that names no metric**. That last one is per-expr deliberately — a global count is satisfied by one healthy rule and lets a sibling parsed down to nothing through, which is the silent pass the gate exists to stop. A sixth assert requires every rule entry to have yielded an expr, so a block-scalar walk that over-consumed fails red instead of quietly checking less.
+
+A rule that names no metric **on purpose** — a dead-man switch watchdog is `expr: vector(1)` by construction — opts out with a `# names-no-metric: <reason>` comment on the line directly above its `expr:` key. The opt-out is per-rule and has to be typed, so the floor stays fail-closed: an expression that silently parsed to nothing is still an error.
+
+Rules are read as entries, starting at the dash that introduces each one, and sibling keys are matched at exactly that entry's key column. That is what makes key order inside a rule irrelevant (`expr:` may lead) while keeping a block-scalar annotation that happens to contain `expr:` or `alert:` from being read as a rule key.
+
+`no-phantom-alert-metric.selftest.sh` runs the gate over twelve fixture trees under `scripts/ci/__fixtures__/alert-metric/`, and `lint.sh` runs it **before** the gate itself: `set -e` stops at the first failure, and on the run where both would fail it is the self-test that says whether the rules file is wrong or the parser regressed. Every rejecting case asserts its own diagnostic string, never a bare non-zero exit: the floors and the hard parse errors all exit 1, so a moved fixture would trip one of them and a non-zero-means-caught check would read that as a successful catch. The `pass` tree exercises every accepted syntax at once, since a false positive there would start rejecting valid rules, and the `fail` tree pins six distinct phantom shapes by name.
+
+If a rule you want has no series behind it, emit the metric or drop the rule. Do not leave it in place: the file is operator-facing, and a rule structurally incapable of firing is worse than a documented gap. Record the gap in `alerts.yml` instead, as the "no alert coverage today" block does.
+
+### A lint rule carrying an invariant must stay armed
+
+Some oxlint rules are not style — they are the only thing standing between the repo and a defect class. `react/no-unstable-nested-components` is one: a component declared inside another's render body is a new type every render, so React tears its subtree down instead of updating it, and on WebKit that clamps `scrollTop` and drags a reader off their place on every poll.
+
+oxlint hard-fails on a misspelled rule or an unknown plugin prefix, so those need no gate. Two drift shapes are **silent**, and both exit 0:
+
+- **A plugin removed from `plugins`.** Setting that array overwrites oxlint's defaults, and `react` is not among them, so trimming the list makes every `react/*` rule vanish from the resolved config with no diagnostic.
+- **A severity downgraded to `warn`.** The rule still runs, but `lint.sh` invokes `bunx oxlint` without `--deny-warnings`, so a warning can never fail the build.
+
+`no-dropped-lint-rule.sh` asserts against `oxlint --print-config` — the _resolved_ config, not the source file — that each listed rule is present at the expected severity, and `lint.sh` runs it before `bunx oxlint` so a disarmed rule is reported before the lint pass reports clean. Add a rule to `required_rules` when its absence would retire an invariant rather than relax a preference.
+
+`no-dropped-lint-rule.selftest.sh` drives the gate over mutated copies via the `OXLINT_CONFIG` seam, so the tracked `.oxlintrc.json` is never edited and a killed run cannot leave a disarmed rule behind. It fixtures only the two silent shapes: a fixture for a misspelling would prove nothing, because oxlint exits 1 before the gate can read anything. Each rejecting case asserts its own diagnostic string, and each fixture asserts that its own `sed` actually applied — a substitution that silently stopped matching would otherwise leave the case passing against an unmodified config.

--- a/docs/design/ui-interaction-guidelines.md
+++ b/docs/design/ui-interaction-guidelines.md
@@ -62,6 +62,46 @@ Per core invariant 3, every view must be fully usable on a 375×667 phone. Inter
 
 Pair colour with a glyph, icon, or text label. Red-only / green-only state fails the roughly 8% of men with red-green colour-vision deficiency and is a WCAG violation. Status uses colour **plus** the status word; trade direction uses colour **plus** ▲/▼. Source: [WCAG 2.2 — Use of Colour](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html).
 
+## Loading states have height
+
+The shell owns the only scroll surface (`h-svh … overflow-hidden`) and the document never scrolls, so a loading branch with no height leaves **nothing under the thumb to drag**. Combined with `overscroll-behavior: none`, which suppresses even the rubber-band, a phone reads that as a frozen app rather than a loading one — the app was unscrollable for 9–16 s per route on a slow link.
+
+A loading branch renders a placeholder from `@/shared/components/page-skeleton`, never a bare `<p>Loading…</p>`:
+
+| Surface | Use |
+| --- | --- |
+| Inside a `Panel` that already draws its frame | `LoadingRows` |
+| A page body that will render a stack of panels | `PanelStackSkeleton shape={[…]}` — one entry per real panel, its value that panel's field count |
+| A list or table | `TableSkeleton` |
+| The router's pending screen, where the route is not yet known | `PageSkeleton` |
+
+Rules that make them safe to render a page-full of:
+
+- **Exactly one `role="status"` per loading surface.** The bars are `aria-hidden`; a live region per bar (or per panel) makes a screen reader read "Loading" once for every box.
+- **No pulse under `prefers-reduced-motion`.** A full page of synchronised pulsing is a vestibular trigger.
+- **Mirror the loaded layout, don't draw a bare frame.** A frame with no internal structure reads as a broken page. Match the panel count and field counts of what will land ([NN/g on skeleton screens](https://www.nngroup.com/articles/skeleton-screens/)).
+- **A route that owns its own scroller must own it while loading too.** The full-screen routes drop `<main>`'s scroll, so their loading branch carries the same `min-h-0 flex-1 overflow-y-auto p-4` box the loaded branch does.
+
+A one-line "Loading…" is still fine **inside a box that already has height** and whose chrome is drawn — the order-book and recent-trades panels, the realised-P/L card. The rule targets surfaces that would otherwise contribute no height at all.
+
+## A polling page must hold the reader still
+
+Every screen refetches on a timer. If a poll re-render changes layout above the fold, the reader is shoved off their spot; if it _rebuilds_ a subtree rather than updating it, the damage is worse and silent. While the subtree is detached the scroller is briefly shorter, so the browser clamps `scrollTop` to the new maximum — and re-inserting the content restores the height but never the scroll position. A reader parked at the bottom is dragged upward on every tick.
+
+That shipped once. `MarketTrendCard` declared its wrapper component **inside** its own render body, so the wrapper got a fresh identity on every render and React discarded the card and rebuilt it. A `setInterval` driving the "next update in ~Xs" countdown fired that once a second. Measured in Safari at 375×667, the card's `getBoundingClientRect().height` was 298 px, and the scroller jumped by exactly that amount 24 times over a 12 s watch — twice per tick, because the dev build runs under `StrictMode`, which re-renders each component an extra time.
+
+Rules:
+
+- **Never declare a component inside another component's body.** Its identity changes per render, which React reads as a different component type: full teardown, not an update. Enforced by `react/no-unstable-nested-components` in `.oxlintrc.json`. A render prop that is _called_ rather than mounted (`fallback(error, reset)`) is safe, but hoist it anyway rather than relaxing the rule.
+- **Keep list `key`s stable across polls.** A key derived from an array index or a formatted timestamp remounts rows whenever the data shifts.
+- **Prefer a reserved box to a panel that appears and disappears.** A block that renders `null` on empty data and content on the next poll changes the page height under the reader.
+
+`useScrollAnchor` (`overflow-anchor` is in Technology Preview and the Safari 27 beta, but no stable Safari release ships it and no iOS Safari release supports it — [caniuse](https://caniuse.com/css-overflow-anchor), checked 2026-08; the shim can be deleted once it lands on iOS) absorbs _legitimate_ reflow — content genuinely growing. It is not a licence to reflow: it corrects a frame late, and it stands down while the reader's own scrolling is live, because a `scrollTop` write during a drag or its momentum cancels the fling on WebKit instead of nudging the reader. A page that needs the shim to look still on a phone is a page with a layout bug.
+
+"The reader's own scrolling" is measured against gestures, not scroll events. A scroll event is not proof a human scrolled: when content shrinks, the browser clamps `scrollTop` and emits one too, and that event is dispatched _before_ the animation frame the correction runs in. Standing down for it would disable the shim for the exact reflow it exists to absorb, and re-anchor at the drifted position — turning a one-frame clamp into permanent drift.
+
+`e2e/tests/scroll-stability.spec.ts` measures this: it parks each route's anchored scroller (the one marked `data-scroll-anchor`, so the probe cannot drift onto an inner panel that no poll touches) at the bottom, **blocks the shim's corrections**, and asserts zero drift, zero subtree teardowns and zero attempted corrections while the page polls. Blocking the shim is the point — with it live, the drift is repaired a frame later and the page looks stable on Blink and desktop WebKit, which is why the defect survived review. The spec needs a running stack (`E2E_USER_EMAIL` / `E2E_USER_PASSWORD` / `E2E_ACCOUNT_ID` / `E2E_PROFILE_ID`); CI runs only the no-stack smoke subset, so it does not gate merges today.
+
 ## Before adding an interactive element
 
 1. Is there already a `variant` or shared component for this intent? Use it.
@@ -69,3 +109,4 @@ Pair colour with a glyph, icon, or text label. Red-only / green-only state fails
 3. Is it in a table row? Use `RowActions`, keep status and action separate.
 4. Is it ≥44px and reachable on a 375px screen?
 5. Does it convey state by more than colour alone?
+6. If it has a loading state, does that state have height and exactly one live region?

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -77,6 +77,66 @@ flowchart TD
     classDef wait fill:#ecf0f1,color:#2c3e50;
 ```
 
+## Alert rules
+
+`deploy/observability/alerts.yml` ships two Prometheus alerting rules. Load the file into your Prometheus stack; the Alertmanager, PagerDuty and Slack receiver wiring is yours to own.
+
+### Scrape config the rules assume
+
+Neither rule works against an arbitrary scrape setup. `WorkerDown` matches `up{job="worker"}`, and `job` is not a label the app emits — Prometheus stamps it from the `job_name` **you** choose, so the rule is inert if you name it anything else.
+
+`/metrics` is also not on the public port. Each service exposes it on a separate admin listener, and **at defaults those listeners are unreachable from any other container**: `ADMIN_HOST` and `WORKER_ADMIN_HOST` both default to `127.0.0.1`, which inside a container means that container's own loopback. A Prometheus container on the `internal` network gets connection-refused, and publishing the port does not help either — Docker forwards a published port to the container's IP, not to its loopback.
+
+Widen the bind, and scrape over the compose network:
+
+```bash
+# .env — required for Prometheus to reach either admin listener at all
+ADMIN_HOST=0.0.0.0
+WORKER_ADMIN_HOST=0.0.0.0
+```
+
+```yaml
+scrape_configs:
+  - job_name: 'worker' # WorkerDown matches this exact name
+    static_configs:
+      - targets: ['app:9101'] # WORKER_ADMIN_PORT
+  - job_name: 'api'
+    static_configs:
+      - targets: ['app:9100'] # ADMIN_PORT
+```
+
+Run Prometheus on the `internal` network so those hostnames resolve. In the default single-container `ROLE=all` deployment both listeners live in the same `app` container, which is why both targets share a hostname; in the split topology (`docker-compose.scale.yml`) point each job at its own service.
+
+!!! warning "Do not add 9100 or 9101 to `ports:`"
+
+    `/healthz`, `/readyz` and `/metrics` are **unauthenticated**, and `/metrics` carries per-profile operational detail. Widening the bind to `0.0.0.0` exposes them to the compose network, which is the point; publishing them puts them on your LAN. Keep them off `ports:` and let Prometheus reach them container-to-container. If you must expose them beyond the host — on Kubernetes, say — restrict the port with a NetworkPolicy: a Service is not a firewall.
+
+| Alert | Severity | Fires when |
+| --- | --- | --- |
+| `WorkerDown` | critical | No `/metrics` scrape from `job=worker` for 2 minutes. v1.0 is single-replica, so trading is halted until the worker recovers. |
+| `BinanceWeightExhausted` | critical | `binance_api_weight` stays above 1000 for 2 minutes. Binance bans above 1200, so this leaves headroom to reduce profile cadence or pause symbols first. |
+
+`BinanceWeightExhausted` is deliberately unaggregated. The weight header covers the whole API key, so every profile on an account samples the same account-wide number: summing would multiply it by the count of actively trading profiles. Each profile over the ceiling raises its own instance labelled with its `profileId` — group them in Alertmanager if the duplicates are noisy.
+
+!!! warning "`BinanceWeightExhausted` can stay firing after the weight comes down"
+
+    The underlying gauge is written per profile on the tick success path and is never removed, so a profile that stops ticking — disabled, disposed, or with every symbol paused — keeps exporting its last reading for the life of the worker process. If that reading was above the ceiling the alert stays open until the worker restarts. Treat a firing instance whose profile you have since disabled as stale and check the weight in the app before acting.
+
+    It is not fixable in the rule. Every tick failure path returns before the metric is recorded, so gating on tick activity would measure tick *success*: a Binance ban fails every request, the activity signal goes flat, and Prometheus would send a **resolved** notification in the middle of the ban. A page that falsely reports recovery is worse than one that sticks open. The fix belongs on the emitter, which needs a way to drop a metric child when a profile goes away (tracked in #777).
+
+### What is not covered
+
+Four rules that previously shipped read metrics this repo emits nowhere. They parsed cleanly and then evaluated empty forever, so they could never fire — they have been removed rather than left in place looking healthy. **These failure modes have no alert coverage today** and reach you only through the UI or `docker compose logs -f app`:
+
+- **Tick failure rate.** The worker counts throttled ticks but has no attempt or failure counter, so no error rate exists to alert on.
+- **Queue backlog.** BullMQ wait-queue depth is not exported.
+- **Postgres pool starvation.** The connection pool exports no idle/total gauges.
+- **Binance WebSocket reconnect storms.** Reconnects are logged, never counted.
+
+Each gap names its missing series and its tracking issue in the comments at the bottom of `alerts.yml`. A CI gate (`no-phantom-alert-metric.sh`) fails the build if a rule names a metric nothing emits, so a rule cannot go back to reading a series that was never written.
+
+**Metric names are checked; nothing else is.** The gate strips label matchers before reading a name, so `up{job="wrker"} == 0` — a one-letter typo in a label the gate never inspects — still parses clean, still evaluates empty forever, and still passes. Thresholds and `for:` windows are not checked either: a rule set to `> 100000` is as silent as one naming a phantom. After editing a rule, confirm it against live data (`promtool check rules` for syntax, then the Prometheus expression browser for a non-empty result) rather than trusting a green build.
+
 ## Common operator commands
 
 ```bash

--- a/e2e/tests/scroll-stability.spec.ts
+++ b/e2e/tests/scroll-stability.spec.ts
@@ -1,0 +1,173 @@
+// Layout-stability gate: no route may move the reader while it polls.
+//
+// The dashboard refetches on a timer across every panel. If a poll re-render
+// changes layout above the fold — or worse, rebuilds a subtree instead of
+// updating it — the browser clamps `scrollTop` to the shorter content and never
+// restores it when the height comes back. A reader parked at the bottom is
+// dragged upward, once per poll, forever. That shipped once: a component
+// declared inside its parent's render body gave the market-trend card a new
+// identity every second, so React tore the card out of the overview and rebuilt
+// it on the countdown tick.
+//
+// The measurement blocks `useScrollAnchor`'s corrections for the duration.
+// That is the point: with the shim live the drift is repaired a frame later and
+// the page looks stable on Blink and desktop WebKit, which is exactly why the
+// defect survived review. Blocking the shim measures whether the page holds
+// still on its own. `shimWrites` is therefore an assertion too — a correction
+// the shim *wanted* to make is a reflow that should not have happened.
+//
+// Gated by env, not E2E_FULL_STACK: like profile-controls, these drive a stack
+// the operator already has running (`bun run dev` or compose). CI runs only the
+// no-stack smoke subset, so this does not gate merges today — it is the tool
+// that reproduces and proves the class.
+//
+// E2E_USER_PASSWORD must be a throwaway local credential. Playwright records
+// every action's arguments into the trace, and `retain-on-failure` is on in
+// playwright.config.ts, so a failing run writes the password in cleartext under
+// e2e/test-results/ — never attach that directory to an issue or MR.
+// Playwright declines to mask password fields by design (microsoft/playwright#35848).
+
+import { test, expect } from '@playwright/test';
+
+const EMAIL = process.env['E2E_USER_EMAIL'] ?? '';
+const PASSWORD = process.env['E2E_USER_PASSWORD'] ?? '';
+const ACCOUNT_ID = process.env['E2E_ACCOUNT_ID'] ?? '';
+const PROFILE_ID = process.env['E2E_PROFILE_ID'] ?? '';
+const ENABLED = EMAIL && PASSWORD && ACCOUNT_ID && PROFILE_ID;
+
+// One full cycle of the slowest poll on these surfaces. Equity P/L and the edge
+// verdict refetch at 60s (equity-pnl-card.tsx, use-edge-verdict.ts), gate status
+// at 30s; a shorter window never observes the heaviest refetches, which are the
+// ones most likely to change page height.
+const WATCH_MS = 65_000;
+
+test.describe.configure({ mode: 'serial' });
+test.skip(
+  !ENABLED,
+  'scroll-stability specs require E2E_USER_EMAIL/PASSWORD + E2E_ACCOUNT_ID + E2E_PROFILE_ID',
+);
+
+const ROUTES: readonly { readonly label: string; readonly path: string }[] = [
+  { label: 'account overview', path: `/accounts/${ACCOUNT_ID}` },
+  { label: 'profile overview', path: `/accounts/${ACCOUNT_ID}/profiles/${PROFILE_ID}` },
+  { label: 'profile discovery', path: `/accounts/${ACCOUNT_ID}/profiles/${PROFILE_ID}/discovery` },
+  { label: 'profile config', path: `/accounts/${ACCOUNT_ID}/profiles/${PROFILE_ID}/config` },
+];
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/login');
+  await page.locator('#login-email').fill(EMAIL);
+  await page.locator('#login-password').fill(PASSWORD);
+  await Promise.all([
+    page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 15_000 }),
+    page.getByRole('button', { name: /sign in|log in/i }).click(),
+  ]);
+});
+
+for (const { label, path } of ROUTES) {
+  test(`${label} holds the reader still while it polls`, async ({ page }) => {
+    test.setTimeout(120_000);
+    await page.goto(path);
+    // Let the first paint and the first round of polls land, so the baseline is
+    // a settled page rather than one still filling in.
+    await page.waitForTimeout(5_000);
+
+    const parked = await page.evaluate(() => {
+      // The scroller under the reader's thumb is the one useScrollAnchor is
+      // bound to, and it marks itself. Picking by tree position instead would
+      // land on whichever panel happens to come last in the document — several
+      // routes carry `max-h-* overflow-y-auto` panels — and then the probe would
+      // watch an element no poll reflows and the shim never writes to, which
+      // reads as a pass no matter how badly the page drifts.
+      const el = document.querySelector('[data-scroll-anchor]');
+      if (!el || el.scrollHeight <= el.clientHeight + 8) return null;
+
+      const native = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollTop');
+      if (!native?.get || !native.set) return null;
+      const read = (): number => (native.get as () => number).call(el);
+
+      (native.set as (v: number) => void).call(el, el.scrollHeight);
+      const start = read();
+
+      const probe = {
+        shimWrites: 0,
+        teardowns: 0,
+        min: start,
+        max: start,
+        running: true,
+      };
+      (window as unknown as { __probe: typeof probe }).__probe = probe;
+      // Held so the closing evaluate can prove it is still THE anchored
+      // scroller. If the element is replaced mid-watch, this reference goes
+      // detached and every metric below reads 0 — a detached node never
+      // scrolls, the swallowing setter is on the old node, and the observer
+      // does not see its own target's removal. All three assertions would pass
+      // while the live page drifted freely.
+      (window as unknown as { __probeEl: Element }).__probeEl = el;
+
+      // Swallow every programmatic write from here on, counting them. The page
+      // must hold still without the shim's help.
+      Object.defineProperty(el, 'scrollTop', {
+        configurable: true,
+        get: read,
+        set: () => {
+          probe.shimWrites += 1;
+        },
+      });
+
+      // Only a removal that SHORTENS the scroller can make the browser clamp
+      // scrollTop, which is the defect this spec is about. Counting every
+      // removal would fail the run on ordinary data arrival — a filled order
+      // leaving the open list, an audit row rolling off — while blaming a
+      // teardown that never happened, and a gate that cries wolf gets ignored.
+      let lastHeight = el.scrollHeight;
+      new MutationObserver((records) => {
+        const height = el.scrollHeight;
+        if (height < lastHeight && records.some((r) => r.removedNodes.length > 0)) {
+          probe.teardowns += 1;
+        }
+        lastHeight = height;
+      }).observe(el, { childList: true, subtree: true });
+
+      const sample = (): void => {
+        const top = read();
+        probe.min = Math.min(probe.min, top);
+        probe.max = Math.max(probe.max, top);
+        if (probe.running) requestAnimationFrame(sample);
+      };
+      requestAnimationFrame(sample);
+      return { start, scrollHeight: el.scrollHeight };
+    });
+
+    expect(
+      parked,
+      `${label}: no anchored scroller with overflowing content — the probe measured nothing`,
+    ).not.toBeNull();
+
+    await page.waitForTimeout(WATCH_MS);
+
+    const result = await page.evaluate(() => {
+      const probe = (
+        window as unknown as {
+          __probe: { shimWrites: number; teardowns: number; min: number; max: number };
+        }
+      ).__probe;
+      (probe as unknown as { running: boolean }).running = false;
+      const el = (window as unknown as { __probeEl: Element }).__probeEl;
+      return {
+        drift: Math.round(probe.max - probe.min),
+        shimWrites: probe.shimWrites,
+        teardowns: probe.teardowns,
+        stillCurrent: el.isConnected && document.querySelector('[data-scroll-anchor]') === el,
+      };
+    });
+
+    expect(
+      result.stillCurrent,
+      `${label}: the anchored scroller was replaced mid-watch — the probe measured a detached node, so the zeros below prove nothing`,
+    ).toBe(true);
+    expect(result.drift, `${label}: reader moved while polling`).toBe(0);
+    expect(result.teardowns, `${label}: a subtree was torn down instead of updated`).toBe(0);
+    expect(result.shimWrites, `${label}: the scroll-anchor shim had to correct a reflow`).toBe(0);
+  });
+}

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist",
+    // Specs run in Node, but `page.evaluate` callbacks are serialised and run in
+    // the browser, so their bodies need the DOM lib to typecheck at all.
+    "lib": ["ES2024", "DOM"],
     "types": ["bun"]
   },
   "include": ["**/*.ts"],

--- a/scripts/ci/__fixtures__/alert-metric/empty-catalog/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/empty-catalog/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,20 @@
+// A catalogue the parser cannot read names out of: the union is spelled with a
+// type alias per member instead of string literals, so the literal harvest finds
+// nothing. Whatever the cause, an empty allowed set would make EVERY alert rule
+// look like a phantom, or, if the resolution order changed, make every rule
+// resolve against nothing at all. The gate refuses to run on it.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+}
+
+type TickLatency = string;
+type DecisionCount = string;
+
+export type MetricName = TickLatency | DecisionCount;
+
+export const CATALOG: Readonly<Record<string, MetricSpec>> = {};

--- a/scripts/ci/__fixtures__/alert-metric/empty-catalog/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/empty-catalog/deploy/observability/alerts.yml
@@ -1,0 +1,85 @@
+# Known-good fixture: every referenced name resolves, across every syntax the
+# gate has to understand. If any one of these regressed into a false positive the
+# gate would start rejecting legitimate rules, which is how a gate gets disabled.
+#
+# Covered here: Prometheus-synthesised `up`; a `_count` series derived from a
+# declared histogram; a `_bucket` off the one prom-client default that is a
+# histogram; a declared gauge; a prom-client constructor name; a default process
+# metric; an aggregation with a `by (…)` label list; an `offset` modifier; a
+# fully quoted expr scalar; a `__name__` equality matcher; an inline expr and a
+# block-scalar expr; and a recording rule, whose head must be counted like an
+# alert head or the head-vs-expr assert misfires.
+
+groups:
+  - name: fixture.pass
+    interval: 30s
+    rules:
+      - alert: ScrapeDown
+        expr: up{job="worker"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Scrape down for 2m'
+
+      - alert: TickVolumeLow
+        expr: |
+          sum by (profileId) (increase(tick_latency_ms_count[10m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Tick rate collapsed on {{ $labels.profileId }}'
+
+      - alert: WeightHigh
+        expr: max by (profileId) (binance_api_weight) > 1000
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Binance request weight > 1000/min'
+
+      - alert: WeightGrewSinceLastHour
+        expr: binance_api_weight - binance_api_weight offset 1h > 100
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Weight climbing hour over hour'
+
+      - alert: QuotedScalarExpr
+        expr: 'decision_count > 0 and pino_dropped_logs_total == 0'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Deciding but dropping no logs'
+
+      - alert: NameMatcherExpr
+        # Quoted because a bare `{` opens a YAML flow mapping, so this is the
+        # only way an operator can actually write a `__name__` matcher here.
+        expr: '{__name__="worker_owned_accounts"} < 1'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'This pod owns no accounts'
+
+      - alert: GcSlow
+        expr: histogram_quantile(0.9, rate(nodejs_gc_duration_seconds_bucket[5m])) > 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'GC pauses above 1s at p90'
+
+      - alert: MemoryHigh
+        expr: process_resident_memory_bytes > 1073741824
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Resident memory above 1GiB'
+
+      - record: fixture:http_requests:rate5m
+        expr: sum by (route) (rate(http_requests_total[5m]))

--- a/scripts/ci/__fixtures__/alert-metric/empty-catalog/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/empty-catalog/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/__fixtures__/alert-metric/fail/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/fail/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,47 @@
+// Fixture stand-in for the worker metric catalogue. It mirrors the SHAPE the gate
+// parses, not just the names: a multi-line union with a leading `|` per member,
+// entry keys at 2 spaces and spec fields at 4, comments between entries, a
+// `buckets` field, and a declaration after CATALOG's closing brace so the
+// parser's terminator is exercised rather than end-of-file.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+  readonly buckets?: readonly number[];
+}
+
+export const LATENCY_MS_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500] as const;
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+    buckets: LATENCY_MS_BUCKETS,
+  },
+  // A counter whose own name ends in `_count`. Prometheus derives `_sum` from a
+  // histogram and never from a counter, so `decision_count_sum` has to stay
+  // reportable: this entry is what makes that half of the rule executable.
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/fail/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/fail/deploy/observability/alerts.yml
@@ -1,0 +1,95 @@
+# Known-bad fixture. Six failure shapes against the same catalogue the pass
+# fixture uses, each one a distinct way a phantom has slipped past a name check:
+#
+#   - a transposed-letter typo on a real histogram's derived series;
+#   - a name that PREFIXES a legal one, so the synthesised/default allowlists
+#     have to match exactly rather than by prefix;
+#   - `_sum` off a COUNTER, which Prometheus never derives (only histograms and
+#     summaries do), and whose parent already ends in `_count`;
+#   - a phantom hidden inside a fully quoted expr scalar, which a tokeniser that
+#     strips quoted runs first would erase to nothing;
+#   - a phantom named through a `__name__` matcher, which a tokeniser that strips
+#     label matchers first would erase before reading;
+#   - a non-metric `name:` literal that sits just after a spread-built
+#     constructor in the fixture's observability source, which a constructor scan
+#     bounded by a character count would wrongly register as declared.
+#
+# Every one of these is asserted by name in the self-test, because the gate has
+# several vacuity floors that also exit non-zero.
+
+groups:
+  - name: fixture.fail
+    interval: 30s
+    rules:
+      - alert: TypoedHistogram
+        expr: |
+          sum by (profileId) (increase(tick_latnecy_ms_count[10m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Tick rate collapsed'
+
+      - alert: PrefixOfSynthesised
+        expr: up_wrong == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Scrape down for 2m'
+
+      - alert: SuffixOffCounter
+        expr: decision_count_sum > 100
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Decisions summed'
+
+      - alert: PhantomInQuotedScalar
+        expr: 'phantom_behind_quotes > 1000'
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Quoted scalar hiding a phantom'
+
+      - alert: PhantomInNameMatcher
+        expr: '{__name__="phantom_behind_name_matcher"} > 0'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Name matcher hiding a phantom'
+
+      - alert: AdoptedNonMetricLiteral
+        expr: not_a_metric_name > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Literal adopted from past a constructor'
+
+      - alert: NotRegisteredOnThisRuntime
+        # prom-client declares this default metric but skips registering it when
+        # v8.getHeapSpaceStatistics() is unimplemented, which is the case on Bun.
+        # Listing it in the default allowlist would bless a series that is never
+        # written, the same phantom the gate exists to catch.
+        expr: nodejs_heap_space_size_used_bytes > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Heap space metric that Bun never registers'
+
+      - alert: OperatorNamedMetric
+        # A metric literally named `sum`. Aggregation operators are always
+        # call-applied, so listing them as bare keywords buys nothing and
+        # silently blesses any real metric that shares the name. This rule fails
+        # the moment one is added back to the keyword set.
+        expr: sum > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Keyword set must not swallow a metric name'

--- a/scripts/ci/__fixtures__/alert-metric/fail/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/fail/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/__fixtures__/alert-metric/flow-style/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/flow-style/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,47 @@
+// Fixture stand-in for the worker metric catalogue. It mirrors the SHAPE the gate
+// parses, not just the names: a multi-line union with a leading `|` per member,
+// entry keys at 2 spaces and spec fields at 4, comments between entries, a
+// `buckets` field, and a declaration after CATALOG's closing brace so the
+// parser's terminator is exercised rather than end-of-file.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+  readonly buckets?: readonly number[];
+}
+
+export const LATENCY_MS_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500] as const;
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+    buckets: LATENCY_MS_BUCKETS,
+  },
+  // A counter whose own name ends in `_count`. Prometheus derives `_sum` from a
+  // histogram and never from a counter, so `decision_count_sum` has to stay
+  // reportable: this entry is what makes that half of the rule executable.
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/flow-style/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/flow-style/deploy/observability/alerts.yml
@@ -1,0 +1,19 @@
+# A flow-style rule entry. It is legal YAML, and it is the dangerous shape:
+# neither the rule-head regex nor the expr regex matches it, so the head and expr
+# counts stay balanced, the consistency assert sees nothing wrong, and the
+# phantom inside is never tokenised. The gate rejects the shape rather than
+# growing a second parser for it.
+
+groups:
+  - name: fixture.flow-style
+    interval: 30s
+    rules:
+      - alert: BlockStyleNeighbour
+        expr: binance_api_weight > 1000
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Parsed normally'
+
+      - { alert: FlowStyleRule, expr: phantom_in_flow_style > 0, for: 5m }

--- a/scripts/ci/__fixtures__/alert-metric/flow-style/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/flow-style/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/__fixtures__/alert-metric/head-expr-skew/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/head-expr-skew/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,47 @@
+// Fixture stand-in for the worker metric catalogue. It mirrors the SHAPE the gate
+// parses, not just the names: a multi-line union with a leading `|` per member,
+// entry keys at 2 spaces and spec fields at 4, comments between entries, a
+// `buckets` field, and a declaration after CATALOG's closing brace so the
+// parser's terminator is exercised rather than end-of-file.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+  readonly buckets?: readonly number[];
+}
+
+export const LATENCY_MS_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500] as const;
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+    buckets: LATENCY_MS_BUCKETS,
+  },
+  // A counter whose own name ends in `_count`. Prometheus derives `_sum` from a
+  // histogram and never from a counter, so `decision_count_sum` has to stay
+  // reportable: this entry is what makes that half of the rule executable.
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/head-expr-skew/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/head-expr-skew/deploy/observability/alerts.yml
@@ -1,0 +1,24 @@
+# Two rule heads, one expr. The gate counts both and asserts they agree, because
+# the failure it guards is invisible otherwise: if the block-scalar walk ever
+# over-consumed and swallowed the next rule's expr, the swallowed expression
+# would simply never be checked and the gate would still report OK. A count that
+# does not add up is a parser fault, not a file fault.
+
+groups:
+  - name: fixture.head-expr-skew
+    interval: 30s
+    rules:
+      - alert: HasExpr
+        expr: binance_api_weight > 1000
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Parsed normally'
+
+      - alert: MissingExpr
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'No expr key at all'

--- a/scripts/ci/__fixtures__/alert-metric/head-expr-skew/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/head-expr-skew/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/__fixtures__/alert-metric/name-regex/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/name-regex/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,47 @@
+// Fixture stand-in for the worker metric catalogue. It mirrors the SHAPE the gate
+// parses, not just the names: a multi-line union with a leading `|` per member,
+// entry keys at 2 spaces and spec fields at 4, comments between entries, a
+// `buckets` field, and a declaration after CATALOG's closing brace so the
+// parser's terminator is exercised rather than end-of-file.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+  readonly buckets?: readonly number[];
+}
+
+export const LATENCY_MS_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500] as const;
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+    buckets: LATENCY_MS_BUCKETS,
+  },
+  // A counter whose own name ends in `_count`. Prometheus derives `_sum` from a
+  // histogram and never from a counter, so `decision_count_sum` has to stay
+  // reportable: this entry is what makes that half of the rule executable.
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/name-regex/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/name-regex/deploy/observability/alerts.yml
@@ -1,0 +1,17 @@
+# A `__name__` matcher whose operator is a regex rather than equality. The rule
+# may well be valid PromQL, but the gate cannot resolve `tick_.*` to a concrete
+# series to check it against the catalogue, and silently ignoring it would be a
+# hole the size of every metric name. It is a hard error telling the author to
+# name the metric directly.
+
+groups:
+  - name: fixture.name-regex
+    interval: 30s
+    rules:
+      - alert: RegexNameMatcher
+        expr: 'sum({__name__=~"tick_.*"}) > 0'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Anything tick-shaped'

--- a/scripts/ci/__fixtures__/alert-metric/name-regex/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/name-regex/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/__fixtures__/alert-metric/no-ctor/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/no-ctor/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,47 @@
+// Fixture stand-in for the worker metric catalogue. It mirrors the SHAPE the gate
+// parses, not just the names: a multi-line union with a leading `|` per member,
+// entry keys at 2 spaces and spec fields at 4, comments between entries, a
+// `buckets` field, and a declaration after CATALOG's closing brace so the
+// parser's terminator is exercised rather than end-of-file.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+  readonly buckets?: readonly number[];
+}
+
+export const LATENCY_MS_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500] as const;
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+    buckets: LATENCY_MS_BUCKETS,
+  },
+  // A counter whose own name ends in `_count`. Prometheus derives `_sum` from a
+  // histogram and never from a counter, so `decision_count_sum` has to stay
+  // reportable: this entry is what makes that half of the rule executable.
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/no-ctor/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/no-ctor/deploy/observability/alerts.yml
@@ -1,0 +1,85 @@
+# Known-good fixture: every referenced name resolves, across every syntax the
+# gate has to understand. If any one of these regressed into a false positive the
+# gate would start rejecting legitimate rules, which is how a gate gets disabled.
+#
+# Covered here: Prometheus-synthesised `up`; a `_count` series derived from a
+# declared histogram; a `_bucket` off the one prom-client default that is a
+# histogram; a declared gauge; a prom-client constructor name; a default process
+# metric; an aggregation with a `by (…)` label list; an `offset` modifier; a
+# fully quoted expr scalar; a `__name__` equality matcher; an inline expr and a
+# block-scalar expr; and a recording rule, whose head must be counted like an
+# alert head or the head-vs-expr assert misfires.
+
+groups:
+  - name: fixture.pass
+    interval: 30s
+    rules:
+      - alert: ScrapeDown
+        expr: up{job="worker"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Scrape down for 2m'
+
+      - alert: TickVolumeLow
+        expr: |
+          sum by (profileId) (increase(tick_latency_ms_count[10m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Tick rate collapsed on {{ $labels.profileId }}'
+
+      - alert: WeightHigh
+        expr: max by (profileId) (binance_api_weight) > 1000
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Binance request weight > 1000/min'
+
+      - alert: WeightGrewSinceLastHour
+        expr: binance_api_weight - binance_api_weight offset 1h > 100
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Weight climbing hour over hour'
+
+      - alert: QuotedScalarExpr
+        expr: 'decision_count > 0 and pino_dropped_logs_total == 0'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Deciding but dropping no logs'
+
+      - alert: NameMatcherExpr
+        # Quoted because a bare `{` opens a YAML flow mapping, so this is the
+        # only way an operator can actually write a `__name__` matcher here.
+        expr: '{__name__="worker_owned_accounts"} < 1'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'This pod owns no accounts'
+
+      - alert: GcSlow
+        expr: histogram_quantile(0.9, rate(nodejs_gc_duration_seconds_bucket[5m])) > 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'GC pauses above 1s at p90'
+
+      - alert: MemoryHigh
+        expr: process_resident_memory_bytes > 1073741824
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Resident memory above 1GiB'
+
+      - record: fixture:http_requests:rate5m
+        expr: sum by (route) (rate(http_requests_total[5m]))

--- a/scripts/ci/__fixtures__/alert-metric/no-ctor/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/no-ctor/deploy/observability/alerts.yml
@@ -1,17 +1,14 @@
-# Known-good fixture: every referenced name resolves, across every syntax the
-# gate has to understand. If any one of these regressed into a false positive the
-# gate would start rejecting legitimate rules, which is how a gate gets disabled.
+# Rejection fixture: the tree carries no prom-client constructor call, so the
+# gate has to fail on its empty-constructor-scan floor. That floor is what stops
+# a scan-path regression — a moved package, a renamed source root — from
+# emptying the emitted set and passing every rule in silence.
 #
-# Covered here: Prometheus-synthesised `up`; a `_count` series derived from a
-# declared histogram; a `_bucket` off the one prom-client default that is a
-# histogram; a declared gauge; a prom-client constructor name; a default process
-# metric; an aggregation with a `by (…)` label list; an `offset` modifier; a
-# fully quoted expr scalar; a `__name__` equality matcher; an inline expr and a
-# block-scalar expr; and a recording rule, whose head must be counted like an
-# alert head or the head-vs-expr assert misfires.
+# These rules are here only so the gate reaches that floor with a well-formed
+# file behind it. They are never resolved: the floor exits before any expr is
+# read, so nothing below asserts anything about name resolution.
 
 groups:
-  - name: fixture.pass
+  - name: fixture.no-ctor
     interval: 30s
     rules:
       - alert: ScrapeDown

--- a/scripts/ci/__fixtures__/alert-metric/no-ctor/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/no-ctor/packages/observability/src/index.ts
@@ -1,0 +1,7 @@
+// An observability module that constructs no prom-client metric. The real repo
+// always has some, so finding none means the file walk stopped resolving source
+// (a moved directory, a widened skip list) rather than that the sinks went away.
+// Passing on an empty scan would silently drop every constructor-declared name
+// from the allowed set, so the gate fails instead.
+
+export const buildRegistry = (): Record<string, never> => ({});

--- a/scripts/ci/__fixtures__/alert-metric/no-exprs/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/no-exprs/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,47 @@
+// Fixture stand-in for the worker metric catalogue. It mirrors the SHAPE the gate
+// parses, not just the names: a multi-line union with a leading `|` per member,
+// entry keys at 2 spaces and spec fields at 4, comments between entries, a
+// `buckets` field, and a declaration after CATALOG's closing brace so the
+// parser's terminator is exercised rather than end-of-file.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+  readonly buckets?: readonly number[];
+}
+
+export const LATENCY_MS_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500] as const;
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+    buckets: LATENCY_MS_BUCKETS,
+  },
+  // A counter whose own name ends in `_count`. Prometheus derives `_sum` from a
+  // histogram and never from a counter, so `decision_count_sum` has to stay
+  // reportable: this entry is what makes that half of the rule executable.
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/no-exprs/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/no-exprs/deploy/observability/alerts.yml
@@ -1,0 +1,14 @@
+# A rule head with no expr key anywhere in the file. Scanning every rule and
+# extracting nothing to check means the expr parser stopped matching, not that
+# the rules are fine, so this is a failure rather than a clean run.
+
+groups:
+  - name: fixture.no-exprs
+    interval: 30s
+    rules:
+      - alert: MissingExpr
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'No expr key at all'

--- a/scripts/ci/__fixtures__/alert-metric/no-exprs/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/no-exprs/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/__fixtures__/alert-metric/no-rules/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/no-rules/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,47 @@
+// Fixture stand-in for the worker metric catalogue. It mirrors the SHAPE the gate
+// parses, not just the names: a multi-line union with a leading `|` per member,
+// entry keys at 2 spaces and spec fields at 4, comments between entries, a
+// `buckets` field, and a declaration after CATALOG's closing brace so the
+// parser's terminator is exercised rather than end-of-file.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+  readonly buckets?: readonly number[];
+}
+
+export const LATENCY_MS_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500] as const;
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+    buckets: LATENCY_MS_BUCKETS,
+  },
+  // A counter whose own name ends in `_count`. Prometheus derives `_sum` from a
+  // histogram and never from a counter, so `decision_count_sum` has to stay
+  // reportable: this entry is what makes that half of the rule executable.
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/no-rules/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/no-rules/deploy/observability/alerts.yml
@@ -1,0 +1,8 @@
+# A rules file with a group but no rule heads. Reaching the end of the scan
+# having found nothing to check is not a clean bill of health, it is a parser
+# that stopped recognising rules, so the gate fails rather than reporting OK.
+
+groups:
+  - name: fixture.no-rules
+    interval: 30s
+    rules:

--- a/scripts/ci/__fixtures__/alert-metric/no-rules/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/no-rules/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/__fixtures__/alert-metric/pass/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/pass/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,47 @@
+// Fixture stand-in for the worker metric catalogue. It mirrors the SHAPE the gate
+// parses, not just the names: a multi-line union with a leading `|` per member,
+// entry keys at 2 spaces and spec fields at 4, comments between entries, a
+// `buckets` field, and a declaration after CATALOG's closing brace so the
+// parser's terminator is exercised rather than end-of-file.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+  readonly buckets?: readonly number[];
+}
+
+export const LATENCY_MS_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500] as const;
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+    buckets: LATENCY_MS_BUCKETS,
+  },
+  // A counter whose own name ends in `_count`. Prometheus derives `_sum` from a
+  // histogram and never from a counter, so `decision_count_sum` has to stay
+  // reportable: this entry is what makes that half of the rule executable.
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/pass/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/pass/deploy/observability/alerts.yml
@@ -1,0 +1,125 @@
+# Known-good fixture: every referenced name resolves, across every syntax the
+# gate has to understand. If any one of these regressed into a false positive the
+# gate would start rejecting legitimate rules, which is how a gate gets disabled.
+#
+# Covered here: Prometheus-synthesised `up`; a `_count` series derived from a
+# declared histogram; a `_bucket` off the one prom-client default that is a
+# histogram; a declared gauge; a prom-client constructor name; a default process
+# metric; an aggregation with a `by (…)` label list; an `offset` modifier; a
+# fully quoted expr scalar; a `__name__` equality matcher; an inline expr and a
+# block-scalar expr; and a recording rule, whose head must be counted like an
+# alert head or the head-vs-expr assert misfires.
+
+groups:
+  - name: fixture.pass
+    interval: 30s
+    rules:
+      - alert: ScrapeDown
+        expr: up{job="worker"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Scrape down for 2m'
+
+      - alert: TickVolumeLow
+        expr: |
+          sum by (profileId) (increase(tick_latency_ms_count[10m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Tick rate collapsed on {{ $labels.profileId }}'
+
+      - alert: WeightHigh
+        expr: max by (profileId) (binance_api_weight) > 1000
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Binance request weight > 1000/min'
+
+      - alert: WeightGrewSinceLastHour
+        # A compound duration: `1h30m` leaves `30m` behind if the offset strip
+        # matches only one unit, and the numeric strip cannot remove the `30`
+        # from it, so a bare `m` gets reported as a metric.
+        expr: binance_api_weight - binance_api_weight offset 1h30m > 100
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          # A Go-template bullet inside a block scalar. It opens with `- {`,
+          # which is also how a flow-style rule entry opens, so a flow check
+          # that does not require a rule key breaks this legitimate rule.
+          description: |
+            Weight climbing on:
+            - {{ $labels.profileId }}
+            Check profile cadence.
+          summary: 'Weight climbing hour over hour'
+
+      - alert: QuotedScalarExpr
+        expr: 'decision_count > 0 and pino_dropped_logs_total == 0' # trailing YAML comment
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Deciding but dropping no logs'
+
+      - alert: HashInsideQuotes
+        # The `#` here is expression content, not a comment: unwrapping has to
+        # find the real closing quote before any comment strip runs.
+        expr: 'binance_api_weight{note="#1 profile"} > 1000'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Quoted hash stays content'
+
+      - alert: Atan2Operator
+        # atan2 is a BINARY operator, written between operands rather than
+        # call-applied, so it reaches the identifier pass as a bare token.
+        expr: binance_api_weight atan2 decision_count > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Binary word operator'
+
+      - expr: process_open_fds > 1000
+        # `expr:` leading the entry. Legal YAML, and the entry has to be counted
+        # from its dash rather than from whichever key happens to come first.
+        alert: ExprFirstOrdering
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Too many open descriptors'
+
+      - alert: NameMatcherExpr
+        # Quoted because a bare `{` opens a YAML flow mapping, so this is the
+        # only way an operator can actually write a `__name__` matcher here.
+        expr: '{__name__="worker_owned_accounts"} < 1'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'This pod owns no accounts'
+
+      - alert: GcSlow
+        expr: histogram_quantile(0.9, rate(nodejs_gc_duration_seconds_bucket[5m])) > 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'GC pauses above 1s at p90'
+
+      - alert: MemoryHigh
+        expr: process_resident_memory_bytes > 1073741824
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Resident memory above 1GiB'
+
+      - record: fixture:http_requests:rate5m
+        expr: sum by (route) (rate(http_requests_total[5m]))

--- a/scripts/ci/__fixtures__/alert-metric/pass/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/pass/deploy/observability/alerts.yml
@@ -5,10 +5,11 @@
 # Covered here: Prometheus-synthesised `up`; a `_count` series derived from a
 # declared histogram; a `_bucket` off the one prom-client default that is a
 # histogram; a declared gauge; a prom-client constructor name; a default process
-# metric; an aggregation with a `by (…)` label list; an `offset` modifier; a
-# fully quoted expr scalar; a `__name__` equality matcher; an inline expr and a
-# block-scalar expr; and a recording rule, whose head must be counted like an
-# alert head or the head-vs-expr assert misfires.
+# metric; an aggregation with a `by (…)` label list; an `offset` modifier; the
+# exponent, hex and `_`-separated float literals; a fully quoted expr scalar; a
+# `__name__` equality matcher; an inline expr and a block-scalar expr; and a
+# recording rule, whose head must be counted like an alert head or the
+# head-vs-expr assert misfires.
 
 groups:
   - name: fixture.pass
@@ -104,6 +105,17 @@ groups:
           severity: warning
         annotations:
           summary: 'This pod owns no accounts'
+
+      - alert: NumericLiteralForms
+        # The float-literal forms beyond a plain decimal. Each leaves a bare
+        # identifier behind if the numeric strip does not know it: `1e6` reads
+        # as `e6`, `0x1f` as `x1f`, `1_000_000` as `_000_000`.
+        expr: binance_api_weight > 1e6 or binance_api_weight > 0x1f or decision_count > 1_000_000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Numeric literals stay literals'
 
       - alert: GcSlow
         expr: histogram_quantile(0.9, rate(nodejs_gc_duration_seconds_bucket[5m])) > 1

--- a/scripts/ci/__fixtures__/alert-metric/pass/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/pass/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/__fixtures__/alert-metric/union-drift/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/union-drift/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,41 @@
+// The MetricName union lists a name CATALOG does not define. TypeScript rejects
+// this shape outright (`Record<MetricName, MetricSpec>` fails on a missing key),
+// so it can only mean the gate's two parsers have drifted apart: one of them is
+// reading something the other is not. The gate reports the symmetric difference
+// rather than quietly trusting whichever set it happened to build.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+}
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight'
+  | 'declared_in_union_only';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/union-drift/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/union-drift/deploy/observability/alerts.yml
@@ -1,0 +1,85 @@
+# Known-good fixture: every referenced name resolves, across every syntax the
+# gate has to understand. If any one of these regressed into a false positive the
+# gate would start rejecting legitimate rules, which is how a gate gets disabled.
+#
+# Covered here: Prometheus-synthesised `up`; a `_count` series derived from a
+# declared histogram; a `_bucket` off the one prom-client default that is a
+# histogram; a declared gauge; a prom-client constructor name; a default process
+# metric; an aggregation with a `by (…)` label list; an `offset` modifier; a
+# fully quoted expr scalar; a `__name__` equality matcher; an inline expr and a
+# block-scalar expr; and a recording rule, whose head must be counted like an
+# alert head or the head-vs-expr assert misfires.
+
+groups:
+  - name: fixture.pass
+    interval: 30s
+    rules:
+      - alert: ScrapeDown
+        expr: up{job="worker"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Scrape down for 2m'
+
+      - alert: TickVolumeLow
+        expr: |
+          sum by (profileId) (increase(tick_latency_ms_count[10m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Tick rate collapsed on {{ $labels.profileId }}'
+
+      - alert: WeightHigh
+        expr: max by (profileId) (binance_api_weight) > 1000
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Binance request weight > 1000/min'
+
+      - alert: WeightGrewSinceLastHour
+        expr: binance_api_weight - binance_api_weight offset 1h > 100
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Weight climbing hour over hour'
+
+      - alert: QuotedScalarExpr
+        expr: 'decision_count > 0 and pino_dropped_logs_total == 0'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Deciding but dropping no logs'
+
+      - alert: NameMatcherExpr
+        # Quoted because a bare `{` opens a YAML flow mapping, so this is the
+        # only way an operator can actually write a `__name__` matcher here.
+        expr: '{__name__="worker_owned_accounts"} < 1'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'This pod owns no accounts'
+
+      - alert: GcSlow
+        expr: histogram_quantile(0.9, rate(nodejs_gc_duration_seconds_bucket[5m])) > 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'GC pauses above 1s at p90'
+
+      - alert: MemoryHigh
+        expr: process_resident_memory_bytes > 1073741824
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Resident memory above 1GiB'
+
+      - record: fixture:http_requests:rate5m
+        expr: sum by (route) (rate(http_requests_total[5m]))

--- a/scripts/ci/__fixtures__/alert-metric/union-drift/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/union-drift/deploy/observability/alerts.yml
@@ -1,7 +1,8 @@
 # Rejection fixture: the worker's `MetricName` union and its `CATALOG` keys
 # disagree, so the gate has to refuse the tree rather than pick a side. The two
-# are cross-checked because either one alone can drift: a name left in the union
-# after its catalogue entry goes reads as emitted when nothing writes it.
+# are cross-checked because TypeScript already couples them, so a disagreement
+# means one of the gate's two parsers regressed and the emitted set it built
+# cannot be trusted to say what is a phantom.
 #
 # These rules are here only so the gate reaches that check with a well-formed
 # file behind it. They are never resolved: the drift check exits before any expr

--- a/scripts/ci/__fixtures__/alert-metric/union-drift/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/union-drift/deploy/observability/alerts.yml
@@ -1,17 +1,14 @@
-# Known-good fixture: every referenced name resolves, across every syntax the
-# gate has to understand. If any one of these regressed into a false positive the
-# gate would start rejecting legitimate rules, which is how a gate gets disabled.
+# Rejection fixture: the worker's `MetricName` union and its `CATALOG` keys
+# disagree, so the gate has to refuse the tree rather than pick a side. The two
+# are cross-checked because either one alone can drift: a name left in the union
+# after its catalogue entry goes reads as emitted when nothing writes it.
 #
-# Covered here: Prometheus-synthesised `up`; a `_count` series derived from a
-# declared histogram; a `_bucket` off the one prom-client default that is a
-# histogram; a declared gauge; a prom-client constructor name; a default process
-# metric; an aggregation with a `by (…)` label list; an `offset` modifier; a
-# fully quoted expr scalar; a `__name__` equality matcher; an inline expr and a
-# block-scalar expr; and a recording rule, whose head must be counted like an
-# alert head or the head-vs-expr assert misfires.
+# These rules are here only so the gate reaches that check with a well-formed
+# file behind it. They are never resolved: the drift check exits before any expr
+# is read, so nothing below asserts anything about name resolution.
 
 groups:
-  - name: fixture.pass
+  - name: fixture.union-drift
     interval: 30s
     rules:
       - alert: ScrapeDown

--- a/scripts/ci/__fixtures__/alert-metric/union-drift/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/union-drift/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/__fixtures__/alert-metric/vacuous/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/vacuous/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,47 @@
+// Fixture stand-in for the worker metric catalogue. It mirrors the SHAPE the gate
+// parses, not just the names: a multi-line union with a leading `|` per member,
+// entry keys at 2 spaces and spec fields at 4, comments between entries, a
+// `buckets` field, and a declaration after CATALOG's closing brace so the
+// parser's terminator is exercised rather than end-of-file.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+  readonly buckets?: readonly number[];
+}
+
+export const LATENCY_MS_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500] as const;
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+    buckets: LATENCY_MS_BUCKETS,
+  },
+  // A counter whose own name ends in `_count`. Prometheus derives `_sum` from a
+  // histogram and never from a counter, so `decision_count_sum` has to stay
+  // reportable: this entry is what makes that half of the rule executable.
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/vacuous/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/vacuous/deploy/observability/alerts.yml
@@ -1,0 +1,26 @@
+# Vacuity fixture: both rules parse, but the second names no metric at all.
+#
+# The first rule is healthy on purpose. A global "did we extract any candidate?"
+# floor would be satisfied by it and let the second rule through, which is the
+# exact silent pass this gate exists to stop, so the floor has to be per-expr.
+
+groups:
+  - name: fixture.vacuous
+    interval: 30s
+    rules:
+      - alert: HealthyNeighbour
+        expr: binance_api_weight > 1000
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'A rule that does name a metric'
+
+      - alert: AlwaysQuiet
+        expr: |
+          vector(0) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Never fires and names nothing'

--- a/scripts/ci/__fixtures__/alert-metric/vacuous/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/vacuous/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/__fixtures__/alert-metric/watchdog/apps/worker/src/metrics/catalog.ts
+++ b/scripts/ci/__fixtures__/alert-metric/watchdog/apps/worker/src/metrics/catalog.ts
@@ -1,0 +1,47 @@
+// Fixture stand-in for the worker metric catalogue. It mirrors the SHAPE the gate
+// parses, not just the names: a multi-line union with a leading `|` per member,
+// entry keys at 2 spaces and spec fields at 4, comments between entries, a
+// `buckets` field, and a declaration after CATALOG's closing brace so the
+// parser's terminator is exercised rather than end-of-file.
+
+export type MetricKind = 'counter' | 'gauge' | 'histogram';
+
+export interface MetricSpec {
+  readonly kind: MetricKind;
+  readonly help: string;
+  readonly labelNames: readonly string[];
+  readonly buckets?: readonly number[];
+}
+
+export const LATENCY_MS_BUCKETS = [1, 5, 10, 25, 50, 100, 250, 500] as const;
+
+export type MetricName =
+  | 'tick_latency_ms'
+  | 'decision_count'
+  | 'binance_api_weight';
+
+export const CATALOG: Readonly<Record<MetricName, MetricSpec>> = {
+  tick_latency_ms: {
+    kind: 'histogram',
+    help: 'Tick handler wall-clock latency in milliseconds.',
+    labelNames: ['profileId', 'symbol'],
+    buckets: LATENCY_MS_BUCKETS,
+  },
+  // A counter whose own name ends in `_count`. Prometheus derives `_sum` from a
+  // histogram and never from a counter, so `decision_count_sum` has to stay
+  // reportable: this entry is what makes that half of the rule executable.
+  decision_count: {
+    kind: 'counter',
+    help: 'Strategy decisions emitted, accumulated across ticks.',
+    labelNames: ['profileId', 'symbol'],
+  },
+  binance_api_weight: {
+    kind: 'gauge',
+    help: 'Binance used request weight in the last 1m window.',
+    labelNames: ['profileId'],
+  },
+};
+
+export interface MetricsSink {
+  record(name: MetricName, value: number, tags?: Readonly<Record<string, string>>): void;
+}

--- a/scripts/ci/__fixtures__/alert-metric/watchdog/deploy/observability/alerts.yml
+++ b/scripts/ci/__fixtures__/alert-metric/watchdog/deploy/observability/alerts.yml
@@ -1,0 +1,26 @@
+# A dead-man's-switch watchdog names no metric by construction: it fires always,
+# so a silent Alertmanager pipeline is itself the signal. The per-expr floor
+# would reject it, so the author opts the rule out explicitly on the line above
+# the expr. The marker is per-rule and has to be typed, which keeps silence
+# failing by default: the `vacuous` fixture is this shape WITHOUT the marker and
+# is still rejected.
+
+groups:
+  - name: fixture.watchdog
+    interval: 30s
+    rules:
+      - alert: Watchdog
+        # names-no-metric: fires always so a silent Alertmanager pipeline shows up
+        expr: vector(1)
+        labels:
+          severity: none
+        annotations:
+          summary: 'Always firing, by design'
+
+      - alert: WeightHigh
+        expr: binance_api_weight > 1000
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Binance request weight > 1000/min'

--- a/scripts/ci/__fixtures__/alert-metric/watchdog/packages/observability/src/index.ts
+++ b/scripts/ci/__fixtures__/alert-metric/watchdog/packages/observability/src/index.ts
@@ -1,0 +1,53 @@
+// Fixture stand-in for the observability registry. The gate reads metric names
+// off `new Counter/Gauge/Histogram/Summary({ name: ... })` call sites, so the
+// constructors are declared locally rather than imported: the fixture tree has no
+// node_modules and the gate never resolves the import.
+//
+// All three real-world call shapes appear here, because the gate's window has to
+// close on each one correctly: a bare top-level construction, one indented inside
+// a factory with `labelNames`/`registers` after the name, and one whose options
+// are spread-built and carry no literal name at all.
+
+type Opts = {
+  name?: string;
+  help: string;
+  labelNames?: readonly string[];
+  buckets?: readonly number[];
+  registers?: readonly unknown[];
+};
+declare const Counter: new (opts: Opts) => unknown;
+declare const Gauge: new (opts: Opts) => unknown;
+declare const Histogram: new (opts: Opts) => unknown;
+
+export const pinoDropped = new Counter({
+  name: 'pino_dropped_logs_total',
+  help: 'Log lines dropped by the async destination when the buffer saturates.',
+});
+
+export const buildHttpMetrics = (registry: unknown): unknown => {
+  const requests = new Counter({
+    name: 'http_requests_total',
+    help: 'Total API HTTP requests, labelled by method, matched route and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+  });
+  return requests;
+};
+
+// The next two declarations are adjacent on purpose. `buildFromSpec` spreads its
+// options and carries no literal name, the shape the worker's sink adapter uses,
+// so the gate must register nothing for it. The descriptor immediately after it
+// does hold a `name:` literal, and it is not a metric. A constructor scan bounded
+// by a character count rather than by the call's own closing `})` reads straight
+// past the constructor, adopts that literal as a declared metric, and then goes
+// quiet on a real phantom. The fail fixture references it to prove it does not.
+export const buildFromSpec = (base: Opts, spec: { buckets: readonly number[] }): unknown =>
+  new Histogram({ ...base, buckets: [...spec.buckets] });
+export const auditStreamDescriptor = { name: 'not_a_metric_name', kind: 'redis-stream' };
+
+export const buildOwnedGauge = (registry: unknown): unknown =>
+  new Gauge({
+    name: 'worker_owned_accounts',
+    help: 'Accounts whose user-data subscription this pod owns.',
+    registers: [registry],
+  });

--- a/scripts/ci/lint.sh
+++ b/scripts/ci/lint.sh
@@ -33,7 +33,17 @@ bash "$(dirname "$0")/no-stripped-err-log.sh"
 bash "$(dirname "$0")/no-error-cast.sh"
 bash "$(dirname "$0")/no-uncommented-coverage-ignore.sh"
 bash "$(dirname "$0")/notify-conformance-coverage.sh"
+# Self-test first: `set -e` aborts on the first failure, and on the one run where
+# both would fail it is the self-test that says whether the rules file is wrong
+# or the parser regressed. Then metric-name existence before PromQL syntax,
+# because promtool accepts a rule over a series nothing emits.
+bash "$(dirname "$0")/no-phantom-alert-metric.selftest.sh"
+bash "$(dirname "$0")/no-phantom-alert-metric.sh"
 bash "$(dirname "$0")/promtool-lint.sh"
+# Self-test first, same reasoning as the alert-metric pair above: on a run where
+# both fail it says whether the config drifted or the gate itself broke.
+bash "$(dirname "$0")/no-dropped-lint-rule.selftest.sh"
+bash "$(dirname "$0")/no-dropped-lint-rule.sh"
 # Whole-repo single-pass lint. One invocation (not per-package) so oxlint's
 # multi-file analysis builds one project-wide module graph for import/no-cycle,
 # rather than a per-package view blind to imports crossing package folders.

--- a/scripts/ci/no-dropped-lint-rule.selftest.sh
+++ b/scripts/ci/no-dropped-lint-rule.selftest.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Self-test for no-dropped-lint-rule.sh. Drives the real gate over mutated
+# copies of .oxlintrc.json via the OXLINT_CONFIG override, so the tracked config
+# is never edited — a killed run cannot leave a disarmed rule behind.
+#
+# Every failing case asserts its OWN diagnostic, never a bare non-zero exit. The
+# gate exits 1 from the vacuity floor, from either diagnostic branch, and from
+# `set -e` if oxlint itself fails on a mangled config; a non-zero-means-caught
+# check would read any of those as a successful catch.
+set -uo pipefail
+
+dir="$(cd -- "$(dirname -- "$0")" && pwd)"
+gate="$dir/no-dropped-lint-rule.sh"
+config="$(cd -- "$dir/../.." && pwd)/.oxlintrc.json"
+
+repo_root="$(cd -- "$dir/../.." && pwd)"
+probe="$repo_root/apps/web/src/__lint_probe__.tsx"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"; rm -f "$probe"' EXIT INT TERM
+
+fails=0
+
+# expect_reject <label> <mutated-config> <substring...>
+expect_reject() {
+  local label="$1" cfg="$2"
+  shift 2
+  local out rc needle
+  out="$(OXLINT_CONFIG="$cfg" bash "$gate" 2>&1)"
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL: $label expected a non-zero exit, got 0"
+    fails=1
+    return
+  fi
+  for needle in "$@"; do
+    if ! grep -qF -- "$needle" <<<"$out"; then
+      echo "FAIL: $label rejected, but not for '$needle' (rc=$rc)"
+      fails=1
+    fi
+  done
+}
+
+# Green on the committed config, and it must say so — a silent pass would be
+# indistinguishable from a gate that never ran.
+if out="$(bash "$gate" 2>&1)" && grep -qF 'no-dropped-lint-rule gate: OK' <<<"$out"; then
+  :
+else
+  echo "FAIL: gate did not pass cleanly on the committed config"
+  echo "$out"
+  fails=1
+fi
+
+# Only the two SILENT drift shapes are fixtured. A misspelled rule or an unknown
+# plugin prefix makes oxlint itself exit 1 before the gate can read the resolved
+# config, so a fixture for those would prove nothing about the gate's own logic.
+
+# Silent shape 1: the plugin is dropped from `plugins`. Setting that array
+# overwrites oxlint's defaults and `react` is not among them, so every react
+# rule leaves the resolved config with no diagnostic and exit 0.
+sed 's#"typescript", "import", "oxc", "react"#"typescript", "import", "oxc"#' \
+  "$config" > "$tmp/no-plugin.json"
+if grep -qF '"react"' "$tmp/no-plugin.json"; then
+  echo "FAIL: plugins-array fixture did not apply — the plugins line has changed shape"
+  fails=1
+else
+  expect_reject "react plugin dropped" "$tmp/no-plugin.json" \
+    "react/no-unstable-nested-components" "absent entirely"
+fi
+
+# Silent shape 2: severity downgraded to warn. The rule still runs, but lint.sh
+# invokes oxlint without --deny-warnings, so it can never fail the build.
+sed 's#"react/no-unstable-nested-components": "error"#"react/no-unstable-nested-components": "warn"#' \
+  "$config" > "$tmp/downgraded.json"
+if grep -qF '"react/no-unstable-nested-components": "error"' "$tmp/downgraded.json"; then
+  echo "FAIL: severity fixture did not apply — the rule entry has changed shape"
+  fails=1
+else
+  expect_reject "severity downgraded" "$tmp/downgraded.json" \
+    "react/no-unstable-nested-components" "different severity"
+fi
+
+# Positive control. The checks above prove the rule is present at the right
+# severity in the resolved config; they cannot prove it RUNS on the files it
+# protects. Adding `apps/web/**` to ignorePatterns, or an overrides entry
+# turning it off there, leaves the rules map untouched and the gate green while
+# the rule applies to nothing. Lint a real web file that trips it.
+cat > "$probe" <<'TSX'
+export function Outer() {
+  const Inner = () => <span />;
+  return <Inner />;
+}
+TSX
+out="$(bunx oxlint "$probe" 2>&1)" && rc=0 || rc=$?
+rm -f "$probe"
+if [ "$rc" -eq 0 ] || ! grep -qF 'no-unstable-nested-components' <<<"$out"; then
+  echo "FAIL: react/no-unstable-nested-components did not fire on a file under apps/web/src."
+  echo "      It is armed in the config but reaches no files — check ignorePatterns and overrides."
+  fails=1
+fi
+
+exit "$fails"

--- a/scripts/ci/no-dropped-lint-rule.selftest.sh
+++ b/scripts/ci/no-dropped-lint-rule.selftest.sh
@@ -14,10 +14,18 @@ gate="$dir/no-dropped-lint-rule.sh"
 config="$(cd -- "$dir/../.." && pwd)/.oxlintrc.json"
 
 repo_root="$(cd -- "$dir/../.." && pwd)"
-probe="$repo_root/apps/web/src/__lint_probe__.tsx"
 
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"; rm -f "$probe"' EXIT INT TERM
+
+# The probe has to live under apps/web/src — the positive control below proves
+# the rule REACHES files there — but the trap deletes whatever this names, so a
+# fixed path would destroy a same-named file that already existed and two runs
+# would race on it. mktemp -d owns a fresh directory instead. Trailing Xs only:
+# BSD mktemp leaves a template's Xs literal when a suffix follows them, handing
+# back exactly the fixed path this avoids.
+probe_dir="$(mktemp -d "$repo_root/apps/web/src/__lint_probe__.XXXXXX")"
+probe="$probe_dir/probe.tsx"
+trap 'rm -rf "$tmp" "$probe_dir"' EXIT INT TERM
 
 fails=0
 
@@ -92,7 +100,7 @@ export function Outer() {
 }
 TSX
 out="$(bunx oxlint "$probe" 2>&1)" && rc=0 || rc=$?
-rm -f "$probe"
+rm -rf "$probe_dir"
 if [ "$rc" -eq 0 ] || ! grep -qF 'no-unstable-nested-components' <<<"$out"; then
   echo "FAIL: react/no-unstable-nested-components did not fire on a file under apps/web/src."
   echo "      It is armed in the config but reaches no files — check ignorePatterns and overrides."

--- a/scripts/ci/no-dropped-lint-rule.sh
+++ b/scripts/ci/no-dropped-lint-rule.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Assert against the RESOLVED oxlint config that the rules carrying a repo
+# invariant are still armed.
+#
+# oxlint already hard-fails on a misspelled rule or an unknown plugin prefix, so
+# those need no gate. Two drift shapes are silent, and both exit 0:
+#
+#   1. A plugin removed from `plugins`. Setting that array overwrites oxlint's
+#      defaults, and `react` is not among them, so trimming the list makes every
+#      react rule vanish from the resolved config with no diagnostic.
+#   2. A severity downgraded to `warn`. The rule still runs, but `bunx oxlint`
+#      is invoked without `--deny-warnings`, so warnings never fail the build.
+#
+# Either one silently retires an invariant. Verified against oxlint 1.73.0 by
+# no-dropped-lint-rule.selftest.sh, which drives both shapes.
+
+set -euo pipefail
+# shellcheck source=_common.sh
+source "$(dirname "$0")/_common.sh"
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+# Seam so the self-test can point at a mutated copy instead of editing the
+# tracked config in place.
+config="${OXLINT_CONFIG:-$repo_root/.oxlintrc.json}"
+
+# Rules whose absence would remove a repo invariant rather than merely relax
+# style. Format: <rule name><TAB><expected severity in the resolved config>.
+required_rules=(
+  "react/no-unstable-nested-components	deny"
+  "import/no-cycle	deny"
+)
+
+if [[ ${#required_rules[@]} -eq 0 ]]; then
+  echo "ERROR: no rules asserted — this gate would pass vacuously." >&2
+  exit 1
+fi
+
+# Whitespace-stripped so both shapes appear verbatim as substrings: a bare
+# `"rule":"deny"` and a rule carrying options, `"rule":["deny",{...}]`.
+resolved="$(bunx oxlint --config "$config" --print-config | tr -d ' \n')"
+
+failed=0
+for entry in "${required_rules[@]}"; do
+  rule="${entry%%	*}"
+  want="${entry##*	}"
+  if printf '%s' "$resolved" | grep -qF "\"$rule\":\"$want\"" ||
+    printf '%s' "$resolved" | grep -qF "\"$rule\":[\"$want\""; then
+    continue
+  fi
+  echo "ERROR: oxlint rule '$rule' is not '$want' in the resolved config." >&2
+  if printf '%s' "$resolved" | grep -qF "\"$rule\":"; then
+    echo "  It resolved to a different severity. A 'warn' does not fail the build," >&2
+    echo "  because lint.sh runs oxlint without --deny-warnings." >&2
+  else
+    echo "  It is absent entirely — its plugin is missing from the 'plugins' array" >&2
+    echo "  in .oxlintrc.json, or oxlint renamed or removed the rule." >&2
+  fi
+  failed=1
+done
+
+[[ $failed -eq 0 ]] || exit 1
+echo "no-dropped-lint-rule gate: OK (${#required_rules[@]} rules armed)"

--- a/scripts/ci/no-phantom-alert-metric.selftest.sh
+++ b/scripts/ci/no-phantom-alert-metric.selftest.sh
@@ -40,7 +40,8 @@ expect_reject() {
 # here rejects legitimate rules and is what gets a gate switched off: synthesised
 # `up`, a histogram-derived `_count`, a `_bucket` off the one default histogram, a
 # declared gauge, a constructor name, a default process metric, a `by (…)` label
-# list, a compound `offset 1h30m`, a quoted scalar with a trailing YAML comment, a
+# list, a compound `offset 1h30m`, the non-decimal float literals, a quoted
+# scalar with a trailing YAML comment, a
 # `#` inside quotes that is content, a `__name__` equality matcher, the bare
 # binary operator `atan2`, a Go-template `- {{ … }}` bullet inside an annotation
 # block scalar, an entry whose first key is `expr:`, and a recording rule.

--- a/scripts/ci/no-phantom-alert-metric.selftest.sh
+++ b/scripts/ci/no-phantom-alert-metric.selftest.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Self-test for no-phantom-alert-metric.sh. Drives the real gate over the fixture
+# trees under __fixtures__/alert-metric/ via the GUARD_ROOT override.
+#
+# Every failing case asserts its OWN diagnostic, never a bare non-zero exit. The
+# gate has five vacuity floors and four hard parse errors that all exit 1, so a
+# moved fixture or a parser regression would trip one of them and a
+# non-zero-means-caught check would read that as a successful catch. Matching the
+# message is what makes each case prove the path it names.
+set -uo pipefail
+
+dir="$(cd -- "$(dirname -- "$0")" && pwd)"
+gate="$dir/no-phantom-alert-metric.sh"
+fixtures="$dir/__fixtures__/alert-metric"
+
+fails=0
+
+# expect_reject <fixture> <substring...>
+#   Runs the gate over the fixture and requires a non-zero exit whose output
+#   contains every substring given.
+expect_reject() {
+  local name="$1"; shift
+  local out rc needle
+  out="$(GUARD_ROOT="$fixtures/$name" bash "$gate" 2>&1)"
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL: $name fixture expected a non-zero exit, got 0"
+    fails=1
+    return
+  fi
+  for needle in "$@"; do
+    if ! grep -qF -- "$needle" <<<"$out"; then
+      echo "FAIL: $name fixture rejected, but not for '$needle' (rc=$rc)"
+      fails=1
+    fi
+  done
+}
+
+# The pass tree exercises every accepted syntax at once, because a false positive
+# here rejects legitimate rules and is what gets a gate switched off: synthesised
+# `up`, a histogram-derived `_count`, a `_bucket` off the one default histogram, a
+# declared gauge, a constructor name, a default process metric, a `by (…)` label
+# list, a compound `offset 1h30m`, a quoted scalar with a trailing YAML comment, a
+# `#` inside quotes that is content, a `__name__` equality matcher, the bare
+# binary operator `atan2`, a Go-template `- {{ … }}` bullet inside an annotation
+# block scalar, an entry whose first key is `expr:`, and a recording rule.
+expect_accept() {
+  local name="$1" out rc
+  out="$(GUARD_ROOT="$fixtures/$name" bash "$gate" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL: $name fixture expected exit 0, got $rc"
+    echo "$out"
+    fails=1
+  fi
+}
+
+expect_accept pass
+
+# A watchdog names no metric on purpose, so the per-expr floor needs an opt-out.
+# It is per-rule and has to be typed: the `vacuous` tree is the same shape without
+# the marker and is still rejected, which is what keeps silence failing.
+expect_accept watchdog
+
+# Six phantom shapes, each asserted by name. Together they pin the parts of
+# resolution easiest to regress into silence: exact-match allowlists (up_wrong),
+# kind-aware suffix derivation (decision_count_sum off a counter), reading
+# through YAML quoting and through a __name__ matcher, and a constructor scan
+# that stops at its own call instead of running on into unrelated literals.
+expect_reject fail \
+  tick_latnecy_ms_count \
+  up_wrong \
+  decision_count_sum \
+  phantom_behind_quotes \
+  phantom_behind_name_matcher \
+  not_a_metric_name \
+  nodejs_heap_space_size_used_bytes \
+  'sum (rule OperatorNamedMetric)'
+
+# One fixture per vacuity floor, so no floor is left as an unexercised branch.
+expect_reject vacuous 'names no metric'
+expect_reject empty-catalog 'zero metric names parsed'
+expect_reject no-ctor 'zero prom-client metric constructors'
+expect_reject no-rules 'zero alert rules parsed'
+expect_reject no-exprs 'zero expr values parsed'
+
+# Hard parse errors: shapes the gate refuses rather than guesses at.
+expect_reject union-drift 'union only: declared_in_union_only'
+expect_reject head-expr-skew 'rule entries with no expr key: MissingExpr'
+expect_reject name-regex '__name__=~'
+expect_reject flow-style 'flow-style rule entry'
+
+if [ "$fails" -ne 0 ]; then
+  echo "no-phantom-alert-metric self-test: RED"
+  exit 1
+fi
+
+echo "no-phantom-alert-metric self-test: OK"

--- a/scripts/ci/no-phantom-alert-metric.sh
+++ b/scripts/ci/no-phantom-alert-metric.sh
@@ -1,0 +1,463 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Phantom-alert-metric gate. Every metric name an alert rule's `expr:` reads must
+# be a name this repo actually emits, or a series Prometheus itself synthesises.
+#
+# `promtool check rules` validates PromQL SYNTAX, not series existence, so a rule
+# over a metric nothing emits parses clean and evaluates to an empty vector
+# forever. It never fires and never errors, which makes it indistinguishable from
+# a healthy rule that simply has not tripped. An operator who installs the shipped
+# rules believes they are covered against, say, a Binance weight ban and is not.
+#
+# The emitted set is assembled from two independent sources so no sink has to be
+# hardcoded here:
+#   1. The worker's closed catalogue (`MetricName` union + `CATALOG` keys). Both
+#      are parsed and diffed against each other: TypeScript already keeps them in
+#      step, so a divergence means this parser regressed, not that the code moved.
+#   2. Every `new Counter/Gauge/Histogram/Summary({ name: '...' })` under apps/**
+#      and packages/**. That picks up the api HTTP sink and the @app/observability
+#      process metrics by construction, so a future sink is covered the day it
+#      lands rather than the day someone remembers to edit a list here.
+# On top of that, two small exact-match sets cover series no repo code declares:
+# Prometheus' synthesised `up`, and the prom-client default process/nodejs
+# metrics. Both match exactly, never by prefix, so `up_wrong` is still reported.
+#
+# Tokenising is SUBTRACTIVE (strip strings, label matchers, range selectors,
+# grouping label lists, modifiers and numeric literals, then read what is left)
+# so a parse miss over-reports and fails the build rather than skipping a name.
+# Only `expr:` values are scanned; annotations legitimately carry
+# `{{ $labels.profileId }}` and prose.
+#
+# Two YAML shapes would otherwise let a phantom through silently, so both are
+# handled rather than skipped: a fully quoted `expr:` scalar (the quote strip
+# would eat the whole expression) and a `{__name__="x"}` matcher (the brace strip
+# would eat the name before it was read). A regex-valued `__name__` matcher
+# cannot be resolved to a concrete series at all, so it is a hard error.
+#
+# Vacuity floors fail the gate rather than pass it: zero catalogue names, zero
+# constructed names, zero rules, zero exprs, and any single expr that names no
+# metric. That last one is per-expr on purpose: a global count would let one
+# healthy rule mask a sibling whose expression was parsed to nothing. Plus a
+# count assert that every rule head yielded an expr, so a block-scalar miss fails
+# red instead of silently scanning nothing. A drift gate that passes vacuously is
+# worse than no gate.
+#
+# Runs in the bun:alpine CI image, whose BusyBox grep lacks -R / --include /
+# --exclude-dir, so the scan uses bun's fs, not a recursive grep.
+# shellcheck source=_common.sh
+source "$(dirname "$0")/_common.sh"
+ci::start no-phantom-alert-metric
+
+root="$(cd -- "$(dirname -- "$0")/../.." && pwd)"
+GUARD_ROOT="${GUARD_ROOT:-$root}"
+cd "$root"
+
+GUARD_ROOT="$GUARD_ROOT" bun -e '
+const fs = require("node:fs");
+const path = require("node:path");
+const root = process.env.GUARD_ROOT;
+
+const fail = (msg) => { console.error(msg); process.exit(1); };
+
+// ---------------------------------------------------------------------------
+// Emitted set, source 1: the worker catalogue.
+// ---------------------------------------------------------------------------
+const catalogPath = path.join(root, "apps/worker/src/metrics/catalog.ts");
+if (!fs.existsSync(catalogPath)) fail("apps/worker/src/metrics/catalog.ts not found — catalogue path regression in this gate.");
+const catalogSrc = fs.readFileSync(catalogPath, "utf8");
+
+// \x27 rather than a literal quote throughout: this whole program is a
+// single-quoted bash argument, so an apostrophe would end it.
+// Union members: everything quoted between `export type MetricName =` and its `;`.
+const unionStart = catalogSrc.indexOf("export type MetricName =");
+if (unionStart < 0) fail("no `export type MetricName =` in the catalogue — union parser regression in this gate.");
+const unionBody = catalogSrc.slice(unionStart, catalogSrc.indexOf(";", unionStart));
+const unionNames = new Set([...unionBody.matchAll(/\x27([A-Za-z_:][A-Za-z0-9_:]*)\x27/g)].map((m) => m[1]));
+
+// CATALOG entries: 2-space keys are entries, 4-space fields are the spec, so the
+// indent alone separates them without needing a brace-depth parser.
+const catalogKinds = new Map();
+{
+  const lines = catalogSrc.split(/\r?\n/);
+  let inside = false;
+  let key = null;
+  for (const line of lines) {
+    if (!inside) { inside = /^export const CATALOG\b/.test(line); continue; }
+    if (/^\};/.test(line)) break;
+    const entry = line.match(/^ {2}([A-Za-z_][A-Za-z0-9_]*):\s*\{/);
+    if (entry) { key = entry[1]; continue; }
+    const kind = line.match(/^ {4}kind:\s*\x27([a-z]+)\x27/);
+    if (kind && key) { catalogKinds.set(key, kind[1]); key = null; }
+  }
+}
+
+if (unionNames.size === 0 || catalogKinds.size === 0) {
+  fail("zero metric names parsed from the worker catalogue — catalogue parser regression in this gate.");
+}
+
+const onlyUnion = [...unionNames].filter((n) => !catalogKinds.has(n));
+const onlyCatalog = [...catalogKinds.keys()].filter((n) => !unionNames.has(n));
+if (onlyUnion.length > 0 || onlyCatalog.length > 0) {
+  fail(
+    "MetricName union and CATALOG keys disagree — parser regression in this gate (TypeScript already couples them):\n" +
+      [...onlyUnion.map((n) => "  union only: " + n), ...onlyCatalog.map((n) => "  CATALOG only: " + n)].join("\n"),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Emitted set, source 2: prom-client constructor call sites across the repo.
+// ---------------------------------------------------------------------------
+const SKIP_DIR = new Set(["node_modules", "dist", "__tests__"]);
+const tsFiles = (dir, out = []) => {
+  if (!fs.existsSync(dir)) return out;
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (!SKIP_DIR.has(e.name)) tsFiles(p, out);
+    } else if (/\.tsx?$/.test(e.name)) {
+      out.push(p);
+    }
+  }
+  return out;
+};
+const files = [...tsFiles(path.join(root, "apps")), ...tsFiles(path.join(root, "packages"))];
+
+const CTOR_KIND = { Counter: "counter", Gauge: "gauge", Histogram: "histogram", Summary: "summary" };
+const CTOR = /new\s+(?:[A-Za-z_$][A-Za-z0-9_$]*\.)?(Counter|Gauge|Histogram|Summary)\s*(?:<[^>]*>)?\s*\(\s*\{/g;
+const constructed = new Map();
+for (const file of files) {
+  const src = fs.readFileSync(file, "utf8");
+  for (const m of src.matchAll(CTOR)) {
+    // Bound the search at the closing `})` of this very call rather than at a
+    // character count. A fixed window can run past the call and adopt an
+    // unrelated `name:` literal as a declared metric, which is fail-OPEN: it
+    // would stop a real phantom being reported. A spread-built options object
+    // (no literal name) truncates to nothing and is skipped, which fails closed.
+    const rest = src.slice(m.index);
+    const close = rest.search(/\}\s*\)/);
+    if (close === -1) continue;
+    const named = rest.slice(0, close).match(/\bname:\s*[\x27"]([A-Za-z_:][A-Za-z0-9_:]*)[\x27"]/);
+    if (named) constructed.set(named[1], CTOR_KIND[m[1]]);
+  }
+}
+if (constructed.size === 0) {
+  fail("zero prom-client metric constructors found under apps/ or packages/ — scan-path regression in this gate.");
+}
+
+const declared = new Map([...catalogKinds, ...constructed]);
+
+// Series no repo code declares. Exact match only: a prefix rule would silently
+// bless `up_wrong` and every typo that happens to start with a real name.
+const PROM_SYNTHESISED = new Set([
+  "up", // Prometheus writes one per scrape target; the target never emits it
+]);
+
+// Registered by promClient.collectDefaultMetrics({ prefix: "" }) in
+// packages/observability. Enumerated rather than prefix-matched for the same reason.
+//
+// Taken from prom-client 15.1.3 lib/metrics/*.js, not from a scrape, and pruned
+// to what THIS runtime registers. lib/metrics/heapSpacesSizeAndUsed.js probes
+// v8.getHeapSpaceStatistics() and returns early on ERR_NOT_IMPLEMENTED (its own
+// comment says "Bun"), so nodejs_heap_space_size_{total,used,available}_bytes
+// never exist here; blessing them would let an alert on one pass and then
+// evaluate empty forever, which is the exact phantom this gate catches.
+// process_virtual_memory_bytes and process_heap_bytes are kept even though
+// lib/metrics/osMemoryHeap.js registers them only on linux: the deployment
+// target is a linux container, so they are real where the rules run.
+const DEFAULT_METRICS = new Set([
+  "process_cpu_user_seconds_total",
+  "process_cpu_system_seconds_total",
+  "process_cpu_seconds_total",
+  "process_start_time_seconds",
+  "process_resident_memory_bytes",
+  "process_virtual_memory_bytes", // linux only, see the note above
+  "process_heap_bytes",           // linux only, see the note above
+  "process_open_fds",
+  "process_max_fds",
+  "nodejs_eventloop_lag_seconds",
+  "nodejs_eventloop_lag_min_seconds",
+  "nodejs_eventloop_lag_max_seconds",
+  "nodejs_eventloop_lag_mean_seconds",
+  "nodejs_eventloop_lag_stddev_seconds",
+  "nodejs_eventloop_lag_p50_seconds",
+  "nodejs_eventloop_lag_p90_seconds",
+  "nodejs_eventloop_lag_p99_seconds",
+  "nodejs_active_resources",
+  "nodejs_active_resources_total",
+  "nodejs_active_handles",
+  "nodejs_active_handles_total",
+  "nodejs_active_requests",
+  "nodejs_active_requests_total",
+  "nodejs_heap_size_total_bytes",
+  "nodejs_heap_size_used_bytes",
+  "nodejs_external_memory_bytes",
+  "nodejs_version_info",
+  "nodejs_gc_duration_seconds",
+]);
+
+// The only default metric prom-client registers as a Histogram, so it is the only
+// one whose _bucket/_sum/_count are real series. Kept separate from the name set
+// above so no kind is claimed for a metric whose constructor was not checked.
+const DEFAULT_METRIC_KINDS = new Map([["nodejs_gc_duration_seconds", "histogram"]]);
+
+// ---------------------------------------------------------------------------
+// Referenced set: expr values in the shipped alert rules.
+// ---------------------------------------------------------------------------
+const alertsPath = path.join(root, "deploy/observability/alerts.yml");
+if (!fs.existsSync(alertsPath)) fail("deploy/observability/alerts.yml not found — rules path regression in this gate.");
+const alertLines = fs.readFileSync(alertsPath, "utf8").split(/\r?\n/);
+
+// A flow-style rule entry matches no block-style key pattern while still being a
+// rule, so it would be skipped in silence with the counts still balanced. Reject
+// the shape. The match requires a rule KEY inside the braces: a bare `- {` also
+// begins an ordinary Go-template bullet (`- {{ $labels.profileId }}`) inside an
+// annotation, which is legitimate and must not be mistaken for a rule.
+const flow = alertLines.findIndex(
+  (l) => /^\s*-\s*\{\s*(?:alert|record|expr)\s*:/.test(l) || /^\s*rules:\s*\[\s*\{/.test(l),
+);
+if (flow >= 0) {
+  fail(
+    "flow-style rule entry at deploy/observability/alerts.yml:" + (flow + 1) +
+      " — this gate parses block style only. Write the rule as indented `- alert:` / `expr:` keys.",
+  );
+}
+
+// A plain YAML scalar ends at an unquoted " #"; a quoted or block scalar does not.
+const stripPlainComment = (s) => s.replace(/\s+#.*$/, "").trim();
+
+// Index of the quote that closes a quoted scalar, honouring the escape each YAML
+// style uses: doubling in single-quoted, backslash in double-quoted. Walking to
+// it (rather than assuming the last character of the line) is what lets a
+// trailing YAML comment follow a quoted expr, while a `#` inside the quotes
+// stays part of the expression.
+const closingQuote = (s, q) => {
+  for (let i = 1; i < s.length; i++) {
+    if (s[i] !== q) continue;
+    if (q === "\x27") {
+      if (s[i + 1] === q) { i++; continue; }
+      return i;
+    }
+    let backslashes = 0;
+    for (let k = i - 1; k >= 0 && s[k] === "\\"; k--) backslashes++;
+    if (backslashes % 2 === 0) return i;
+  }
+  return -1;
+};
+
+// A quoted `expr:` scalar would be erased whole by the quote strip in the
+// tokeniser, contributing no candidates. Unwrap it here so the PromQL inside is
+// tokenised like any other expression.
+const unwrapScalar = (s, lineNo) => {
+  const q = s[0];
+  // \x22 is a double quote: only an apostrophe would end the bash argument, but
+  // both quote characters are escaped here so the two branches read alike.
+  if (q !== "\x27" && q !== "\x22") return stripPlainComment(s);
+  const close = closingQuote(s, q);
+  if (close === -1) {
+    fail(
+      "unterminated quoted expr scalar at deploy/observability/alerts.yml:" + lineNo +
+        " — this gate reads single-line quoted or block scalars only.",
+    );
+  }
+  const tail = s.slice(close + 1).trim();
+  if (tail !== "" && !tail.startsWith("#")) {
+    fail(
+      "unexpected content after the closing quote of the expr scalar at deploy/observability/alerts.yml:" +
+        lineNo + " — only a trailing YAML comment may follow it.",
+    );
+  }
+  const inner = s.slice(1, close);
+  return q === "\x27" ? inner.replace(/\x27\x27/g, "\x27") : inner.replace(/\\(.)/g, "$1");
+};
+
+// Rules are read as ENTRIES rather than as a stream of keys. An entry begins at
+// the dash that introduces it, whichever of its keys comes first, so `expr:`
+// leading a rule is parsed like any other ordering instead of going uncounted.
+// Sibling keys are then matched at exactly the entry key column, which keeps a
+// block-scalar annotation containing `expr:` or `alert:` from being read as one.
+const ENTRY_START = /^(\s*)-\s*(?:alert|record|expr)\s*:/;
+const entries = [];
+for (let i = 0; i < alertLines.length; i++) {
+  const start = ENTRY_START.exec(alertLines[i]);
+  if (!start) continue;
+  const dashCol = start[1].length;
+  let j = i + 1;
+  for (; j < alertLines.length; j++) {
+    if (alertLines[j].trim() === "") continue;
+    if (alertLines[j].match(/^\s*/)[0].length <= dashCol) break;
+  }
+  entries.push({ first: i, lines: alertLines.slice(i, j) });
+  i = j - 1;
+}
+
+if (entries.length === 0) fail("zero alert rules parsed from deploy/observability/alerts.yml — rules parser regression in this gate.");
+
+const exprs = [];
+const missingExpr = [];
+for (const entry of entries) {
+  // Blank the dash so the first key sits at the same column as its siblings.
+  const lines = entry.lines.slice();
+  lines[0] = lines[0].replace(/^(\s*)-/, "$1 ");
+  const keyCol = lines[0].match(/^\s*/)[0].length;
+  const keyAt = new RegExp("^\\s{" + keyCol + "}(alert|record|expr):\\s*(.*)$");
+
+  let rule = "(unnamed)";
+  let expr = null;
+  let exprLine = -1;
+  for (let k = 0; k < lines.length; k++) {
+    const key = keyAt.exec(lines[k]);
+    if (key === null) continue;
+    if (key[1] !== "expr") {
+      if (rule === "(unnamed)") rule = key[2].trim();
+      continue;
+    }
+    if (expr !== null) continue;
+    exprLine = entry.first + k;
+    const inline = key[2].trim();
+    if (!/^[|>]/.test(inline)) { expr = unwrapScalar(inline, exprLine + 1); continue; }
+    // Block scalar: the value is every following line indented past the key column.
+    const buf = [];
+    for (let b = k + 1; b < lines.length; b++) {
+      if (lines[b].trim() === "") continue;
+      if (lines[b].match(/^\s*/)[0].length <= keyCol) break;
+      buf.push(lines[b].trim());
+    }
+    expr = buf.join(" ");
+  }
+
+  if (expr === null) { missingExpr.push(rule); continue; }
+  exprs.push({ rule, expr, exprLine });
+}
+
+if (exprs.length === 0) fail("zero expr values parsed from deploy/observability/alerts.yml — expr parser regression in this gate.");
+if (missingExpr.length > 0) {
+  fail(
+    "rule entries with no expr key: " + missingExpr.join(", ") +
+      " — every rule carries one, so this is an expr parser regression in this gate.",
+  );
+}
+
+// Only keywords that can actually reach the identifier pass as BARE tokens.
+//
+// Aggregation operators (sum, max, topk, quantile, limitk, …) are deliberately
+// absent. Every legal spelling puts them in front of a `(` — `sum(x)`,
+// `sum by (job) (x)`, `sum(x) by (job)` — and the grouping strip below leaves
+// that `(` in place, so the call-applied rule already drops them. Listing them
+// anyway would mean a real metric that happened to be named `count` or `group`
+// was silently blessed, which is fail-open in a file whose whole design is
+// fail-closed. `start` and `end` are absent for the same reason: they are legal
+// only as `@ start()` / `@ end()`.
+//
+// `atan2` is here because, unlike the other operators spelled as words, it is a
+// BINARY operator written between its operands, so it does appear bare.
+// The six vector-matching keywords are belt-and-braces behind the grouping
+// strip: each is also legal without a label list (`group_left` alone).
+const PROMQL_KEYWORDS = new Set([
+  "and", "or", "unless", "bool", "offset", "atan2",
+  "by", "without", "on", "ignoring", "group_left", "group_right",
+  "Inf", "NaN",
+]);
+
+// A rule may legitimately name no metric: a dead-man switch watchdog is
+// `expr: vector(1)` by construction. Opting one out is explicit and per-rule, so
+// silence still fails; the author writes the marker on the line above `expr:`.
+const OPT_OUT = /^\s*#\s*names-no-metric:\s*\S/;
+
+// `{__name__="x"}` selects metric x exactly as a bare `x` does, so the name has
+// to be read before the brace strip removes it.
+const NAME_MATCHER = /__name__\s*(=~|!~|!=|=)\s*("(?:[^"\\]|\\.)*"|\x27[^\x27]*\x27)/g;
+
+const candidates = [];
+for (const { rule, expr, exprLine } of exprs) {
+  const found = [];
+
+  for (const m of expr.matchAll(NAME_MATCHER)) {
+    if (m[1] !== "=") {
+      fail(
+        "rule " + rule + " selects a metric with `__name__" + m[1] + "` — this gate cannot resolve a regex or negated " +
+          "name matcher to a concrete series. Name the metric directly in the expression.",
+      );
+    }
+    found.push(m[2].slice(1, -1));
+  }
+
+  const stripped = expr
+    .replace(/\x27[^\x27]*\x27|"(?:[^"\\]|\\.)*"|`[^`]*`/g, " ") // quoted label values
+    .replace(/\{[^}]*\}/g, " ") // label matchers
+    .replace(/\[[^\]]*\]/g, " ") // range and subquery selectors
+    // Grouping and vector-matching label lists sit in round brackets, which are
+    // never stripped, so their labels would otherwise read as metric names.
+    .replace(/\b(?:by|without|on|ignoring|group_left|group_right)\s*\([^)]*\)/g, " ")
+    // Offset modifier and its duration. The unit group repeats because PromQL
+    // durations compound (`1h30m`), and a leftover `30m` survives the numeric
+    // strip as a bare `m`. `ms` leads the alternation so it is not read as `m`
+    // plus a stray `s`. No fractional part: PromQL does not allow one.
+    .replace(/\boffset\s+-?(?:\d+(?:ms|[smhdwy]))+/g, " ")
+    .replace(/@\s*-?\d+(?:\.\d+)?/g, " ") // @ timestamp modifier
+    // Word-boundary anchored so a digit inside an identifier survives and the
+    // name is still reported: binance_weight_used_1m keeps its _1m.
+    .replace(/\b\d+(?:\.\d+)?\b/g, " ");
+
+  for (const m of stripped.matchAll(/[a-zA-Z_:][a-zA-Z0-9_:]*\s*\(?/g)) {
+    // A metric name is never call-applied, so a trailing `(` marks a function.
+    // That kills rate/increase/histogram_quantile with no list to maintain.
+    if (m[0].endsWith("(")) continue;
+    const name = m[0].trim();
+    if (PROMQL_KEYWORDS.has(name)) continue;
+    found.push(name);
+  }
+
+  // Per-expr, not global: a global count lets one healthy rule mask a sibling
+  // whose expression was parsed down to nothing, which is the exact silent pass
+  // this gate exists to stop. A watchdog opts out by saying so above its expr.
+  if (found.length === 0 && !OPT_OUT.test(alertLines[exprLine - 1] ?? "")) {
+    fail(
+      "expr for rule " + rule + " names no metric — expr tokeniser regression in this gate, or a rule that " +
+        "watches nothing and can never fire. A rule that names none on purpose (a vector(1) watchdog) " +
+        "declares it with a `# names-no-metric: <reason>` comment on the line above its expr.",
+    );
+  }
+  for (const name of found) candidates.push({ rule, name });
+}
+
+// ---------------------------------------------------------------------------
+// Resolution.
+// ---------------------------------------------------------------------------
+// Prometheus derives these from the parent metric, and only for these kinds: a
+// counter or gauge named `foo` gives no `foo_sum`, so a typo like `decision_count`
+// -> `decision_count_sum` must still be reported.
+const DERIVED_SUFFIXES = { histogram: new Set(["count", "sum", "bucket"]), summary: new Set(["count", "sum"]) };
+const kindOf = (name) => declared.get(name) ?? DEFAULT_METRIC_KINDS.get(name);
+
+const isEmitted = (name) => {
+  if (declared.has(name) || PROM_SYNTHESISED.has(name) || DEFAULT_METRICS.has(name)) return true;
+  const derived = name.match(/^(.+)_(count|sum|bucket)$/);
+  if (derived === null) return false;
+  const suffixes = DERIVED_SUFFIXES[kindOf(derived[1])];
+  return suffixes !== undefined && suffixes.has(derived[2]);
+};
+
+const seen = new Set();
+const phantoms = [];
+for (const { rule, name } of candidates) {
+  if (isEmitted(name)) continue;
+  const dedupe = rule + " " + name;
+  if (seen.has(dedupe)) continue;
+  seen.add(dedupe);
+  phantoms.push("  " + name + " (rule " + rule + ")");
+}
+
+if (phantoms.length > 0) {
+  console.error("Alert rules reference metric names nothing emits:");
+  console.error(phantoms.join("\n"));
+  console.error("");
+  console.error("For each: emit the metric (catalogue entry or prom-client constructor), correct the");
+  console.error("name to one that is emitted, or delete the rule. A rule over a series nothing writes");
+  console.error("evaluates empty forever, so it can never fire and never errors.");
+  process.exit(1);
+}
+
+console.log(
+  "no-phantom-alert-metric gate: OK (" + declared.size + " declared, " + candidates.length + " referenced)",
+);
+'

--- a/scripts/ci/no-phantom-alert-metric.sh
+++ b/scripts/ci/no-phantom-alert-metric.sh
@@ -394,9 +394,16 @@ for (const { rule, expr, exprLine } of exprs) {
     // plus a stray `s`. No fractional part: PromQL does not allow one.
     .replace(/\boffset\s+-?(?:\d+(?:ms|[smhdwy]))+/g, " ")
     .replace(/@\s*-?\d+(?:\.\d+)?/g, " ") // @ timestamp modifier
+    // Every float-literal form the PromQL grammar accepts: decimal with an
+    // optional exponent, hex, and `_` digit separators. A form the strip misses
+    // does not survive as a number, it survives as an identifier — `1e6` reaches
+    // the scan below as `e6` and `0x1f` as `x1f` — so the gate rejects a
+    // legitimate rule, which is how a gate gets switched off. Hex leads: the
+    // decimal branch would take the `0` and leave `x1f` behind.
     // Word-boundary anchored so a digit inside an identifier survives and the
     // name is still reported: binance_weight_used_1m keeps its _1m.
-    .replace(/\b\d+(?:\.\d+)?\b/g, " ");
+    .replace(/\b0[xX]_?[0-9a-fA-F][0-9a-fA-F_]*\b/g, " ")
+    .replace(/\b\d[\d_]*(?:\.[\d_]+)?(?:[eE][-+]?\d+)?\b/g, " ");
 
   for (const m of stripped.matchAll(/[a-zA-Z_:][a-zA-Z0-9_:]*\s*\(?/g)) {
     // A metric name is never call-applied, so a trailing `(` marks a function.


### PR DESCRIPTION
## Why

Two independent defect classes, both invisible to a green build.

**1. The app read as frozen on a phone.** The shell owns the only scroll surface (`h-svh … overflow-hidden`) and the document never scrolls, so any loading branch with no height leaves nothing under the thumb to drag. With `overscroll-behavior: none` suppressing even the rubber-band, iOS shows a page that does not respond to touch at all — measured at 9–16 s per route on a slow link, including the whole pre-React window before the router's root `beforeLoad` resolved.

**2. A polling page dragged the reader off their spot.** `MarketTrendCard` declared its wrapper component *inside* its own render body, so the wrapper got a fresh identity every render and React tore the card down and rebuilt it rather than updating it. A `setInterval` countdown fired that once a second. While the subtree was detached the scroller was 298 px shorter, the browser clamped `scrollTop`, and re-inserting the content restored the height but never the position. Measured in Safari at 375×667: 24 jumps over a 12 s watch (twice per tick — StrictMode). `useScrollAnchor` repaired it a frame later on Blink and desktop WebKit, which is why it survived review.

**3. Alert rules named metrics nothing emits.** `promtool check rules` validates PromQL *syntax*, not series existence, so a rule over a phantom metric parses clean and evaluates to an empty vector forever. It never fires and never errors — indistinguishable from a healthy rule that has not tripped. An operator who installed the shipped rules believed they were covered against, say, a Binance weight ban and was not.

## What changed

### Loading states carry height

- New `@/shared/components/page-skeleton` (`PageSkeleton`, `PanelStackSkeleton`, `TableSkeleton`, `LoadingRows`) over a decorative `Skeleton` bar; one `role="status"` per surface, bars are `aria-hidden`, pulse drops under `prefers-reduced-motion`.
- Every bare `Loading…` / spinner across account, profile, symbol, dashboard and notifications panels replaced with a placeholder that mirrors the loaded layout.
- `index.html` ships an inline-styled boot placeholder inside `#root`, painted from first paint until React's first commit, taller than a phone viewport. Literal colours, not tokens: the token stylesheet is not applied yet at that moment.
- `RoutePending` moved from a `fixed inset-0` overlay to an in-flow scroller. The overlay was covering the top bar, ticker, health bar and nav for the length of every slow load; React already hides the outgoing route inside the shared Suspense boundary, so nothing needed covering.
- New `--skeleton` token (dark + light) in `app.css`, documented in `DESIGN.md`.

### Polling pages hold the reader still

- `MarketTrendCard`'s `Shell` hoisted to module scope.
- `useScrollAnchor` now corrects only while the reader's own scrolling is idle, measured against *gestures* (touch/wheel/scroll-keys plus an unbroken scroll run for iOS momentum), never against scroll events — a shrink-clamp emits one itself, and standing down for it would disable the shim for its primary case and bake the drift in. Self-writes are ignored; a lost `touchend` degrades after 10 s rather than wedging the shim.
- `lightweight-charts` canvases (`equity-area-chart`, `symbol-candle-chart`) opt out of `handleScroll`/`handleScale` wheel and vertical-touch capture so they stop swallowing the page scroll.

### Regression gates

- oxlint: `react` plugin enabled for `react/no-unstable-nested-components` (`react/exhaustive-deps` explicitly `off` pending triage of pre-existing violations).
- `scripts/ci/no-dropped-lint-rule.sh` asserts against `oxlint --print-config` — the *resolved* config — that invariant-carrying rules are still armed at the right severity. Covers the two silent drift shapes: a plugin dropped from `plugins`, and a severity downgraded to `warn` (oxlint runs without `--deny-warnings`).
- `e2e/tests/scroll-stability.spec.ts` parks each route's anchored scroller at the bottom, **blocks the shim's corrections**, and asserts zero drift, zero subtree teardowns and zero attempted corrections while the page polls. Needs a running stack; CI runs only the no-stack smoke subset, so it does not gate merges today.
- Unit tests for the skeletons, the scroll-anchor gesture logic, the CSS token, the route-pending screen and the market-trend card.

### Observability

- `alerts.yml` rewritten so every `expr:` names a series this repo actually emits; uncovered failure modes are now listed explicitly at the bottom of the file instead of being implied by dead rules.
- `scripts/ci/no-phantom-alert-metric.sh` fails the build on a rule naming a metric nothing writes. The emitted set is assembled from the worker's `MetricName` union and `CATALOG` keys (cross-checked against each other) plus every prom-client `new Counter/Gauge/…({ name })` under `apps/**` and `packages/**`, so a future sink is covered the day it lands.
- Both gates ship self-tests over fixture trees, run *before* the gate itself in `lint.sh`: on a run where both fail, the self-test says whether the input drifted or the parser regressed.
- `docs/operations/deploy.md` documents the scrape config the rules assume (`up{job="worker"}` is Prometheus-synthesised and inert unless the operator names the job `worker`) and what the gate does *not* check: label typos, thresholds and `for:` windows.

## Limitations

- A scrollbar-thumb drag emits no touch/wheel/key event, so a reflow during one is still corrected. Desktop-only, where a write nudges rather than cancels a fling — accepted over listening for `pointerdown`, which fires on every tap.
- `useScrollAnchor` exists only because no stable Safari release ships `overflow-anchor` and no iOS Safari release supports it ([caniuse](https://caniuse.com/css-overflow-anchor), checked 2026-08). Delete the hook once it lands on iOS.
- A reflow arriving mid-flick goes uncorrected by design.

## Verification

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [ ] `bash scripts/ci/no-phantom-alert-metric.selftest.sh` / `no-dropped-lint-rule.selftest.sh`
- [ ] Safari 375×667: dashboard, symbol, profile — scrollable from first paint, no jump across three poll cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177gTJsB3GbUNij17A3gAg9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured loading skeletons across dashboards, profiles, account settings, notifications, and symbol views.
  * Added an instant, themed loading placeholder during initial application startup.
  * Added reduced-motion and accessibility support for loading states.
* **Bug Fixes**
  * Improved pending-route layouts, chart scrolling, and scroll anchoring during interactions and polling.
* **Documentation**
  * Added guidance for consistent loading states, polling pages, and scroll behavior.
* **Chores**
  * Strengthened validation for alert configurations and linting rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->