### PR TITLE
feat(strategy): add the price-outside-exchange-band protective-stop blocker

### DIFF
--- a/apps/web/__tests__/symbol-protective-stop-blocker.test.tsx
+++ b/apps/web/__tests__/symbol-protective-stop-blocker.test.tsx
@@ -26,6 +26,25 @@ describe('<SymbolProtectiveStopBlocker>', () => {
     expect(panel).toHaveTextContent(/189\.87/);
     expect(panel).toHaveTextContent(/cancel that order on Binance/i);
   });
+
+  it('softens the alert when a stop is resting but stuck at an older level', () => {
+    // Danger red is reserved for a position with nothing standing behind it. A
+    // stop that merely cannot move up yet is a warning, or the red stops meaning
+    // anything.
+    render(
+      <SymbolProtectiveStopBlocker
+        protectiveStopBlocker={{
+          reason: 'price-outside-exchange-band',
+          detail: { price: '7.312', floor: '7.9488', avgPriceMins: 5, guarded: true },
+        }}
+      />,
+    );
+    const panel = screen.getByTestId('symbol-protective-stop-blocker');
+    expect(panel).toHaveTextContent(/stuck at an older level/i);
+    expect(panel).not.toHaveTextContent(/not in place/i);
+    expect(panel.className).toMatch(/warning/);
+    expect(panel.className).not.toMatch(/danger/);
+  });
 });
 
 describe('glossProtectiveStopBlocker', () => {
@@ -33,6 +52,101 @@ describe('glossProtectiveStopBlocker', () => {
     const line = glossProtectiveStopBlocker({ reason: 'base-locked-by-foreign-order' });
     expect(line).toMatch(/locked by another sell order/i);
     expect(line).not.toMatch(/undefined/);
+  });
+
+  it('tells the operator to sit tight when the price band will move back on its own', () => {
+    const line = glossProtectiveStopBlocker({
+      reason: 'price-outside-exchange-band',
+      detail: { price: '7.312', floor: '7.9488', avgPriceMins: 5, terminal: false },
+    });
+    expect(line).toMatch(/automatic sell that caps a loss/i);
+    expect(line).toMatch(/last 5 minutes/);
+    expect(line).toMatch(/7\.9488/);
+    expect(line).toMatch(/nothing for you to do/i);
+    // The opposite advice would be actively wrong here: no setting is at fault.
+    expect(line).not.toMatch(/limitOffsetPercentage/);
+  });
+
+  it('names the setting to change when no market move can ever arm the stop', () => {
+    const line = glossProtectiveStopBlocker({
+      reason: 'price-outside-exchange-band',
+      detail: {
+        price: '6.715',
+        floor: '7.9488',
+        avgPriceMins: 5,
+        askMultiplierDown: '0.9',
+        terminal: true,
+      },
+    });
+    expect(line).toMatch(/limitOffsetPercentage/);
+    expect(line).toMatch(/0\.9/);
+    expect(line).toMatch(/waiting will not fix it/i);
+    // Raising the offset restores the possibility of arming, not the arming
+    // itself: the stop still needs the market back near its trigger. Promising
+    // the next check invites the operator to raise it again when nothing happens.
+    expect(line).not.toMatch(/arms itself on the next check/i);
+  });
+
+  it('says the last trade price, not a 0-minute average, when avgPriceMins is 0', () => {
+    const line = glossProtectiveStopBlocker({
+      reason: 'price-outside-exchange-band',
+      detail: { avgPriceMins: 0, terminal: false },
+    });
+    expect(line).toMatch(/last trade/i);
+    expect(line).not.toMatch(/0 minutes/);
+    expect(line).not.toMatch(/undefined/);
+  });
+
+  it('drops the no-safety-net line when a stop is still resting on Binance', () => {
+    // The refusal only stopped the stop from MOVING. Telling the operator the
+    // position is naked would be false, and false alarms are how the real one
+    // gets ignored.
+    const stale = glossProtectiveStopBlocker({
+      reason: 'price-outside-exchange-band',
+      detail: { price: '7.312', floor: '7.9488', avgPriceMins: 5, guarded: true },
+    });
+    expect(stale).toMatch(/still resting on Binance/i);
+    expect(stale).not.toMatch(/no safety net/i);
+    // Absent flag is unknown coverage, and unknown reads as uncovered — the
+    // louder default. Over-warning costs a glance, under-warning the position.
+    const naked = glossProtectiveStopBlocker({
+      reason: 'price-outside-exchange-band',
+      detail: { price: '7.312', floor: '7.9488', avgPriceMins: 5 },
+    });
+    expect(naked).toMatch(/no safety net/i);
+  });
+
+  it('quotes the ceiling, not the floor, when the stop sits above the band', () => {
+    // Printing "lowest allowed sell of 6" at an operator whose stop is priced at
+    // 7.312 is a self-contradicting sentence, and the number to act on is the one
+    // that was actually breached.
+    const line = glossProtectiveStopBlocker({
+      reason: 'price-outside-exchange-band',
+      detail: { price: '7.312', floor: '2.7', ceiling: '6', bound: 'ceiling', avgPriceMins: 5 },
+    });
+    expect(line).toMatch(/highest allowed sell of 6/i);
+    expect(line).not.toMatch(/2\.7/);
+  });
+
+  it('does not present the estimated floor as the exact rejection point', () => {
+    // The bot bands against the current price, not the window Binance averages
+    // over, so an operator comparing the two must not be told they are the same.
+    const line = glossProtectiveStopBlocker({
+      reason: 'price-outside-exchange-band',
+      detail: { price: '7.312', floor: '7.9488', avgPriceMins: 5 },
+    });
+    expect(line).toMatch(/estimate/i);
+  });
+
+  it('names no averaging window at all when avgPriceMins is missing', () => {
+    // A legacy cache entry carries the band without the window; the sentence must
+    // still read as English rather than leaking `null`.
+    const line = glossProtectiveStopBlocker({
+      reason: 'price-outside-exchange-band',
+      detail: { price: '7.312' },
+    });
+    expect(line).toMatch(/works it out itself|works out itself/i);
+    expect(line).not.toMatch(/null|undefined|NaN/);
   });
 
   it('never renders blank for a reason code it does not know', () => {

--- a/apps/web/__tests__/symbol-table.test.tsx
+++ b/apps/web/__tests__/symbol-table.test.tsx
@@ -397,7 +397,7 @@ describe('<SymbolTable>', () => {
     );
     const status = await screen.findByTestId('symbol-status-pa-LINKUSDT');
     expect(status).toHaveAttribute('data-status', 'stop-stale');
-    expect(status).toHaveTextContent('Stop stale');
+    expect(status).toHaveTextContent('Old stop');
     expect(status.getAttribute('title')).toMatch(/still resting on Binance/i);
   });
 });

--- a/apps/web/__tests__/symbol-table.test.tsx
+++ b/apps/web/__tests__/symbol-table.test.tsx
@@ -374,4 +374,30 @@ describe('<SymbolTable>', () => {
     // The gloss folds in the shortfall so the operator sees WHY it is unfundable.
     expect(status.getAttribute('title')).toContain('189.87');
   });
+
+  // The same blocker field, a materially smaller emergency: an earlier stop is
+  // still resting, the strategy just could not move it up. NO STOP here would be
+  // a false alarm on a position that is in fact guarded.
+  it('a stop stuck behind the exchange band reads STOP STALE, not NO STOP', async () => {
+    renderTable([row('pa', 'alpha')], () =>
+      json(
+        dashboard([
+          sym({
+            symbol: 'LINKUSDT',
+            avgEntryPrice: '8.416',
+            quantity: '3.13',
+            currentPrice: '8.832',
+            protectiveStopBlocker: {
+              reason: 'price-outside-exchange-band',
+              detail: { price: '7.312', floor: '7.9488', avgPriceMins: 5, guarded: true },
+            },
+          }),
+        ]),
+      ),
+    );
+    const status = await screen.findByTestId('symbol-status-pa-LINKUSDT');
+    expect(status).toHaveAttribute('data-status', 'stop-stale');
+    expect(status).toHaveTextContent('Stop stale');
+    expect(status.getAttribute('title')).toMatch(/still resting on Binance/i);
+  });
 });

--- a/apps/web/src/features/dashboard/components/symbol-table.tsx
+++ b/apps/web/src/features/dashboard/components/symbol-table.tsx
@@ -21,7 +21,10 @@ import { useActiveAccountId } from '@/shared/lib/account-scope';
 import { isHeldPosition, unrealisedPnlOf } from '@/features/profile/lib/unrealised-pnl';
 import { deriveQuote } from '@/shared/lib/symbol-quote';
 import { formatAmount, formatPrice } from '@/shared/lib/format';
-import { glossProtectiveStopBlocker } from '@/shared/lib/gloss-protective-stop-blocker';
+import {
+  blockerPositionGuarded,
+  glossProtectiveStopBlocker,
+} from '@/shared/lib/gloss-protective-stop-blocker';
 import { glossEntryBlocker } from '@/shared/lib/gloss-entry-blocker';
 import { PnlValue } from '@/shared/components/pnl-value';
 import { LoadingRows } from '@/shared/components/page-skeleton';
@@ -160,8 +163,9 @@ function GridHeader() {
   );
 }
 
-/** The trading status of a symbol, in priority order: unprotected > held > paused > blocked > watching. */
-type SymbolStatusKind = 'unprotected' | 'holding' | 'paused' | 'blocked' | 'watching';
+/** The trading status of a symbol, in priority order: unprotected / stop-stale > held > paused > blocked > watching. */
+type SymbolStatusKind =
+  'unprotected' | 'stop-stale' | 'holding' | 'paused' | 'blocked' | 'watching';
 
 export interface SymbolStatus {
   readonly kind: SymbolStatusKind;
@@ -175,24 +179,28 @@ export interface SymbolStatus {
    * variant), BLOCKED to `warning` (amber tint matching the trade-archive
    * panel's status badges), PAUSED to `secondary`, WATCHING to `outline`, and
    * UNPROTECTED to `danger` — it is the only status that says money is at risk.
+   * A stop resting at a stale level reads `warning`, not `danger`: protection
+   * exists, it is just behind the trail.
    */
   readonly variant: 'up' | 'secondary' | 'warning' | 'outline' | 'danger';
 }
 
 /**
  * Derive a symbol's at-a-glance status. An open position whose protective stop
- * could not be placed outranks everything — it is unguarded right now. Otherwise
+ * could not be placed outranks everything — it is unguarded right now, unless an
+ * earlier stop of ours still covers it, which downgrades it to stale. Otherwise
  * held positions read HOLDING regardless of enabled state (the operator's money
  * is in it); a paused symbol that holds nothing reads PAUSED; a flat enabled
  * symbol with a blocker shows the blocker (amber), otherwise it is WATCHING.
  */
 export function deriveStatus(sym: ProfileDashboardSymbol): SymbolStatus {
   if (sym.protectiveStopBlocker) {
+    const stale = blockerPositionGuarded(sym.protectiveStopBlocker);
     return {
-      kind: 'unprotected',
-      label: t('grid.status.unprotected'),
+      kind: stale ? 'stop-stale' : 'unprotected',
+      label: stale ? t('grid.status.stopStale') : t('grid.status.unprotected'),
       title: glossProtectiveStopBlocker(sym.protectiveStopBlocker),
-      variant: 'danger',
+      variant: stale ? 'warning' : 'danger',
     };
   }
   if (isHeldPosition(sym)) {

--- a/apps/web/src/features/symbol/components/symbol-protective-stop-blocker.tsx
+++ b/apps/web/src/features/symbol/components/symbol-protective-stop-blocker.tsx
@@ -6,7 +6,10 @@
 import type { SymbolStateResponse } from '@app/contracts';
 
 import { Alert, AlertDescription, AlertTitle } from '@/shared/components/ui/alert';
-import { glossProtectiveStopBlocker } from '@/shared/lib/gloss-protective-stop-blocker';
+import {
+  blockerPositionGuarded,
+  glossProtectiveStopBlocker,
+} from '@/shared/lib/gloss-protective-stop-blocker';
 
 export function SymbolProtectiveStopBlocker({
   protectiveStopBlocker,
@@ -14,9 +17,14 @@ export function SymbolProtectiveStopBlocker({
   readonly protectiveStopBlocker: SymbolStateResponse['protectiveStopBlocker'];
 }): React.JSX.Element | null {
   if (!protectiveStopBlocker) return null;
+  // A stop that is still resting at a stale level is a smaller emergency than no
+  // stop at all, and red on both trains the operator to skim past the real one.
+  const stale = blockerPositionGuarded(protectiveStopBlocker);
   return (
-    <Alert variant="danger" data-testid="symbol-protective-stop-blocker">
-      <AlertTitle>Protective stop not in place</AlertTitle>
+    <Alert variant={stale ? 'warning' : 'danger'} data-testid="symbol-protective-stop-blocker">
+      <AlertTitle>
+        {stale ? 'Protective stop stuck at an older level' : 'Protective stop not in place'}
+      </AlertTitle>
       <AlertDescription>{glossProtectiveStopBlocker(protectiveStopBlocker)}</AlertDescription>
     </Alert>
   );

--- a/apps/web/src/shared/lib/gloss-protective-stop-blocker.ts
+++ b/apps/web/src/shared/lib/gloss-protective-stop-blocker.ts
@@ -15,6 +15,31 @@ function str(detail: ProtectiveStopBlocker['detail'], key: string): string | nul
   return typeof v === 'string' ? v : typeof v === 'number' ? String(v) : null;
 }
 
+/**
+ * How Binance derives the price it bands orders against. A window of 0 means it
+ * compares against the last trade rather than an average, so the clause changes
+ * shape and not just its number.
+ */
+function referenceWindow(avgPriceMins: string | null): string {
+  if (avgPriceMins === null) return 'a reference price it works out itself';
+  if (avgPriceMins === '0') return 'the price of the last trade on this pair';
+  return `the average price over the last ${avgPriceMins} minutes`;
+}
+
+/**
+ * Whether the strategy asserts the position is still covered by a working stop
+ * on Binance despite the blocker. Callers use it to pick between "no safety net"
+ * and "the safety net is stale", which are different amounts of danger —
+ * painting the second one red is what teaches an operator to ignore the first.
+ *
+ * Only an explicit `true` counts. A blocker that does not carry the field says
+ * nothing about coverage rather than denying it, and unknown coverage is shown
+ * as uncovered: over-warning costs a glance, under-warning costs the position.
+ */
+export function blockerPositionGuarded(blocker: ProtectiveStopBlocker): boolean {
+  return blocker.detail?.['guarded'] === true;
+}
+
 export function glossProtectiveStopBlocker(blocker: ProtectiveStopBlocker): string {
   const d = blocker.detail;
   switch (blocker.reason) {
@@ -33,6 +58,34 @@ export function glossProtectiveStopBlocker(blocker: ProtectiveStopBlocker): stri
         ? ` The stop needs ${required} coins but none are free to sell.`
         : ' None of the coins are free to sell.';
       return `The bot thinks it holds this position, but the coins are not free in your Binance wallet — they were moved, withdrawn, or are being held back by a base reserve — so it cannot place its protective stop (the automatic sell that caps a loss).${detail} Move the coins back (or lower the reserve) and the stop arms itself on the next check. Until then this position has no safety net.`;
+    }
+    case 'price-outside-exchange-band': {
+      const price = str(d, 'price');
+      // Which end of the range was breached. A stop priced ABOVE the ceiling is
+      // rarer but possible, and quoting the floor at that operator produces a
+      // sentence that contradicts itself. Absent field reads as the floor, the
+      // only bound earlier blockers could describe.
+      const overCeiling = str(d, 'bound') === 'ceiling';
+      const limit = overCeiling ? str(d, 'ceiling') : str(d, 'floor');
+      // Binance bands against an average the bot cannot read from inside a tick,
+      // so the limit here is estimated from the current price. Saying so keeps an
+      // operator from treating a near-miss figure as the exact rejection point.
+      const basis = ` Binance works that limit out from ${referenceWindow(str(d, 'avgPriceMins'))}; the bot estimates it from the current price, so these numbers are close rather than exact.`;
+      const range =
+        limit && price
+          ? ` The stop would be priced at ${price}, against an estimated ${overCeiling ? 'highest' : 'lowest'} allowed sell of ${limit}.`
+          : '';
+      const net = blockerPositionGuarded(blocker)
+        ? ' An earlier protective stop is still resting on Binance and was deliberately left there, so the position is not unguarded — the bot just cannot move the stop up to its new level yet.'
+        : ' Until then this position has no safety net.';
+      if (d?.['terminal'] === true) {
+        const down = str(d, 'askMultiplierDown');
+        const knob = down
+          ? `above ${down} (Binance's floor multiplier for this pair)`
+          : "above Binance's floor multiplier for this pair";
+        return `Binance will not accept a protective stop (the automatic sell that caps a loss) at this price, and waiting will not fix it: your limit offset puts the order under the floor Binance allows for a sell on this pair.${basis}${range} Raise this profile's protective-stop "limitOffsetPercentage" ${knob}; the bot can then arm the stop once the price is back near its trigger, which may take longer than the next check.${net}`;
+      }
+      return `Binance will not accept a protective stop (the automatic sell that caps a loss) at this price right now: it falls outside the range the exchange allows for a sell on this pair.${basis}${range} Nothing for you to do — the bot re-checks every tick and arms the stop as soon as the market moves back into range.${net}`;
     }
     case 'base-below-exchange-minimum': {
       const free = str(d, 'free');

--- a/apps/web/src/shared/lib/i18n.ts
+++ b/apps/web/src/shared/lib/i18n.ts
@@ -135,7 +135,7 @@ const en: Readonly<Record<string, string>> = {
   'grid.status.watching': 'Watching',
   'grid.status.blocked': 'Blocked',
   'grid.status.unprotected': 'No stop',
-  'grid.status.stopStale': 'Stop stale',
+  'grid.status.stopStale': 'Old stop',
   'grid.status.paused': 'Paused',
   'home.scoped.title': 'Profile',
   'home.scoped.discovery_title': 'Discovery',

--- a/apps/web/src/shared/lib/i18n.ts
+++ b/apps/web/src/shared/lib/i18n.ts
@@ -135,6 +135,7 @@ const en: Readonly<Record<string, string>> = {
   'grid.status.watching': 'Watching',
   'grid.status.blocked': 'Blocked',
   'grid.status.unprotected': 'No stop',
+  'grid.status.stopStale': 'Stop stale',
   'grid.status.paused': 'Paused',
   'home.scoped.title': 'Profile',
   'home.scoped.discovery_title': 'Discovery',

--- a/apps/worker/__tests__/tick/symbol-info-cache.test.ts
+++ b/apps/worker/__tests__/tick/symbol-info-cache.test.ts
@@ -63,6 +63,50 @@ describe('createSymbolInfoCache', () => {
     expect(refresh).not.toHaveBeenCalled();
   });
 
+  it('reads a pre-band blob back with an undefined percentPriceBySide, not a throw', async () => {
+    // Entries are cast, not schema-parsed, and no migration rewrites them: a blob
+    // written before the band existed must survive the read and present the field
+    // as UNKNOWN, which every consumer treats as "impose no constraint".
+    const redis = stubRedis({ [buildSymbolInfoKey('BTCUSDT')]: JSON.stringify(symbolInfo) });
+    const cache = createSymbolInfoCache({
+      redis,
+      logger: silentLogger,
+      refreshExchangeInfo: vi.fn(async () => undefined),
+    });
+
+    const result = await cache.get('BTCUSDT');
+
+    expect(result.filters.percentPriceBySide).toBeUndefined();
+    expect(result.filters.tickSize).toBe('0.01');
+  });
+
+  it('carries the band through when the cached blob has one', async () => {
+    const banded = {
+      ...symbolInfo,
+      filters: {
+        ...symbolInfo.filters,
+        percentPriceBySide: {
+          bidMultiplierUp: '1.1',
+          bidMultiplierDown: '0.5',
+          askMultiplierUp: '2',
+          askMultiplierDown: '0.9',
+          avgPriceMins: 5,
+        },
+      },
+    };
+    const redis = stubRedis({ [buildSymbolInfoKey('BTCUSDT')]: JSON.stringify(banded) });
+    const cache = createSymbolInfoCache({
+      redis,
+      logger: silentLogger,
+      refreshExchangeInfo: vi.fn(async () => undefined),
+    });
+
+    const result = await cache.get('BTCUSDT');
+
+    expect(result.filters.percentPriceBySide?.askMultiplierDown).toBe('0.9');
+    expect(result.filters.percentPriceBySide?.avgPriceMins).toBe(5);
+  });
+
   it('primes the cache via refresh on first-tick miss, then returns from cache', async () => {
     const redis = stubRedis();
     const refresh = vi.fn(async () => {

--- a/packages/contracts/__tests__/symbol-filters.test.ts
+++ b/packages/contracts/__tests__/symbol-filters.test.ts
@@ -60,6 +60,53 @@ describe('projectSymbolFilters', () => {
   });
 });
 
+describe('projectSymbolFilters — PERCENT_PRICE_BY_SIDE', () => {
+  const notional = { filterType: 'NOTIONAL', minNotional: '10' };
+  const band = {
+    filterType: 'PERCENT_PRICE_BY_SIDE',
+    bidMultiplierUp: '1.1',
+    bidMultiplierDown: '0.5',
+    askMultiplierUp: '2',
+    askMultiplierDown: '0.9',
+    avgPriceMins: 5,
+  };
+
+  it('carries the multipliers and the averaging window through verbatim', () => {
+    expect(projectSymbolFilters([price, lot, notional, band])?.percentPriceBySide).toEqual({
+      bidMultiplierUp: '1.1',
+      bidMultiplierDown: '0.5',
+      askMultiplierUp: '2',
+      askMultiplierDown: '0.9',
+      avgPriceMins: 5,
+    });
+  });
+
+  it('omits the key when Binance publishes no band, leaving the seven intact', () => {
+    const projected = projectSymbolFilters([price, lot, notional]);
+    expect(projected).not.toBeNull();
+    expect(projected).not.toHaveProperty('percentPriceBySide');
+    expect(projected?.tickSize).toBe('0.01');
+  });
+
+  it('degrades a garbled band to "unknown" rather than voiding the whole set', () => {
+    // A band that failed the same all-or-nothing parse as the seven sizing
+    // thresholds would take every symbol's filters down with it, which is a far
+    // worse outage than the band it was meant to add.
+    const garbled = { ...band, askMultiplierDown: 'abc' };
+    const projected = projectSymbolFilters([price, lot, notional, garbled]);
+    expect(projected).not.toBeNull();
+    expect(projected).not.toHaveProperty('percentPriceBySide');
+    expect(projected?.minNotional).toBe('10');
+  });
+
+  it('degrades a band missing avgPriceMins the same way', () => {
+    const { avgPriceMins: _dropped, ...partial } = band;
+    const projected = projectSymbolFilters([price, lot, notional, partial]);
+    expect(projected).not.toBeNull();
+    expect(projected).not.toHaveProperty('percentPriceBySide');
+  });
+});
+
 describe('ProfileSymbolResponse save diagnostics', () => {
   const base = { symbol: 'BTCUSDT', overrideConfig: null, source: 'manual' as const };
 

--- a/packages/contracts/src/symbols.ts
+++ b/packages/contracts/src/symbols.ts
@@ -117,10 +117,34 @@ const FilterDecimalString = z
   .regex(/^(0|[1-9][0-9]*)(\.[0-9]+)?$/, 'filter value must be a positive decimal-string');
 
 /**
+ * Binance's `PERCENT_PRICE_BY_SIDE` band: the multipliers that bound how far an
+ * order's price may sit from a reference price, per side. Binance refuses a BUY
+ * outside `[ref × bidMultiplierDown, ref × bidMultiplierUp]` and a SELL outside
+ * `[ref × askMultiplierDown, ref × askMultiplierUp]` with -1013, so a resting
+ * protective stop priced under the ask floor can never be placed however often
+ * it is retried. `avgPriceMins` is the averaging window Binance derives the
+ * reference over (0 = last trade price), carried so a refusal can name it.
+ */
+export const PercentPriceBySide = z.object({
+  bidMultiplierUp: FilterDecimalString,
+  bidMultiplierDown: FilterDecimalString,
+  askMultiplierUp: FilterDecimalString,
+  askMultiplierDown: FilterDecimalString,
+  avgPriceMins: z.number().int().nonnegative(),
+});
+/** TS type derived from {@link PercentPriceBySide} so consumers don't re-run z.infer at every call site. */
+export type PercentPriceBySide = z.infer<typeof PercentPriceBySide>;
+
+/**
  * The seven Binance filter thresholds a strategy needs to size and price an
  * order, mirroring `SymbolFilters` in `@app/strategy-core`. Each value is a
  * decimal-string (trailing zeros preserved) so a consumer can read tick/step
  * precision straight off the string.
+ *
+ * `percentPriceBySide` is OPTIONAL and parsed independently of those seven:
+ * absence means the band is UNKNOWN, never "no band", so a consumer reading it
+ * fails open. Binance does not publish the row on every symbol, cached entries
+ * written before the field existed omit it, and there is no migration.
  */
 export const SymbolFilters = z.object({
   minNotional: FilterDecimalString,
@@ -130,6 +154,7 @@ export const SymbolFilters = z.object({
   maxQty: FilterDecimalString,
   minPrice: FilterDecimalString,
   maxPrice: FilterDecimalString,
+  percentPriceBySide: PercentPriceBySide.optional(),
 });
 /** TS type derived from {@link SymbolFilters} so consumers don't re-run z.infer at every call site. */
 export type SymbolFilters = z.infer<typeof SymbolFilters>;
@@ -145,6 +170,11 @@ interface RawSymbolFilter {
   readonly maxQty?: string;
   readonly stepSize?: string;
   readonly minNotional?: string;
+  readonly bidMultiplierUp?: string;
+  readonly bidMultiplierDown?: string;
+  readonly askMultiplierUp?: string;
+  readonly askMultiplierDown?: string;
+  readonly avgPriceMins?: number;
 }
 
 /**
@@ -155,6 +185,14 @@ interface RawSymbolFilter {
  * trailing zeros survive. Returns `null` when a required filter group is absent
  * or any value is not a positive decimal-string, so a partial upstream row can
  * never produce a half-populated filter set.
+ *
+ * `PERCENT_PRICE_BY_SIDE` is parsed SEPARATELY and spread in only on success,
+ * because the two carry opposite failure meanings. A missing sizing threshold
+ * must void the whole set (a half-populated one sizes a bad order), whereas a
+ * missing or garbled band must degrade to "unknown" and leave the seven intact:
+ * folding it into the same all-or-nothing parse would turn every symbol Binance
+ * publishes no band for into a null filter set, which is a far larger outage
+ * than the band it was meant to add.
  */
 export const projectSymbolFilters = (
   filters: readonly RawSymbolFilter[] | undefined,
@@ -173,7 +211,13 @@ export const projectSymbolFilters = (
     minPrice: price?.minPrice,
     maxPrice: price?.maxPrice,
   });
-  return parsed.success ? parsed.data : null;
+  if (!parsed.success) return null;
+  // Only the by-side band is projected. Binance still documents a legacy
+  // `PERCENT_PRICE` filter carrying the same -1013, but no listed spot symbol
+  // publishes it (all 3641 carry `PERCENT_PRICE_BY_SIDE` instead), so mapping it
+  // would be dead code guarding a case that cannot arrive.
+  const band = PercentPriceBySide.safeParse(find('PERCENT_PRICE_BY_SIDE'));
+  return band.success ? { ...parsed.data, percentPriceBySide: band.data } : parsed.data;
 };
 
 /**

--- a/packages/strategy/core/__tests__/protective-stop.test.ts
+++ b/packages/strategy/core/__tests__/protective-stop.test.ts
@@ -10,6 +10,7 @@ import type {
   ProtectiveStopArmParams,
   ProtectiveStopLevel,
   SizeFilters,
+  SymbolFilters,
 } from '../src/index.js';
 import {
   armableBaseQuantity,
@@ -18,7 +19,9 @@ import {
   findForeignRestingSell,
   findRestingProtectiveStop,
   ownRestingSellBase,
+  percentPriceBySideRefusal,
   protectiveStopNeedsRearm,
+  stillGuarding,
 } from '../src/protective-stop.js';
 
 const OURS = 'tt-p1-btcusdt-ps';
@@ -262,11 +265,27 @@ describe('evaluateProtectiveStopArm — shared orchestration', () => {
 
   type Params = ProtectiveStopArmParams<unknown, unknown, Record<string, never>>;
 
+  // No `percentPriceBySide`: the arm must behave exactly as it did before the
+  // band existed on every symbol Binance publishes no band for.
+  const BTC_FILTERS: SymbolFilters = {
+    minNotional: '10',
+    tickSize: '0.01',
+    stepSize: '0.001',
+    minQty: '0.001',
+    maxQty: '9000',
+    minPrice: '0.01',
+    maxPrice: '1000000',
+  };
+
   const armInput = (openOrders: OpenOrder[], acct: AccountSnapshot): Params['input'] =>
     ({
       openOrders,
       account: acct,
-      market: { symbol: 'BTCUSDT', symbolInfo: { baseAsset: 'BTC' } },
+      market: {
+        symbol: 'BTCUSDT',
+        currentPrice: '100.00',
+        symbolInfo: { baseAsset: 'BTC', filters: BTC_FILTERS },
+      },
     }) as unknown as Params['input'];
 
   const buildPlace = (desired: DesiredProtectiveStop): Decision => ({
@@ -379,5 +398,343 @@ describe('evaluateProtectiveStopArm — shared orchestration', () => {
     });
     expect(out.blocker).toBeNull();
     expect(out.decisions).toEqual([placed({ quantity: '0.344' })]);
+  });
+});
+
+describe('evaluateProtectiveStopArm — PERCENT_PRICE_BY_SIDE band', () => {
+  // Live LINKUSDT reproduction. Binance accepts a SELL only inside
+  // `ref * askMultiplierDown <= price <= ref * askMultiplierUp`. The arm emitted
+  // [cancel, place]; the cancel landed, the place was refused -1013, and the pair
+  // was re-derived every tick for 2h18m with the position unguarded. The cancel is
+  // the damaging half: it strips real protection to make room for an order the
+  // exchange will never accept.
+  const LINK_OURS = 'mom-p1-linkusdt-ps';
+
+  const FILTERS: SizeFilters = {
+    step: new Decimal('0.01'),
+    minQty: new Decimal('0.01'),
+    minNotional: new Decimal('5'),
+  };
+
+  // The live LINKUSDT filter row. `withBand: false` is the symbol Binance
+  // publishes no band for, which must stay indistinguishable from today.
+  const symbolFilters = (withBand: boolean): SymbolFilters => ({
+    minNotional: '5',
+    tickSize: '0.001',
+    stepSize: '0.01',
+    minQty: '0.01',
+    maxQty: '92141578',
+    minPrice: '0.001',
+    maxPrice: '10000',
+    ...(withBand
+      ? {
+          percentPriceBySide: {
+            askMultiplierUp: '2',
+            askMultiplierDown: '0.9',
+            bidMultiplierUp: '1.1',
+            bidMultiplierDown: '0.5',
+            avgPriceMins: 5,
+          },
+        }
+      : {}),
+  });
+
+  // highSinceEntry 8.779 * (1 - trailingStopPct 0.15) floored to tickSize 0.001,
+  // then limitOffsetPercentage 0.98 applied and floored again: the exact pair the
+  // live order carried.
+  const stopLevel = (over: Partial<ProtectiveStopLevel> = {}): ProtectiveStopLevel => ({
+    stop: new Decimal('7.462'),
+    limit: new Decimal('7.312'),
+    held: new Decimal('3.13'),
+    filters: FILTERS,
+    tick: new Decimal('0.001'),
+    ...over,
+  });
+
+  type Params = ProtectiveStopArmParams<unknown, unknown, Record<string, never>>;
+
+  // The whole position sits in `locked` behind our own resting stop, which is what
+  // the wallet reads while a stop rests; `reclaimableBase` credits it back.
+  const linkAccount = (): AccountSnapshot => ({
+    balances: {
+      LINK: { asset: 'LINK', free: new Decimal('0'), locked: new Decimal('3.13') } as Balance,
+    },
+    readable: true,
+  });
+
+  const armInput = (
+    currentPrice: string,
+    withBand: boolean,
+    openOrders: OpenOrder[],
+  ): Params['input'] =>
+    ({
+      openOrders,
+      account: linkAccount(),
+      market: {
+        symbol: 'LINKUSDT',
+        currentPrice,
+        symbolInfo: { baseAsset: 'LINK', quoteAsset: 'USDT', filters: symbolFilters(withBand) },
+      },
+    }) as unknown as Params['input'];
+
+  const buildPlace = (desired: DesiredProtectiveStop): Decision => ({
+    type: 'place-order',
+    intent: {
+      symbol: 'LINKUSDT',
+      side: 'SELL',
+      reason: 'protective-stop',
+      clientOrderId: LINK_OURS,
+    },
+    params: {
+      type: 'STOP_LOSS_LIMIT',
+      stopPrice: desired.stopPrice,
+      price: desired.price,
+      quantity: desired.quantity,
+      timeInForce: 'GTC',
+    },
+  });
+
+  const buildCancel = (resting: OpenOrder): Decision => ({
+    type: 'cancel-order',
+    orderId: resting.orderId,
+    symbol: 'LINKUSDT',
+    reason: 'superseded',
+  });
+
+  // The previous trail level, far enough below the recomputed 7.462 to clear the
+  // drift band, so today's arm reaches the [cancel, place] re-arm return.
+  const resting = (): OpenOrder =>
+    order({
+      orderId: 4242,
+      clientOrderId: LINK_OURS,
+      symbol: 'LINKUSDT',
+      price: '7.154',
+      stopPrice: '7.300',
+      origQty: '3.13',
+      executedQty: '0',
+    });
+
+  const placed = (over: Partial<DesiredProtectiveStop> = {}): Decision =>
+    buildPlace({ stopPrice: '7.462', price: '7.312', quantity: '3.13', ...over });
+
+  const run = (over: Partial<Params>): ReturnType<typeof evaluateProtectiveStopArm> =>
+    evaluateProtectiveStopArm({
+      input: armInput('8.8320', true, [resting()]),
+      enabled: true,
+      level: stopLevel(),
+      reclaimableBase: new Decimal('3.13'),
+      ourClientOrderId: LINK_OURS,
+      buildPlace,
+      buildCancel,
+      ...over,
+    } as Params);
+
+  it('refuses BOTH halves of the re-arm when the desired price is below the ask floor', () => {
+    // reference 8.8320 * askMultiplierDown 0.9 = 7.9488. Both 7.462 and 7.312 sit
+    // under it, so the replacement can only ever come back -1013.
+    const out = run({});
+    expect(out.decisions.filter((d) => d.type === 'place-order')).toEqual([]);
+    // The live stop must survive: cancelling it buys nothing when no replacement
+    // can be accepted.
+    expect(out.decisions.filter((d) => d.type === 'cancel-order')).toEqual([]);
+    expect(out.blocker?.reason).toBe('price-outside-exchange-band');
+  });
+
+  it('re-arms again once the reference falls back inside the band (no operator action)', () => {
+    // 7.312 / 0.9 = 8.1244 is the highest reference that still admits this stop.
+    const out = run({ input: armInput('8.10', true, [resting()]) });
+    expect(out.blocker).toBeNull();
+    expect(out.decisions).toEqual([buildCancel(resting()), placed()]);
+  });
+
+  it('places unchanged when the symbol carries no percentPriceBySide filter', () => {
+    // Absent filter means unknown band, not a zero-width one. Refusing to protect
+    // a position needs proof, so the arm must behave exactly as it does today.
+    const out = run({ input: armInput('8.8320', false, [resting()]) });
+    expect(out.blocker).toBeNull();
+    expect(out.decisions).toEqual([buildCancel(resting()), placed()]);
+  });
+
+  it('marks the blocker terminal when the limit offset can never clear the ask floor', () => {
+    // limitOffsetPercentage 0.9 against askMultiplierDown 0.9: the limit is
+    // stop * 0.9 and the floor is ref * 0.9, and a protective stop's trigger is
+    // always at or below the reference, so no price movement can arm it. The
+    // operator must widen the offset; waiting will not help, and the gloss has to
+    // say so.
+    const out = run({ level: stopLevel({ limit: new Decimal('6.715') }) });
+    expect(out.blocker?.reason).toBe('price-outside-exchange-band');
+    expect(out.blocker?.detail).toMatchObject({ terminal: true });
+  });
+
+  it('stays silent when the resting stop is already at the desired level', () => {
+    // Nothing would be sent, so no band applies. A blocker here reads to every
+    // consumer as "this position has no stop" and paints the symbol red, which is
+    // the opposite of true: the stop is resting exactly where it should be.
+    const settled = order({
+      orderId: 4242,
+      clientOrderId: LINK_OURS,
+      symbol: 'LINKUSDT',
+      price: '7.312',
+      stopPrice: '7.462',
+      origQty: '3.13',
+      executedQty: '0',
+    });
+    const out = run({ input: armInput('8.8320', true, [settled]) });
+    expect(out.decisions).toEqual([]);
+    expect(out.blocker).toBeNull();
+  });
+
+  it('tells the operator whether a stop still covers the position behind the refusal', () => {
+    // Same refusal, two very different amounts of danger: an unguarded position
+    // versus one guarded at last tick's level. The detail carries the difference
+    // so the UI can stop crying wolf on the second.
+    expect(run({}).blocker?.detail).toMatchObject({ guarded: true });
+    // Nothing resting and the base sitting free in the wallet: fully armable, and
+    // refused only by the band — the genuinely unguarded case.
+    const naked = run({
+      input: {
+        ...armInput('8.8320', true, []),
+        account: {
+          balances: {
+            LINK: { asset: 'LINK', free: new Decimal('3.13'), locked: new Decimal('0') } as Balance,
+          },
+          readable: true,
+        },
+      } as Params['input'],
+      reclaimableBase: new Decimal('0'),
+    });
+    expect(naked.blocker?.detail).toMatchObject({ guarded: false });
+    expect(naked.decisions).toEqual([]);
+  });
+
+  it('does not call a position guarded by a stop that is leaving the book', () => {
+    // PENDING_CANCEL is a cancel already in flight. `isRestingSell` reports it as
+    // resting because it still locks the base, which is the right answer to that
+    // question and the wrong one here: the order is about to stop protecting
+    // anything, so the operator must still see red.
+    const out = run({
+      input: armInput('8.8320', true, [{ ...resting(), status: 'PENDING_CANCEL' }]),
+    });
+    expect(out.blocker?.detail).toMatchObject({ guarded: false });
+    // Still no cancel: leaving it alone costs nothing, and the band would refuse
+    // the replacement regardless of how the coverage reads.
+    expect(out.decisions).toEqual([]);
+  });
+
+  it('still calls a position guarded by a stop that covers more than it', () => {
+    // The coverage test is one-sided on purpose. An oversized resting stop does
+    // trigger a re-arm, but more protection than asked for is still protection,
+    // and painting it red would send the operator hunting for a missing stop.
+    const out = run({ input: armInput('8.8320', true, [{ ...resting(), origQty: '4.0' }]) });
+    expect(out.blocker?.detail).toMatchObject({ guarded: true });
+  });
+
+  it('does not call a position guarded by a stop that covers a fraction of it', () => {
+    // A stop armed while a foreign order held most of the base. It exists, it is
+    // working, and it protects 16% of the position — reporting that as covered
+    // hides a position that is materially naked behind an amber chip.
+    const out = run({
+      input: armInput('8.8320', true, [{ ...resting(), origQty: '0.5' }]),
+    });
+    expect(out.blocker?.detail).toMatchObject({ guarded: false });
+  });
+});
+
+describe('percentPriceBySideRefusal', () => {
+  const desired: DesiredProtectiveStop = {
+    stopPrice: '7.462',
+    price: '7.312',
+    quantity: '3.13',
+  };
+
+  const refuse = (
+    band: unknown,
+    reference = '8.8320',
+    over: Partial<DesiredProtectiveStop> = {},
+  ): ReturnType<typeof percentPriceBySideRefusal> =>
+    percentPriceBySideRefusal({
+      symbol: 'LINKUSDT',
+      reference,
+      band: band as never,
+      desired: { ...desired, ...over },
+      guarded: false,
+    });
+
+  const BAND = {
+    askMultiplierUp: '2',
+    askMultiplierDown: '0.9',
+    bidMultiplierUp: '1.1',
+    bidMultiplierDown: '0.5',
+    avgPriceMins: 5,
+  };
+
+  it('refuses a stop stranded ABOVE the ceiling, not just below the floor', () => {
+    // A gap up leaves the previous level far under the market, but the mirror case
+    // is real: a trigger above `ref * askMultiplierUp` is refused with the same
+    // -1013, and gating only the floor would loop on it exactly as before.
+    const out = refuse(BAND, '3.00', { stopPrice: '7.462', price: '7.312' });
+    expect(out?.reason).toBe('price-outside-exchange-band');
+    // `bound` names the end that was breached: the gloss quotes the floor by
+    // default, and quoting a floor at a stop that is too HIGH reads as nonsense.
+    expect(out?.detail).toMatchObject({ ceiling: '6', bound: 'ceiling', terminal: false });
+  });
+
+  it('bands the limit price only, never the trigger', () => {
+    // `PRICE_FILTER` spells out that it covers price AND stopPrice;
+    // PERCENT_PRICE_BY_SIDE names only the order price. Banding the trigger as
+    // well would defer a stop the exchange accepts, and a deferred first arm is
+    // an unguarded position waiting on a rule Binance does not enforce.
+    // ceiling = 3.7 * 2 = 7.4: the trigger 7.462 is over it, the limit 7.312 is not.
+    expect(refuse(BAND, '3.7')).toBeNull();
+  });
+
+  it('imposes no constraint when the band is absent, null, or not an object', () => {
+    // Absence is unknown, never zero-width. Refusing to protect a position needs
+    // proof the exchange would reject it.
+    for (const band of [undefined, null, 'PERCENT_PRICE_BY_SIDE', 42]) {
+      expect(refuse(band)).toBeNull();
+    }
+  });
+
+  it('ignores a multiplier that is zero, negative, or unparseable', () => {
+    // `0` would collapse the window to a point and refuse every stop on the
+    // symbol — a fail-closed reading of data that simply could not be evaluated.
+    expect(refuse({ ...BAND, askMultiplierDown: '0' })).toBeNull();
+    expect(refuse({ ...BAND, askMultiplierDown: 'n/a' })).toBeNull();
+    expect(refuse({ ...BAND, askMultiplierDown: -0.9 })).toBeNull();
+    // Each bound fails open on its own: a garbled floor must not disable the
+    // ceiling check that is still evaluable.
+    expect(refuse({ ...BAND, askMultiplierUp: 'n/a' }, '8.8320')?.reason).toBe(
+      'price-outside-exchange-band',
+    );
+    // The mirror case: a garbled floor still serialises as null next to a
+    // ceiling breach, so the gloss has a bound to quote.
+    expect(refuse({ ...BAND, askMultiplierDown: 'n/a' }, '3.00')?.detail).toMatchObject({
+      floor: null,
+      ceiling: '6',
+      bound: 'ceiling',
+      terminal: false,
+    });
+  });
+
+  it('imposes no constraint when the reference or the desired prices do not parse', () => {
+    expect(refuse(BAND, 'not-a-price')).toBeNull();
+    expect(refuse(BAND, '0')).toBeNull();
+    expect(refuse(BAND, '8.8320', { price: '' })).toBeNull();
+    expect(refuse(BAND, '8.8320', { stopPrice: 'NaN' })).toBeNull();
+  });
+});
+
+describe('stillGuarding', () => {
+  it('reads an unquantifiable resting stop as NOT covering the position', () => {
+    // This flag decides whether the operator is told the position is naked, so
+    // every unreadable input has to land on the loud side. An unreadable fill
+    // count is the sharp one: reading it as zero fills would report a stop that
+    // is almost entirely filled as full coverage.
+    expect(stillGuarding(order({ origQty: '' }), '2')).toBe(false);
+    expect(stillGuarding(order({ executedQty: 'n/a' }), '2')).toBe(false);
+    expect(stillGuarding(order(), 'n/a')).toBe(false);
+    expect(stillGuarding(order(), '0')).toBe(false);
+    expect(stillGuarding(order(), '2')).toBe(true);
   });
 });

--- a/packages/strategy/core/__tests__/protective-stop.test.ts
+++ b/packages/strategy/core/__tests__/protective-stop.test.ts
@@ -638,6 +638,26 @@ describe('evaluateProtectiveStopArm — PERCENT_PRICE_BY_SIDE band', () => {
     });
     expect(out.blocker?.detail).toMatchObject({ guarded: false });
   });
+
+  it('does not call a position guarded when a foreign lock capped what this tick could size', () => {
+    // The same fraction, arrived at from the other direction: a foreign SELL holds
+    // 2.13 of the 3.13 position, so this tick can only size 1.00 and the resting
+    // stop already matches that reduced size. Judging coverage against what we
+    // could size — rather than against full protection — reports a 32%-covered
+    // position as guarded, which is the amber chip the operator dismisses.
+    const foreign = order({
+      orderId: 999,
+      clientOrderId: 'ghost',
+      symbol: 'LINKUSDT',
+      origQty: '2.13',
+    });
+    const out = run({
+      input: armInput('8.8320', true, [{ ...resting(), origQty: '1.00' }, foreign]),
+      reclaimableBase: new Decimal('1.00'),
+    });
+    expect(out.blocker?.reason).toBe('price-outside-exchange-band');
+    expect(out.blocker?.detail).toMatchObject({ guarded: false });
+  });
 });
 
 describe('percentPriceBySideRefusal', () => {

--- a/packages/strategy/core/src/contract.ts
+++ b/packages/strategy/core/src/contract.ts
@@ -32,6 +32,22 @@ export interface Candle {
   readonly isClosed: boolean;
 }
 
+/**
+ * Binance's `PERCENT_PRICE_BY_SIDE` band. An order is refused -1013 unless a BUY
+ * prices inside `[ref × bidMultiplierDown, ref × bidMultiplierUp]` or a SELL
+ * inside `[ref × askMultiplierDown, ref × askMultiplierUp]`, where `ref` is the
+ * average price over the last `avgPriceMins` minutes (0 = last trade price).
+ * Multipliers are decimal-strings; `avgPriceMins` is a plain minute count, not
+ * money.
+ */
+export interface PercentPriceBySideFilter {
+  readonly bidMultiplierUp: string;
+  readonly bidMultiplierDown: string;
+  readonly askMultiplierUp: string;
+  readonly askMultiplierDown: string;
+  readonly avgPriceMins: number;
+}
+
 export interface SymbolFilters {
   readonly minNotional: string;
   readonly tickSize: string;
@@ -40,6 +56,19 @@ export interface SymbolFilters {
   readonly maxQty: string;
   readonly minPrice: string;
   readonly maxPrice: string;
+  /**
+   * Binance's per-side price band for this symbol. Optional because Binance does
+   * not publish the row on every symbol, the cached entries written before the
+   * field existed are parsed with an unvalidated cast, and there is no
+   * migration: a reader MUST treat absence as "band unknown" and impose no
+   * constraint, never as "no order is placeable".
+   *
+   * Explicitly `| undefined` because the producer is a zod projection in
+   * `@app/contracts`, whose optional key infers as `T | undefined`; under
+   * `exactOptionalPropertyTypes` a bare `?: T` would reject it. Absent and
+   * explicitly-undefined carry the same meaning here, so both are accepted.
+   */
+  readonly percentPriceBySide?: PercentPriceBySideFilter | undefined;
 }
 
 export interface SymbolInfo {

--- a/packages/strategy/core/src/index.ts
+++ b/packages/strategy/core/src/index.ts
@@ -6,6 +6,7 @@ export type {
   Clock,
   RNG,
   Candle,
+  PercentPriceBySideFilter,
   SymbolFilters,
   SymbolInfo,
   ApiLimits,
@@ -86,12 +87,14 @@ export type { SizeFilters } from './sizing.js';
 export { log, metric } from './emit.js';
 export { resolveCandleWindow } from './window.js';
 export {
+  PROTECTIVE_STOP_BLOCKER_REASONS,
   armableBaseQuantity,
   classifyProtectiveStopRefusal,
   evaluateProtectiveStopArm,
   findForeignRestingSell,
   findRestingProtectiveStop,
   ownRestingSellBase,
+  percentPriceBySideRefusal,
   protectiveStopNeedsRearm,
 } from './protective-stop.js';
 export type {

--- a/packages/strategy/core/src/protective-stop.ts
+++ b/packages/strategy/core/src/protective-stop.ts
@@ -533,7 +533,11 @@ export const evaluateProtectiveStopArm = <C, S, B extends Readonly<Record<string
     reference: input.market.currentPrice,
     band: input.market.symbolInfo.filters.percentPriceBySide,
     desired,
-    guarded: stillGuarding(resting, desired.quantity),
+    // Measured against FULL protection, not the quantity this tick could size.
+    // A stop armed while a foreign order held most of the base covers a fraction
+    // of the position; calling that guarded is exactly the dismissible-amber-chip
+    // downgrade `stillGuarding` exists to refuse.
+    guarded: stillGuarding(resting, full.quantity),
   });
   if (outsideBand !== null) return { decisions: [], blocker: outsideBand };
 

--- a/packages/strategy/core/src/protective-stop.ts
+++ b/packages/strategy/core/src/protective-stop.ts
@@ -1,6 +1,6 @@
 import { isRestingSell } from '@app/contracts';
 import { Decimal, roundToStep, toFixedStep } from '@app/money';
-import type { OpenOrder, TickInput } from './contract.js';
+import type { OpenOrder, PercentPriceBySideFilter, TickInput } from './contract.js';
 import type { Decision } from './decision.js';
 import { sizableBase } from './balances.js';
 import { finalise, type SizeFilters } from './sizing.js';
@@ -94,9 +94,21 @@ export const armableBaseQuantity = (
   ownLocked: Decimal,
 ): Decimal => (free === undefined ? held : Decimal.min(held, free.add(ownLocked)));
 
-/** Why an open position has no exchange-side protective stop. One vocabulary, so every strategy's refusal glosses the same way. */
-export type ProtectiveStopBlockerReason =
-  'base-locked-by-foreign-order' | 'base-below-exchange-minimum' | 'base-short-of-tracked-position';
+/**
+ * Why an open position has no exchange-side protective stop, or none at the
+ * level it should have. One vocabulary, so every strategy's refusal glosses the
+ * same way. Declared as a value first so a strategy's attribution map can be
+ * checked against the real vocabulary instead of a hand-copied list that silently
+ * stops covering it.
+ */
+export const PROTECTIVE_STOP_BLOCKER_REASONS = [
+  'base-locked-by-foreign-order',
+  'base-below-exchange-minimum',
+  'base-short-of-tracked-position',
+  'price-outside-exchange-band',
+] as const;
+
+export type ProtectiveStopBlockerReason = (typeof PROTECTIVE_STOP_BLOCKER_REASONS)[number];
 
 /** A refusal record persisted on strategy state: `{ reason, detail }`, read by the api projection and the web gloss. */
 export interface ProtectiveStopBlocker {
@@ -143,6 +155,106 @@ export const classifyProtectiveStopRefusal = (params: {
   return available.lte(0)
     ? { reason: 'base-short-of-tracked-position', detail: base }
     : { reason: 'base-below-exchange-minimum', detail: base };
+};
+
+// A band multiplier or reference price is usable only when it parses to a
+// positive finite number. Anything else means the band cannot be evaluated, and
+// an unevaluable band must impose NO constraint: `0` would otherwise collapse
+// the window to a point and refuse every stop on the symbol.
+const positiveDecimal = (value: unknown): Decimal | null => {
+  if (typeof value !== 'string') return null;
+  const parsed = safeDecimal(value);
+  return parsed !== null && parsed.isFinite() && parsed.gt(0) ? parsed : null;
+};
+
+/**
+ * Whether Binance's `PERCENT_PRICE_BY_SIDE` band makes this stop unplaceable,
+ * as a blocker, or `null` when it is placeable or the band is unknown.
+ *
+ * Judged on the limit `price` alone, which is what the filter definition bounds:
+ * `PRICE_FILTER` spells out that it covers `price` AND `stopPrice`, while
+ * `PERCENT_PRICE_BY_SIDE` names only the order price, and the contrast is the
+ * evidence. Banding the trigger too would be conservative in the wrong
+ * direction on the ceiling — the trigger is the higher of the two legs, so it
+ * alone can breach a ceiling the limit clears, and a stop deferred there is a
+ * naked position waiting on a rule the exchange does not enforce.
+ *
+ * `reference` is the price the caller already holds for this tick, NOT Binance's
+ * own reference: for `avgPriceMins > 0` the exchange bands against a volume
+ * weighted average over that window. The two drift apart in a fast market, in
+ * opposite directions with opposite costs. Spot above the average overstates the
+ * floor, so a placeable stop is deferred one tick and nothing resting is touched.
+ * Spot below it understates the floor, so an order goes out and comes back -1013,
+ * which is what already happens today. Neither direction cancels protection that
+ * the exchange would have let us replace.
+ *
+ * Fails OPEN on every ambiguity — no band published, a band that is not an
+ * object, an unparseable multiplier, an unreadable reference price. Refusing to
+ * protect an open position needs proof. Each bound is judged on its own, so an
+ * unreadable ceiling cannot disable the floor, which is the bound a protective
+ * stop actually breaches.
+ *
+ * `terminal` marks the config-shaped case: an armable stop needs
+ * `stop × offset ≥ ref × askMultiplierDown` while the trigger sits at or below
+ * the reference, so `offset > askMultiplierDown` is necessary. When the ratio is
+ * at or under the floor multiplier NO price movement can ever arm the stop and
+ * the operator must widen the offset, which is the opposite of the advice the
+ * ordinary case deserves. Read off the price ratio alone, so it holds for any
+ * plugin's level formula, and only ever from a FLOOR breach: a ceiling breach is
+ * transient by nature and raising the offset would push the price further into it.
+ */
+export const percentPriceBySideRefusal = (params: {
+  readonly symbol: string;
+  readonly reference: string;
+  readonly band: PercentPriceBySideFilter | null | undefined;
+  readonly desired: DesiredProtectiveStop;
+  /** Whether the position is still covered by a working stop, so a refusal is not a naked position. */
+  readonly guarded: boolean;
+}): ProtectiveStopBlocker | null => {
+  const { symbol, reference, band, desired, guarded } = params;
+  // Cast, not parsed: the cached symbol blob is revived with `JSON.parse(...) as
+  // SymbolInfo`, so this slot can hold any JSON value. A `null` in particular
+  // would throw on the first property read, and a throw inside the pure tick
+  // dead-letters the symbol every pass, leaving the position wholly unmanaged.
+  if (typeof band !== 'object' || band === null) return null;
+
+  const ref = positiveDecimal(reference);
+  const stopPrice = positiveDecimal(desired.stopPrice);
+  const price = positiveDecimal(desired.price);
+  if (ref === null || stopPrice === null || price === null) return null;
+
+  const down = positiveDecimal(band.askMultiplierDown);
+  const up = positiveDecimal(band.askMultiplierUp);
+  const floor = down === null ? null : ref.mul(down);
+  const ceiling = up === null ? null : ref.mul(up);
+  const belowFloor = floor !== null && price.lt(floor);
+  const aboveCeiling = ceiling !== null && price.gt(ceiling);
+  if (!belowFloor && !aboveCeiling) return null;
+
+  const ratio = price.div(stopPrice);
+  return {
+    reason: 'price-outside-exchange-band',
+    detail: {
+      symbol,
+      stopPrice: desired.stopPrice,
+      price: desired.price,
+      reference,
+      // `toFixed` never switches to exponential notation, which `toString` does
+      // below 1e-7: the operator is asked to compare this against a real price.
+      floor: floor === null ? null : floor.toFixed(),
+      ceiling: ceiling === null ? null : ceiling.toFixed(),
+      askMultiplierDown: band.askMultiplierDown,
+      askMultiplierUp: band.askMultiplierUp,
+      avgPriceMins: band.avgPriceMins,
+      limitOffsetRatio: ratio.toDecimalPlaces(6).toString(),
+      terminal: belowFloor && down !== null && ratio.lte(down),
+      // Which bound was actually breached, so the gloss never quotes a floor at
+      // an operator whose stop is priced too HIGH. One price cannot breach both
+      // unless the band itself is inverted, where the floor is the safer read.
+      bound: belowFloor ? 'floor' : 'ceiling',
+      guarded,
+    },
+  };
 };
 
 // Re-place the resting stop only when the recomputed trigger has moved by at
@@ -204,6 +316,41 @@ export const findRestingProtectiveStop = (
   ourClientOrderId: string,
 ): OpenOrder | undefined =>
   openOrders.find((o) => o.clientOrderId === ourClientOrderId && isRestingSell(o));
+
+// Statuses under which a stop is actually working on the book. An ALLOWLIST,
+// deliberately narrower than the denylist above: that one answers "do these
+// coins still count as locked?" and must fail CLOSED, so it reports a
+// PENDING_CANCEL — a cancel already in flight — and every status Binance adds
+// later as resting. The question here is the opposite-facing "is this position
+// still covered?", where that same answer fails OPEN.
+const GUARDING_STATUSES = new Set(['NEW', 'PARTIALLY_FILLED']);
+
+/**
+ * Whether `resting` still covers the position the strategy wants protected: it is
+ * working on the book AND its unfilled remainder is not materially short of the
+ * desired size. Existence alone is not coverage — a stop sized while a foreign
+ * order held most of the base guards a fraction of the position, and calling that
+ * guarded downgrades a naked position to a warning the operator can dismiss.
+ *
+ * One-sided, on the same 1% tolerance the re-arm test uses: anything reported as
+ * covering is at least the desired size, so it is never re-armed for being too
+ * small. An OVERSIZED resting stop still counts as covering even though its size
+ * difference does trigger a re-arm — more coverage than asked for is coverage.
+ * Anything unreadable reads as NOT covering: the claim is that the operator may
+ * ignore an alert, and that needs proof.
+ */
+export const stillGuarding = (resting: OpenOrder | undefined, desiredQuantity: string): boolean => {
+  if (resting === undefined || !GUARDING_STATUSES.has(resting.status.toUpperCase())) return false;
+  const orig = safeDecimal(resting.origQty);
+  const desired = safeDecimal(desiredQuantity);
+  // An unreadable fill count is NOT read as zero fills here, unlike the sizing
+  // helpers above: overstating the remainder would claim coverage the position
+  // may not have.
+  const executed = safeDecimal(resting.executedQty);
+  if (orig === null || desired === null || executed === null || !desired.gt(0)) return false;
+  const remaining = orig.minus(executed);
+  return remaining.gte(desired.mul(new Decimal(1).minus(MIN_QTY_DRIFT)));
+};
 
 /** Stop trigger + limit price, sized to `quantity`, for the resting STOP_LOSS_LIMIT SELL. */
 export interface DesiredProtectiveStop {
@@ -287,6 +434,10 @@ export interface ProtectiveStopArmParams<C, S, B extends Readonly<Record<string,
  *     the operator must cancel. The resting stop and any foreign order are LEFT
  *     untouched — `openOrders` is a TTL cache and cancelling a live stop we merely
  *     cannot resize strips real protection.
+ *   - the priced order falls outside Binance's `PERCENT_PRICE_BY_SIDE` band ⇒
+ *     [] + a blocker, again leaving anything resting alone. The exchange can only
+ *     answer -1013, so cancelling to make room buys nothing and costs the
+ *     protection already in place.
  *   - no resting stop ⇒ [place]; trigger OR sized quantity drifted materially ⇒
  *     [cancel, place]; within both bands ⇒ [] (no churn).
  *
@@ -354,15 +505,39 @@ export const evaluateProtectiveStopArm = <C, S, B extends Readonly<Record<string
     price: toFixedStep(limit, tick),
     quantity: sized.quantity,
   };
+
   // Resolved before `buildPlace` so the plugin is told whether this placement is
   // a first arm or a re-price of a live stop.
   const resting = findRestingProtectiveStop(input.openOrders, ourClientOrderId);
-  if (resting === undefined) return { decisions: [buildPlace(desired, false)], blocker: null };
+
+  // A stop that is already resting at the right level is settled: nothing is
+  // sent, so no band applies. Tested BEFORE the band check because a blocker
+  // here would be a lie the operator cannot ignore — every consumer reads the
+  // field as "this position has no stop" and paints it red, and a static level
+  // sits outside a tight band for most of a winning position's life.
   if (
+    resting !== undefined &&
     !protectiveStopNeedsRearm(resting, desired.stopPrice, desired.quantity, params.minStopDrift)
   ) {
     return { decisions: [], blocker: null };
   }
+
+  // Checked on the exact bytes the executor would send, and gating BOTH halves
+  // of the re-arm from ONE return so a later edit cannot let the cancel through
+  // alone. Emitting the pair is what left a live position unguarded: the cancel
+  // lands, the replacement comes back -1013, and the arm re-derives the same
+  // impossible order every tick. Leaving the resting stop in place keeps the
+  // protection that does exist while the band moves back.
+  const outsideBand = percentPriceBySideRefusal({
+    symbol,
+    reference: input.market.currentPrice,
+    band: input.market.symbolInfo.filters.percentPriceBySide,
+    desired,
+    guarded: stillGuarding(resting, desired.quantity),
+  });
+  if (outsideBand !== null) return { decisions: [], blocker: outsideBand };
+
+  if (resting === undefined) return { decisions: [buildPlace(desired, false)], blocker: null };
   // Our own stop is cancelled in the same batch, so the base it locks is released
   // before the replacement is sent: no funding check is owed here.
   return { decisions: [buildCancel(resting), buildPlace(desired, true)], blocker: null };

--- a/packages/strategy/momentum/__tests__/attribution.test.ts
+++ b/packages/strategy/momentum/__tests__/attribution.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import { PROTECTIVE_STOP_BLOCKER_REASONS } from '@app/strategy-core';
 import type { ReasonKind } from '@app/strategy-core';
 import { momentumReasonAttribution } from '../src/attribution.js';
 
 // Momentum owns the reason-code -> gloss/kind map so the web names the levers off
 // the strategy's own declaration (invariant #1), never a hardcoded web copy. Every
 // entry-suppression reason the pure tick can emit must have a legible entry here.
-const REASON_CODES = [
+const ENTRY_REASON_CODES = [
   'already-entered-this-candle',
   'insufficient-history',
   'below-trend',
@@ -17,16 +18,19 @@ const REASON_CODES = [
   'invalid-filters',
   'overextended',
   'extension-insufficient-history',
-  // Not an entry suppression: an OPEN position whose protective stop the strategy
-  // refused to place. It rides the same reason-code map because it is glossed the
-  // same way, and the tick emits it as a `momentum.skip` with this reason.
-  'base-locked-by-foreign-order',
 ] as const;
+
+// Not entry suppressions: an OPEN position whose protective stop the strategy
+// refused to place or re-price. They ride the same reason-code map because they
+// gloss the same way, and the tick emits each as a `momentum.skip`. Taken from
+// the core vocabulary rather than copied, so a new blocker reason fails here
+// until it is glossed instead of reaching the operator as a bare kebab code.
+const REASON_CODES = [...ENTRY_REASON_CODES, ...PROTECTIVE_STOP_BLOCKER_REASONS] as const;
 
 const KINDS: readonly ReasonKind[] = ['market', 'config', 'sizing', 'data'];
 
 describe('momentumReasonAttribution', () => {
-  it('covers every one of the twelve suppression reason codes', () => {
+  it('covers every suppression and protective-stop reason code', () => {
     for (const code of REASON_CODES) {
       expect(momentumReasonAttribution[code], code).toBeDefined();
     }

--- a/packages/strategy/momentum/__tests__/momentum.test.ts
+++ b/packages/strategy/momentum/__tests__/momentum.test.ts
@@ -2295,6 +2295,38 @@ describe('protective stop — a foreign resting SELL holding the base', () => {
     expect(out.nextState.entryBlocker).toBeNull();
   });
 
+  it('logs a stop still covered at its previous level at info, not warn', () => {
+    // The exchange band refuses the re-price while our own stop keeps resting at
+    // the old trigger, so the position IS covered. A winning trail can sit
+    // outside the band for hours; warning every tick through it is how the real
+    // "no stop at all" warning gets skimmed past.
+    const out = momentum.tick(
+      armInput({
+        openOrders: [psOrder({ stopPrice: '80.00' })],
+        filters: {
+          ...FILTERS,
+          percentPriceBySide: {
+            askMultiplierUp: '5',
+            askMultiplierDown: '0.99',
+            bidMultiplierUp: '5',
+            bidMultiplierDown: '0.2',
+            avgPriceMins: 5,
+          },
+        },
+      }),
+    );
+    // Neither half of the re-arm goes out, and the resting stop is left alone.
+    expect(out.decisions).toEqual([{ type: 'noop' }]);
+    expect(out.nextState.protectiveStopBlocker).toMatchObject({
+      reason: 'price-outside-exchange-band',
+      detail: { guarded: true },
+    });
+    expect(out.logs[0]).toMatchObject({
+      level: 'info',
+      message: 'momentum: protective stop held at its previous level',
+    });
+  });
+
   it('clears the blocker on the tick the stop finally arms', () => {
     const blocked = longState({
       protectiveStopBlocker: { reason: 'base-locked-by-foreign-order' },

--- a/packages/strategy/momentum/__tests__/momentum.test.ts
+++ b/packages/strategy/momentum/__tests__/momentum.test.ts
@@ -2321,10 +2321,20 @@ describe('protective stop — a foreign resting SELL holding the base', () => {
       reason: 'price-outside-exchange-band',
       detail: { guarded: true },
     });
-    expect(out.logs[0]).toMatchObject({
-      level: 'info',
-      message: 'momentum: protective stop held at its previous level',
-    });
+    // The WHOLE array, not `logs[0]`: the point of the branch is that no warn
+    // is emitted, and indexing the first entry would still pass if a second one
+    // arrived carrying it.
+    expect(out.logs).toEqual([
+      {
+        level: 'info',
+        message: 'momentum: protective stop held at its previous level',
+        context: expect.objectContaining({
+          symbol: 'BTCUSDT',
+          reason: 'price-outside-exchange-band',
+          guarded: true,
+        }),
+      },
+    ]);
   });
 
   it('clears the blocker on the tick the stop finally arms', () => {

--- a/packages/strategy/momentum/src/attribution.ts
+++ b/packages/strategy/momentum/src/attribution.ts
@@ -102,4 +102,18 @@ export const momentumReasonAttribution: ReasonAttribution = {
     gloss: 'Too few coins are free to meet the exchange minimum for a protective stop',
     kind: 'sizing',
   },
+  // Carries a lever because one shape of this refusal never clears on its own: a
+  // limit offset at or under the symbol's floor multiplier puts the order under
+  // the band at every possible price.
+  'price-outside-exchange-band': {
+    setting: 'Protective stop limit offset',
+    paths: ['protectiveStop.limitOffsetPercentage'],
+    // The map is keyed on the reason code alone and cannot see whether this
+    // refusal is the permanent shape, so the gloss says which one the lever
+    // answers. Raising the offset when the market is merely moving fast buys
+    // nothing and narrows the gap the stop needs to fill in a fast drop.
+    gloss:
+      'Binance will not accept a protective stop at this price yet; the limit offset is at fault only when the symbol marks the refusal permanent',
+    kind: 'sizing',
+  },
 };

--- a/packages/strategy/momentum/src/schema.ts
+++ b/packages/strategy/momentum/src/schema.ts
@@ -528,6 +528,7 @@ export const MomentumStateSchema = z.object({
         'base-locked-by-foreign-order',
         'base-below-exchange-minimum',
         'base-short-of-tracked-position',
+        'price-outside-exchange-band',
       ]),
       detail: z.record(z.string(), z.unknown()).optional(),
     })

--- a/packages/strategy/momentum/src/tick.ts
+++ b/packages/strategy/momentum/src/tick.ts
@@ -526,12 +526,21 @@ const evaluateExit = (
             }),
           ]
         : [
-            // An open position with no protective stop is not a debug detail.
-            log('warn', 'momentum: protective stop not armed', {
-              symbol: market.symbol,
-              reason: arm.blocker.reason,
-              ...arm.blocker.detail,
-            }),
+            // An open position with no protective stop is not a debug detail. One
+            // still covered by the previous level is a different, quieter fact:
+            // logging it at warn every tick, for as long as a winning trail sits
+            // outside the band, is how the real warning gets skimmed past.
+            arm.blocker.detail['guarded'] === true
+              ? log('info', 'momentum: protective stop held at its previous level', {
+                  symbol: market.symbol,
+                  reason: arm.blocker.reason,
+                  ...arm.blocker.detail,
+                })
+              : log('warn', 'momentum: protective stop not armed', {
+                  symbol: market.symbol,
+                  reason: arm.blocker.reason,
+                  ...arm.blocker.detail,
+                }),
           ],
     // The refusal is a SKIP with a reason, like every entry suppression: that is
     // what makes it queryable and what gives the attribution gloss a consumer.

--- a/packages/strategy/trailing-trade/__tests__/protective-stop.test.ts
+++ b/packages/strategy/trailing-trade/__tests__/protective-stop.test.ts
@@ -7,12 +7,13 @@
 
 import { describe, expect, it } from 'vitest';
 import { Decimal } from '@app/money';
-import type { Decision, OpenOrder, TickInput } from '@app/strategy-core';
+import type { Decision, OpenOrder, PercentPriceBySideFilter, TickInput } from '@app/strategy-core';
 
 import {
   trailingTrade,
   TTConfigSchema,
   TTBundleSchema,
+  TTStateSchema,
   type TTState,
   type TTBundle,
   type TTConfig,
@@ -45,6 +46,7 @@ interface BuildOpts {
   readonly openOrders?: readonly OpenOrder[];
   readonly tickSize?: string;
   readonly stepSize?: string;
+  readonly percentPriceBySide?: PercentPriceBySideFilter;
   // Sell-side trigger / technicals / regime knobs needed to drive each closing
   // path to its terminal MARKET sell in the ordering tests below.
   readonly technicals?: TechnicalsConfig;
@@ -146,6 +148,7 @@ const buildInput = (o: BuildOpts = {}): TickInput<TTConfig, TTState, TTBundle> =
           maxQty: '9000',
           minPrice: '0.01',
           maxPrice: '1000000',
+          ...(o.percentPriceBySide ? { percentPriceBySide: o.percentPriceBySide } : {}),
         },
       },
     },
@@ -987,5 +990,58 @@ describe('closing-sell ordering — cancel precedes the MARKET sell', () => {
     // A BUY adds exposure; the stop stays correctly in place ⇒ no cancel.
     expect(out.decisions.some(isCancel)).toBe(false);
     expect(out.decisions.some((d) => isPlace(d) && d.intent.side === 'BUY')).toBe(true);
+  });
+});
+
+describe('protective stop — outside Binance’s PERCENT_PRICE_BY_SIDE band', () => {
+  const BAND: PercentPriceBySideFilter = {
+    bidMultiplierUp: '1.1',
+    bidMultiplierDown: '0.5',
+    askMultiplierUp: '2',
+    askMultiplierDown: '0.95',
+    avgPriceMins: 5,
+  };
+
+  it('emits neither the place nor the cancel and records the refusal', () => {
+    // stop 96.00 / limit 95.52 against a floor of 105 × 0.95 = 99.75.
+    const out = trailingTrade.tick(
+      buildInput({
+        percentPriceBySide: BAND,
+        openOrders: [restingProtectiveStop({ stopPrice: '80.00' })],
+      }),
+    );
+    expect(out.decisions.some(isCancel)).toBe(false);
+    expect(out.decisions.some((d) => isPlace(d) && d.intent.reason === 'protective-stop')).toBe(
+      false,
+    );
+    expect(blockerOf(out.nextState)).toMatchObject({
+      reason: 'price-outside-exchange-band',
+      detail: { stopPrice: '96.00', price: '95.52', floor: '99.75', terminal: false },
+    });
+  });
+
+  it('round-trips the new blocker through the persisted-state schema', () => {
+    // The blocker is written to `symbol_states` and re-parsed on the next tick's
+    // load: a reason the schema does not know reads back as a corrupt row.
+    const blocked = trailingTrade.tick(
+      buildInput({
+        percentPriceBySide: BAND,
+        openOrders: [restingProtectiveStop({ stopPrice: '80.00' })],
+      }),
+    ).nextState;
+
+    const reloaded = TTStateSchema.parse(JSON.parse(JSON.stringify(blocked)));
+
+    expect(reloaded.protectiveStopBlocker?.reason).toBe('price-outside-exchange-band');
+  });
+
+  it('arms unchanged on a symbol Binance publishes no band for', () => {
+    const out = trailingTrade.tick(
+      buildInput({ openOrders: [restingProtectiveStop({ stopPrice: '80.00' })] }),
+    );
+    expect(blockerOf(out.nextState)).toBeNull();
+    expect(out.decisions.some((d) => isPlace(d) && d.intent.reason === 'protective-stop')).toBe(
+      true,
+    );
   });
 });

--- a/packages/strategy/trailing-trade/src/schema.ts
+++ b/packages/strategy/trailing-trade/src/schema.ts
@@ -1593,6 +1593,7 @@ export const TTStateSchema = z.object({
         'base-locked-by-foreign-order',
         'base-below-exchange-minimum',
         'base-short-of-tracked-position',
+        'price-outside-exchange-band',
       ]),
       detail: z.record(z.string(), z.unknown()).optional(),
     })


### PR DESCRIPTION
## Problem

Binance enforces a `PERCENT_PRICE_BY_SIDE` filter: a SELL order's price must sit inside a band around the current market price. When a winning trail ratchets the desired stop level up faster than the market moves, the re-arm is refused by the exchange — but the **previous resting stop is still on the book and still protecting the position**.

Today the strategy reports that refusal exactly like a naked position: `protective stop not armed`, at `warn`, on every tick, for as long as the trail sits outside the band. Two problems follow:

- The operator cannot tell "still covered by the previous level" from "no downside protection at all".
- The genuinely urgent case gets buried under a repeating warning for a position that is, in fact, guarded.

## Change

- Adds a fourth `ProtectiveStopBlockerReason`: `price-outside-exchange-band`, so the exchange-band refusal is its own fact rather than being folded into an existing reason.
- Adds a `guarded` detail on the blocker, set from whether a resting stop still covers the tracked quantity.
- Splits the log accordingly: a guarded refusal logs `info: protective stop held at its previous level`; only a genuinely unguarded position logs `warn: protective stop not armed`.
- Carries the reason through the places that already speak this vocabulary — the strategy contract, both strategy schemas, the attribution reason-code map, the symbol-filter parsing for `PERCENT_PRICE_BY_SIDE`, the web gloss, the dashboard symbol status and i18n.

The blocker is surfaced, not acted on: it never gates an entry, and the position is already open. It clears itself on the tick the stop arms.

## Notes for review

- `PROTECTIVE_STOP_BLOCKER_REASONS` is the single vocabulary both strategies gloss from, so widening it required the matching enum member in each strategy's state schema. Both are additive with `.default(null)`, so no state version bump.
- The dashboard's `unprotected` status still outranks the other statuses; a guarded refusal does not raise it.

## Verification

| gate | result |
|---|---|
| `bun run typecheck` | 42/42 tasks successful |
| `bun run lint` | clean |
| `bun run test` | 42/42 tasks successful |
| `bun run docs:build` | config tables up to date, mkdocs `--strict` OK |
| `bun run test:replay` | trailing-trade 22 passed, momentum 5 passed |

Golden-fixture replay diff is 0 for both strategies, so no existing decision path changed behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6PoVkvJPuHLpWLkA8YWjQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Protective stops now respect exchange price bands, preventing invalid replacements or cancellations.
  - Dashboard statuses distinguish stale but still protective stops from unprotected positions.
  - Added clearer explanations for price-band limits, averaging windows, retryable issues, and terminal configuration problems.

- **Bug Fixes**
  - Existing protection remains in place when replacement prices are rejected.
  - Cached or incomplete price-band data is handled safely.
  - Protective-stop blockers now provide clearer operator guidance and warning messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->