### PR TITLE
test(typecheck): type-check the worker and binance __tests__ surface

### DIFF
--- a/apps/worker/__tests__/audit-shipper/audit-shipper.test.ts
+++ b/apps/worker/__tests__/audit-shipper/audit-shipper.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ProfileId, UserId } from '@app/contracts';
+import type { AccountId, ProfileId } from '@app/contracts';
 import {
   AUDIT_CONSUMER_LAG_ALERT,
   AUDIT_DRAINER_CONSUMER,
@@ -48,7 +48,7 @@ const stubLogger = {
 } as unknown as Parameters<typeof createAuditShipper>[0]['logger'];
 
 const baseEntry: AuditEntry = {
-  userId: 'u_1' as unknown as UserId,
+  accountId: 'u_1' as unknown as AccountId,
   profileId: 'p_1' as unknown as ProfileId,
   tickId: '00000000-0000-4000-8000-000000000793',
   ts: 1_700_000_000_000,
@@ -62,7 +62,17 @@ const baseEntry: AuditEntry = {
 
 describe('audit shipper publish', () => {
   it('forwards an XADD with MAXLEN ~ AUDIT_STREAM_MAXLEN', async () => {
-    const xadd = vi.fn(async () => '0-0');
+    const xadd = vi.fn<
+      (
+        key: string,
+        trim: 'MAXLEN',
+        approximate: '~',
+        maxlen: string,
+        id: '*',
+        field: 'body',
+        body: string,
+      ) => Promise<string>
+    >(async () => '0-0');
     const redis = { xadd, xlen: vi.fn() } as unknown as Parameters<
       typeof createAuditShipper
     >[0]['redis'];
@@ -106,7 +116,7 @@ describe('audit shipper publish', () => {
     const shipper = createAuditShipper({ redis, logger: stubLogger });
 
     const len = await shipper.streamLength(
-      'u_1' as unknown as UserId,
+      'u_1' as unknown as AccountId,
       'p_1' as unknown as ProfileId,
     );
     expect(len).toBe(42);
@@ -1501,7 +1511,7 @@ describe('drainOnce PEL reclaim (#781)', () => {
   // for a batch of N are the same counter movement, and nothing here has an
   // opinion on the round-trip shape.
   const stuckTotal = (record: ReturnType<typeof vi.fn>): number =>
-    incidentRecords(record, 'audit_entries_stuck').reduce(
+    incidentRecords(record, 'audit_entries_stuck').reduce<number>(
       (sum, c) => sum + ((c as unknown[])[1] as number),
       0,
     );

--- a/apps/worker/__tests__/audit-shipper/audit-to-action-log.test.ts
+++ b/apps/worker/__tests__/audit-shipper/audit-to-action-log.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { asProfileId, asUserId } from '@app/contracts';
+import { asAccountId, asProfileId } from '@app/contracts';
 import type { AuditEntry } from '../../src/audit-shipper/audit-shipper.js';
 import {
   auditEntriesToActionLogs,
@@ -7,7 +7,7 @@ import {
 } from '../../src/audit-shipper/audit-to-action-log.js';
 
 const entry = (over: Partial<AuditEntry> = {}): AuditEntry => ({
-  userId: asUserId('11111111-1111-1111-1111-111111111111'),
+  accountId: asAccountId('11111111-1111-1111-1111-111111111111'),
   profileId: asProfileId('22222222-2222-2222-2222-222222222222'),
   tickId: '00000000-0000-4000-8000-000000000793',
   ts: 1_700_000_000_000,

--- a/apps/worker/__tests__/backtest/backtest-cancel.test.ts
+++ b/apps/worker/__tests__/backtest/backtest-cancel.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import pino from 'pino';
 
+type GetRange = typeof import('@app/db').repo.candles.getRange;
+
 // Mock the engine so onProgress is driven without a real replay; the runner's
 // wrapper probes shouldCancel first and throws on cancellation. Candle backfill
 // and the Postgres reads are mocked away so the test exercises only the
@@ -18,7 +20,7 @@ vi.mock('../../src/backtest/candle-backfill.js', () => ({
 const repoMocks = vi.hoisted(() => ({
   findGaps: vi.fn(async () => []),
   insertNew: vi.fn(async () => undefined),
-  getRange: vi.fn(async () => []),
+  getRange: vi.fn<GetRange>(async () => []),
 }));
 vi.mock('@app/db', async (importOriginal) => {
   const orig = await importOriginal<typeof import('@app/db')>();
@@ -42,6 +44,8 @@ const { runProfileBacktest, BacktestCancelledError } =
 const silentLogger = pino({ level: 'silent' });
 
 const candleRow = (i: number) => ({
+  symbol: 'BTCUSDT',
+  interval: '1h',
   openTime: new Date(i * 3_600_000),
   closeTime: new Date(i * 3_600_000 + 3_599_999),
   open: '100',

--- a/apps/worker/__tests__/backtest/discovery-mode.test.ts
+++ b/apps/worker/__tests__/backtest/discovery-mode.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import pino from 'pino';
 
+type GetRange = typeof import('@app/db').repo.candles.getRange;
+
 // Scope: this test proves the RUNNER WIRING only — that `runProfileBacktest`
 // threads `params.discoveryMode` into `buildBundle`, which arms the
 // `entryHint.enterOnAdd` seam (the same key the live worker's bundle-builder
@@ -25,7 +27,7 @@ vi.mock('../../src/backtest/candle-backfill.js', () => ({
 const repoMocks = vi.hoisted(() => ({
   findGaps: vi.fn(async () => []),
   insertNew: vi.fn(async () => undefined),
-  getRange: vi.fn(async () => []),
+  getRange: vi.fn<GetRange>(async () => []),
 }));
 vi.mock('@app/db', async (importOriginal) => {
   const orig = await importOriginal<typeof import('@app/db')>();
@@ -52,6 +54,8 @@ const HOUR = 3_600_000;
 // A flat candle row; 230 of them satisfy the runner's warm-up floor so it
 // reaches runBacktest (where our mock captures the bundle callback).
 const candleRow = (i: number) => ({
+  symbol: 'BTCUSDT',
+  interval: '1h',
   openTime: new Date(i * HOUR),
   closeTime: new Date(i * HOUR + (HOUR - 1)),
   open: '100',

--- a/apps/worker/__tests__/backtest/interval-from-config.test.ts
+++ b/apps/worker/__tests__/backtest/interval-from-config.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import pino from 'pino';
 
+type GetRange = typeof import('@app/db').repo.candles.getRange;
+
 // Scope: proves the runner streams the strategy's OWN decision interval
 // (`config.candleInterval`) — the same field the live worker keys its feed off
 // (`feedIntervals(candleInterval)` / tick-context) — and NOT a separate
@@ -22,7 +24,7 @@ vi.mock('../../src/backtest/candle-backfill.js', () => ({
 const repoMocks = vi.hoisted(() => ({
   findGaps: vi.fn(async () => []),
   insertNew: vi.fn(async () => undefined),
-  getRange: vi.fn(async () => []),
+  getRange: vi.fn<GetRange>(async () => []),
 }));
 vi.mock('@app/db', async (importOriginal) => {
   const orig = await importOriginal<typeof import('@app/db')>();
@@ -48,6 +50,8 @@ const silentLogger = pino({ level: 'silent' });
 const FIVE_MIN = 300_000;
 
 const candleRow = (i: number) => ({
+  symbol: 'BTCUSDT',
+  interval: '5m',
   openTime: new Date(i * FIVE_MIN),
   closeTime: new Date(i * FIVE_MIN + (FIVE_MIN - 1)),
   open: '100',

--- a/apps/worker/__tests__/boot/builders/audit.test.ts
+++ b/apps/worker/__tests__/boot/builders/audit.test.ts
@@ -165,7 +165,10 @@ describe('auditPersistBatch', () => {
     );
     vi.spyOn(repo.actionLogs, 'insertMany').mockRejectedValue(drizzleErr);
 
-    const thrown = await auditPersistBatch(fakeDb())([entry(['place-order'])]).catch(
+    const thrown = await auditPersistBatch(fakeDb())([entry(['place-order'])]).then(
+      () => {
+        throw new Error('expected the batch to reject');
+      },
       (e: unknown) => e as Error,
     );
 
@@ -194,7 +197,10 @@ describe('auditPersistBatch', () => {
     vi.spyOn(repo.actionLogs, 'insertMany').mockRejectedValue(
       Object.assign(new Error('null value in column "symbol"'), { code: '23502' }),
     );
-    const thrown = await auditPersistBatch(fakeDb())([entry(['place-order'])]).catch(
+    const thrown = await auditPersistBatch(fakeDb())([entry(['place-order'])]).then(
+      () => {
+        throw new Error('expected the batch to reject');
+      },
       (e: unknown) => e as Error,
     );
     expect(thrown.message).toContain('sqlstate 23502');
@@ -203,7 +209,10 @@ describe('auditPersistBatch', () => {
 
   it('reports an unclassifiable rejection as unknown, leaving the gate to fail closed', async () => {
     vi.spyOn(repo.actionLogs, 'insertMany').mockRejectedValue(new Error('socket hang up'));
-    const thrown = await auditPersistBatch(fakeDb())([entry(['place-order'])]).catch(
+    const thrown = await auditPersistBatch(fakeDb())([entry(['place-order'])]).then(
+      () => {
+        throw new Error('expected the batch to reject');
+      },
       (e: unknown) => e as Error,
     );
     expect(thrown.message).toContain('sqlstate unknown');

--- a/apps/worker/__tests__/boot/builders/tick-handler-override-deps.test.ts
+++ b/apps/worker/__tests__/boot/builders/tick-handler-override-deps.test.ts
@@ -129,7 +129,7 @@ describe('buildTickHandler — override row claim deps', () => {
     // Stamping `processing_at` is what makes the row undeletable by the cancel route,
     // and it stamps the CALLER's value: a database-side `now()` would leave the tick
     // unable to name the stamp its release has to be fenced on.
-    expect(updates[0]?.values.processingAt).toBe(CLAIM_AT);
+    expect(updates[0]?.values['processingAt']).toBe(CLAIM_AT);
   });
 
   it('reports a lost claim rather than swallowing it', async () => {

--- a/apps/worker/__tests__/boot/log-err-serializer.test.ts
+++ b/apps/worker/__tests__/boot/log-err-serializer.test.ts
@@ -10,7 +10,7 @@ class CaptureStream extends Writable implements DestinationStream {
     this.buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
     cb();
   }
-  write(chunk: Buffer | string): boolean {
+  override write(chunk: Buffer | string): boolean {
     this.buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
     return true;
   }
@@ -51,7 +51,7 @@ describe('worker logger err serializer', () => {
     const out = new CaptureStream();
     const logger = buildLogger('debug', out);
     logger.error({ err: new Error('boom') }, 'x');
-    const err = lastLine(out).err as { stack?: unknown; message?: unknown };
+    const err = lastLine(out)['err'] as { stack?: unknown; message?: unknown };
     expect(typeof err.stack).toBe('string');
     expect(err.stack as string).toContain('boom');
     expect(err.message).toBe('boom');
@@ -61,7 +61,7 @@ describe('worker logger err serializer', () => {
     const out = new CaptureStream();
     const logger = buildLogger('debug', out);
     expect(() => logger.error({ err: { code: -1013 } }, 'x')).not.toThrow();
-    expect(lastLine(out).err).toEqual({ code: -1013 });
+    expect(lastLine(out)['err']).toEqual({ code: -1013 });
   });
 
   it('logs a failed api-keys write without its bound secret', () => {
@@ -110,7 +110,7 @@ describe('worker logger err serializer', () => {
     const logger = buildLogger('debug', out);
     logger.error({ err: drizzleQueryError(API_KEY_INSERT, ['acct-1', SECRET, 'sec']) }, 'x');
 
-    expect(lastLine(out).err).not.toHaveProperty('raw');
+    expect(lastLine(out)['err']).not.toHaveProperty('raw');
     expect(lastRawLine(out)).not.toContain('"raw"');
   });
 });

--- a/apps/worker/__tests__/boot/metrics-sink.test.ts
+++ b/apps/worker/__tests__/boot/metrics-sink.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 import { createMetricsRegistry } from '@app/observability';
 
 import { createWorkerMetricsSink } from '../../src/boot/metrics-sink.js';
+import type { MetricName } from '../../src/metrics/catalog.js';
 
 const setUp = (): {
   registry: ReturnType<typeof createMetricsRegistry>;
@@ -71,7 +72,10 @@ describe('createWorkerMetricsSink', () => {
 
   it('drops an unlisted metric name without throwing or registering a series', async () => {
     const { registry, sink } = setUp();
-    expect(() => sink.record('totally_unknown_metric', 1, { profileId: 'p1' })).not.toThrow();
+    // The catalogue closes `MetricName`, so this call is unreachable through the type. The cast is the point of the case: it reproduces what a JS caller or a stale build would do, and asserts the adapter drops it rather than throwing.
+    expect(() =>
+      sink.record('totally_unknown_metric' as MetricName, 1, { profileId: 'p1' }),
+    ).not.toThrow();
     const body = await registry.metrics();
     expect(body).not.toContain('totally_unknown_metric');
   });

--- a/apps/worker/__tests__/boot/reap-stale-orders.test.ts
+++ b/apps/worker/__tests__/boot/reap-stale-orders.test.ts
@@ -202,7 +202,11 @@ describe('reconcileMissingOrder', () => {
 
   it('reaps as CANCELED when getOrder reports the order never existed (-2013)', async () => {
     const { run, reapWithReason } = setup(async () => {
-      throw new BinanceApiError({ status: 400, code: -2013, msg: 'Order does not exist.' }, false);
+      throw new BinanceApiError(
+        { status: 400, code: -2013, msg: 'Order does not exist.' },
+        false,
+        'rejected',
+      );
     });
     await expect(run()).resolves.toBe('reaped');
     expect(reapWithReason).toHaveBeenCalledWith(3478655619n, 'CANCELED', 'reaped-not-on-exchange');
@@ -210,7 +214,11 @@ describe('reconcileMissingOrder', () => {
 
   it('leaves the row live on a transient getOrder failure — never stamps CANCELED on a flaky read', async () => {
     const { run, markFilledByBinanceOrderId, reapWithReason } = setup(async () => {
-      throw new BinanceApiError({ status: 500, code: -1001, msg: 'Internal error.' }, true);
+      throw new BinanceApiError(
+        { status: 500, code: -1001, msg: 'Internal error.' },
+        true,
+        'ambiguous',
+      );
     });
     await expect(run()).resolves.toBe('skipped');
     expect(markFilledByBinanceOrderId).not.toHaveBeenCalled();
@@ -248,6 +256,7 @@ describe('reconcileMissingOrder', () => {
         throw new BinanceApiError(
           { status: 400, code: -2013, msg: 'Order does not exist.' },
           false,
+          'rejected',
         );
       },
       { reapReturns: 0 },

--- a/apps/worker/__tests__/boot/run-backtest-job.test.ts
+++ b/apps/worker/__tests__/boot/run-backtest-job.test.ts
@@ -43,6 +43,7 @@ const VALID_PARAMS = {
 
 const RUN_ID = 'run-1';
 const USER_ID = '11111111-1111-4111-8111-111111111111';
+const ACCOUNT_ID = '33333333-3333-4333-8333-333333333333';
 const PROFILE_ID = '22222222-2222-4222-8222-222222222222';
 
 const aProfile = (overrides: Record<string, unknown> = {}) => ({
@@ -71,7 +72,7 @@ const buildDeps = (overrides: Record<string, unknown> = {}) =>
   }) as never;
 
 const invoke = (deps = buildDeps()) =>
-  createRunBacktestJob(deps)(RUN_ID, USER_ID, PROFILE_ID, vi.fn(), () => false);
+  createRunBacktestJob(deps)(RUN_ID, USER_ID, ACCOUNT_ID, PROFILE_ID, vi.fn(), () => false);
 
 beforeEach(() => {
   getRun.mockReset();

--- a/apps/worker/__tests__/crons/account-snapshot.test.ts
+++ b/apps/worker/__tests__/crons/account-snapshot.test.ts
@@ -5,13 +5,13 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import type { Redis } from 'ioredis';
-import { asProfileId, asUserId } from '@app/contracts';
+import { asAccountId, asProfileId } from '@app/contracts';
 
 import { createAccountSnapshotStore } from '../../src/crons/account-snapshot.js';
 import { parseAccountSnapshot } from '../../src/tick/snapshot-loader.js';
 import { Decimal } from '@app/money';
 
-const u = asUserId('u1');
+const a = asAccountId('u1');
 const p = asProfileId('p1');
 
 describe('createAccountSnapshotStore — persistAccount', () => {
@@ -25,7 +25,7 @@ describe('createAccountSnapshotStore — persistAccount', () => {
       get: vi.fn(async () => null),
     } as unknown as Redis;
 
-    await createAccountSnapshotStore(redis).persistAccount(u, p, [
+    await createAccountSnapshotStore(redis).persistAccount(a, p, [
       { asset: 'BTC', free: '0.5', locked: '0.1' },
       { asset: 'USDT', free: '100', locked: '0' },
     ]);
@@ -52,10 +52,12 @@ describe('createAccountSnapshotStore — persistAccount', () => {
   });
 
   it('writes the account-info key with a bounded TTL', async () => {
-    const set = vi.fn(async () => 'OK');
+    const set = vi.fn(
+      async (_key: string, _value: string, _mode: 'EX', _ttl: number) => 'OK' as const,
+    );
     const redis = { set, get: vi.fn(async () => null) } as unknown as Redis;
 
-    await createAccountSnapshotStore(redis).persistAccount(u, p, []);
+    await createAccountSnapshotStore(redis).persistAccount(a, p, []);
 
     const call = set.mock.calls[0] ?? [];
     expect(call[0]).toBe('tenant:u1:profile:p1:account-info');
@@ -82,7 +84,7 @@ describe('createAccountSnapshotStore — mergeAccount', () => {
       }),
     } as unknown as Redis;
 
-    await createAccountSnapshotStore(redis).mergeAccount(u, p, [
+    await createAccountSnapshotStore(redis).mergeAccount(a, p, [
       { asset: 'USDT', free: '42', locked: '5' },
     ]);
 
@@ -110,7 +112,7 @@ describe('createAccountSnapshotStore — mergeAccount', () => {
       }),
     } as unknown as Redis;
 
-    await createAccountSnapshotStore(redis).mergeAccount(u, p, [
+    await createAccountSnapshotStore(redis).mergeAccount(a, p, [
       { asset: 'TAO', free: '0', locked: '0' },
     ]);
 
@@ -121,13 +123,15 @@ describe('createAccountSnapshotStore — mergeAccount', () => {
   });
 
   it('writes the merged key with the same bounded TTL', async () => {
-    const set = vi.fn(async () => 'OK');
+    const set = vi.fn(
+      async (_key: string, _value: string, _mode: 'EX', _ttl: number) => 'OK' as const,
+    );
     const redis = {
       get: vi.fn(async () => JSON.stringify({ balances: { BTC: { free: '1', locked: '0' } } })),
       set,
     } as unknown as Redis;
 
-    await createAccountSnapshotStore(redis).mergeAccount(u, p, []);
+    await createAccountSnapshotStore(redis).mergeAccount(a, p, []);
 
     const call = set.mock.calls[0] ?? [];
     expect(call[0]).toBe('tenant:u1:profile:p1:account-info');
@@ -145,7 +149,9 @@ describe('createAccountSnapshotStore — mergeAccount', () => {
 // know"), which the sizing paths fail open on and the cron repairs.
 describe('createAccountSnapshotStore — mergeAccount refuses to write a truncated snapshot', () => {
   const storeOver = (existing: string | null) => {
-    const set = vi.fn(async () => 'OK');
+    const set = vi.fn(
+      async (_key: string, _value: string, _mode: 'EX', _ttl: number) => 'OK' as const,
+    );
     const store = createAccountSnapshotStore({
       get: vi.fn(async () => existing),
       set,
@@ -155,25 +161,25 @@ describe('createAccountSnapshotStore — mergeAccount refuses to write a truncat
 
   it('does not write when no snapshot exists yet (cold cache)', async () => {
     const { set, store } = storeOver(null);
-    await store.mergeAccount(u, p, [{ asset: 'BTC', free: '1', locked: '0' }]);
+    await store.mergeAccount(a, p, [{ asset: 'BTC', free: '1', locked: '0' }]);
     expect(set).not.toHaveBeenCalled();
   });
 
   it('does not write when the existing snapshot is malformed JSON', async () => {
     const { set, store } = storeOver('not-json');
-    await store.mergeAccount(u, p, [{ asset: 'ETH', free: '2', locked: '0' }]);
+    await store.mergeAccount(a, p, [{ asset: 'ETH', free: '2', locked: '0' }]);
     expect(set).not.toHaveBeenCalled();
   });
 
   it('does not write when the existing snapshot has a non-object balances shape', async () => {
     const { set, store } = storeOver(JSON.stringify({ balances: [] }));
-    await store.mergeAccount(u, p, [{ asset: 'ADA', free: '3', locked: '0' }]);
+    await store.mergeAccount(a, p, [{ asset: 'ADA', free: '3', locked: '0' }]);
     expect(set).not.toHaveBeenCalled();
   });
 
   it('does not write when the existing snapshot has no balances key at all', async () => {
     const { set, store } = storeOver(JSON.stringify({ somethingElse: 1 }));
-    await store.mergeAccount(u, p, [{ asset: 'ADA', free: '3', locked: '0' }]);
+    await store.mergeAccount(a, p, [{ asset: 'ADA', free: '3', locked: '0' }]);
     expect(set).not.toHaveBeenCalled();
   });
 
@@ -181,7 +187,7 @@ describe('createAccountSnapshotStore — mergeAccount refuses to write a truncat
     const { set, store } = storeOver(
       JSON.stringify({ balances: { BTC: { free: '1', locked: '0' } } }),
     );
-    await store.mergeAccount(u, p, [{ asset: 'USDT', free: '9', locked: '0' }]);
+    await store.mergeAccount(a, p, [{ asset: 'USDT', free: '9', locked: '0' }]);
     expect(set).toHaveBeenCalledTimes(1);
     expect(parseAccountSnapshot(set.mock.calls[0]?.[1] as unknown as string)).toEqual({
       balances: {
@@ -201,15 +207,15 @@ describe('createAccountSnapshotStore — lastWsEventMs', () => {
     } as unknown as Redis);
 
   it('returns the stamped epoch-ms when the marker is present', async () => {
-    expect(await storeWith('1700000000000').lastWsEventMs(u, p)).toBe(1_700_000_000_000);
+    expect(await storeWith('1700000000000').lastWsEventMs(a, p)).toBe(1_700_000_000_000);
   });
 
   it('returns null when the marker is absent', async () => {
-    expect(await storeWith(null).lastWsEventMs(u, p)).toBeNull();
+    expect(await storeWith(null).lastWsEventMs(a, p)).toBeNull();
   });
 
   it('returns null when the marker is non-numeric (corrupt key)', async () => {
-    expect(await storeWith('not-a-number').lastWsEventMs(u, p)).toBeNull();
+    expect(await storeWith('not-a-number').lastWsEventMs(a, p)).toBeNull();
   });
 });
 
@@ -222,16 +228,16 @@ describe('createAccountSnapshotStore — accountInfoExists', () => {
     } as unknown as Redis);
 
   it('checks presence of the account-info key', async () => {
-    const exists = vi.fn(async () => 1);
-    await createAccountSnapshotStore({ exists } as unknown as Redis).accountInfoExists(u, p);
+    const exists = vi.fn(async (_key: string) => 1);
+    await createAccountSnapshotStore({ exists } as unknown as Redis).accountInfoExists(a, p);
     expect(exists).toHaveBeenCalledWith('tenant:u1:profile:p1:account-info');
   });
 
   it('returns true when the key exists', async () => {
-    expect(await storeWithExists(1).accountInfoExists(u, p)).toBe(true);
+    expect(await storeWithExists(1).accountInfoExists(a, p)).toBe(true);
   });
 
   it('returns false when the key is absent (expired)', async () => {
-    expect(await storeWithExists(0).accountInfoExists(u, p)).toBe(false);
+    expect(await storeWithExists(0).accountInfoExists(a, p)).toBe(false);
   });
 });

--- a/apps/worker/__tests__/crons/alive-digest.test.ts
+++ b/apps/worker/__tests__/crons/alive-digest.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import type { Logger } from 'pino';
-import type { NotifyProviderRegistry } from '@app/notify';
+import type { AnyNotifyProvider, NotifyProviderRegistry } from '@app/notify';
 
 import { createAliveDigest } from '../../src/crons/alive-digest.js';
 import type { NotifierRowInput } from '../../src/notifiers/lookup.js';
@@ -43,6 +43,7 @@ describe('createAliveDigest', () => {
       resolveBinance,
       listNotifiers: async () => [],
       isEventEnabled: async () => true,
+      resolveProfileName: async () => null,
       notifyRegistry: { get: () => undefined } as unknown as NotifyProviderRegistry,
     })(profile);
     // No notifiers → no point spending a Binance call.
@@ -56,6 +57,7 @@ describe('createAliveDigest', () => {
       resolveBinance,
       listNotifiers: async () => [notifierRow()],
       isEventEnabled: async () => false,
+      resolveProfileName: async () => null,
       notifyRegistry: { get: () => undefined } as unknown as NotifyProviderRegistry,
     })(profile);
     // Muted → no notifier resolution and no Binance call.
@@ -69,6 +71,7 @@ describe('createAliveDigest', () => {
       resolveBinance,
       listNotifiers: async () => [notifierRow({ enabled: false })],
       isEventEnabled: async () => true,
+      resolveProfileName: async () => null,
       notifyRegistry: { get: () => undefined } as unknown as NotifyProviderRegistry,
     })(profile);
     expect(resolveBinance).not.toHaveBeenCalled();
@@ -81,6 +84,7 @@ describe('createAliveDigest', () => {
       resolveBinance: async () => null,
       listNotifiers: async () => [notifierRow()],
       isEventEnabled: async () => true,
+      resolveProfileName: async () => null,
       notifyRegistry: {
         get: () => ({ name: 'slack', send }),
       } as unknown as NotifyProviderRegistry,
@@ -89,7 +93,7 @@ describe('createAliveDigest', () => {
   });
 
   it('sends a digest of non-zero balances to each configured notifier', async () => {
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     await createAliveDigest({
       logger: stubLogger,
       resolveBinance: async () =>
@@ -107,20 +111,13 @@ describe('createAliveDigest', () => {
     })(profile);
 
     expect(send).toHaveBeenCalledTimes(1);
-    const arg = send.mock.calls[0]?.[0] as {
-      config: unknown;
-      message: {
-        topic: string;
-        title: string;
-        profile: string;
-        fields: { label: string; value: string }[];
-      };
-    };
+    const arg = send.mock.calls[0]?.[0];
+    if (!arg) throw new Error('expected one notification');
     expect(arg.message.topic).toBe('alive');
     expect(arg.message.title).toBe('Periodic summary');
     expect(arg.message.profile).toBe('RealNet-Momentum');
     // The zero-balance USDT row is dropped; BTC (free) and ETH (locked, total 2) stay.
-    const holdings = arg.message.fields.find((f) => f.label === 'Holdings')?.value;
+    const holdings = arg.message.fields?.find((f) => f.label === 'Holdings')?.value;
     expect(holdings).toBe('0.5 BTC, 2 ETH');
     // config + secrets merged for the provider.
     expect(arg.config).toMatchObject({
@@ -130,7 +127,7 @@ describe('createAliveDigest', () => {
   });
 
   it('caps the holdings list with "+N more" and omits the profile when the name is unresolved', async () => {
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     // Eight held assets: HOLDINGS_CAP is 6, so two collapse into "+2 more".
     const balances = Array.from({ length: 8 }, (_, i) => ({
       asset: `A${i}`,
@@ -148,10 +145,9 @@ describe('createAliveDigest', () => {
       } as unknown as NotifyProviderRegistry,
     })(profile);
 
-    const message = send.mock.calls[0]?.[0] as {
-      message: { profile?: string; fields: { label: string; value: string }[] };
-    };
+    const message = send.mock.calls[0]?.[0];
+    if (!message) throw new Error('expected one notification');
     expect(message.message.profile).toBeUndefined();
-    expect(message.message.fields.find((f) => f.label === 'Holdings')?.value).toContain('+2 more');
+    expect(message.message.fields?.find((f) => f.label === 'Holdings')?.value).toContain('+2 more');
   });
 });

--- a/apps/worker/__tests__/crons/daily-ath.test.ts
+++ b/apps/worker/__tests__/crons/daily-ath.test.ts
@@ -7,7 +7,7 @@ import type { Logger } from 'pino';
 import type { Redis } from 'ioredis';
 
 import { KlineParseError } from '@app/binance';
-import { createDailyAthRefresh } from '../../src/crons/daily-ath.js';
+import { createDailyAthRefresh, type DailyAthRefreshDeps } from '../../src/crons/daily-ath.js';
 import { athKey } from '../../src/indicator-computer/indicator-computer.js';
 
 const stubLogger = {
@@ -16,6 +16,9 @@ const stubLogger = {
   error: vi.fn(),
   debug: vi.fn(),
 } as unknown as Logger;
+type FetchImpl = NonNullable<DailyAthRefreshDeps['fetchImpl']>;
+type FetchCall = (...args: Parameters<FetchImpl>) => ReturnType<FetchImpl>;
+type RedisSet = (key: string, value: string) => Promise<'OK'>;
 
 // One Binance kline row: [openTime, open, high, low, close, volume, closeTime].
 const kline = (openTime: number, high: string): unknown => [
@@ -38,8 +41,8 @@ const jsonResponse = (body: unknown, ok = true, status = 200): Response =>
 
 describe('createDailyAthRefresh', () => {
   it('writes ath:<symbol> as the highest high across the kline window', async () => {
-    const set = vi.fn(async () => 'OK');
-    const fetchImpl = vi.fn(async () =>
+    const set = vi.fn<RedisSet>(async () => 'OK');
+    const fetchImpl = vi.fn<FetchCall>(async () =>
       jsonResponse([kline(1, '100'), kline(2, '250'), kline(3, '180')]),
     );
     const refresh = createDailyAthRefresh({
@@ -57,7 +60,7 @@ describe('createDailyAthRefresh', () => {
   });
 
   it('requests the 1d interval for the given symbol', async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse([kline(1, '100')]));
+    const fetchImpl = vi.fn<FetchCall>(async () => jsonResponse([kline(1, '100')]));
     const refresh = createDailyAthRefresh({
       redis: { set: vi.fn(async () => 'OK') } as unknown as Redis,
       logger: stubLogger,
@@ -72,7 +75,7 @@ describe('createDailyAthRefresh', () => {
   });
 
   it('drops the in-progress day so ATH is computed over closed candles only', async () => {
-    const set = vi.fn(async () => 'OK');
+    const set = vi.fn<RedisSet>(async () => 'OK');
     // Three rows: the last has a closeTime in the future (the open day);
     // its high of 999 must NOT reach the ATH.
     const fetchImpl = vi.fn(async () =>

--- a/apps/worker/__tests__/crons/db-backup.cron.test.ts
+++ b/apps/worker/__tests__/crons/db-backup.cron.test.ts
@@ -29,8 +29,8 @@ const baseDeps = (over: Partial<DbBackupDeps> = {}): DbBackupDeps => ({
   logger: noopLogger(),
   now: () => FIXED,
   getConfig: vi.fn(async () => config()),
-  runBackup: vi.fn(async () => undefined),
-  touchLastBackup: vi.fn(async () => undefined),
+  runBackup: vi.fn<DbBackupDeps['runBackup']>(async () => undefined),
+  touchLastBackup: vi.fn<DbBackupDeps['touchLastBackup']>(async () => undefined),
   listDir: vi.fn(async () => []),
   removeFile: vi.fn(async () => undefined),
   ensureDir: vi.fn(async () => undefined),
@@ -63,10 +63,14 @@ describe('dbBackupHandler', () => {
     await dbBackupHandler(deps)({} as Job);
     expect(deps.ensureDir).toHaveBeenCalledTimes(1);
     expect(deps.runBackup).toHaveBeenCalledTimes(1);
-    const outPath = (deps.runBackup as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const outPath = (deps.runBackup as ReturnType<typeof vi.fn<DbBackupDeps['runBackup']>>).mock
+      .calls[0]?.[0];
     expect(outPath).toBe(`/backups/backup-${FIXED_MS}.dump`);
     expect(deps.touchLastBackup).toHaveBeenCalledTimes(1);
-    expect((deps.touchLastBackup as ReturnType<typeof vi.fn>).mock.calls[0][0]).toEqual(FIXED);
+    expect(
+      (deps.touchLastBackup as ReturnType<typeof vi.fn<DbBackupDeps['touchLastBackup']>>).mock
+        .calls[0]?.[0],
+    ).toEqual(FIXED);
   });
 
   it('does not touch or prune when the dump itself fails', async () => {

--- a/apps/worker/__tests__/crons/detached-orders-reconcile.test.ts
+++ b/apps/worker/__tests__/crons/detached-orders-reconcile.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Job } from 'bullmq';
 import type { Logger } from 'pino';
-import { BinanceApiError } from '@app/binance';
+import { BinanceApiError, type BinanceRestClient } from '@app/binance';
 
 import {
   detachedOrdersReconcileHandler,
@@ -149,11 +149,12 @@ describe('detachedOrdersReconcileHandler', () => {
     // The client cache is keyed by account precisely because a detached row can
     // only be settled with ITS OWN account's key pair — querying account B's order
     // with account A's credentials returns -2013 and would close a live order.
-    const getOrderA = vi.fn(async () => orderDto({ orderId: 10 }));
-    const getOrderB = vi.fn(async () => orderDto({ orderId: 20 }));
-    const resolveBinance = vi.fn(async (_operatorId: unknown, accountId: unknown) =>
-      accountId === ACC_A ? { getOrder: getOrderA } : { getOrder: getOrderB },
-    ) as unknown as DetachedOrdersReconcileDeps['resolveBinance'];
+    const getOrderA = vi.fn<BinanceRestClient['getOrder']>(async () => orderDto({ orderId: 10 }));
+    const getOrderB = vi.fn<BinanceRestClient['getOrder']>(async () => orderDto({ orderId: 20 }));
+    const resolveBinance = vi.fn<DetachedOrdersReconcileDeps['resolveBinance']>(
+      async (_operatorId, accountId) =>
+        accountId === ACC_A ? { getOrder: getOrderA } : { getOrder: getOrderB },
+    );
     await detachedOrdersReconcileHandler(
       mkDeps({
         listLiveDetached: async () => [
@@ -165,10 +166,7 @@ describe('detachedOrdersReconcileHandler', () => {
       }),
     )(job);
     // One resolve per DISTINCT account (the cache works)...
-    expect((resolveBinance as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[1])).toEqual([
-      ACC_A,
-      ACC_B,
-    ]);
+    expect(resolveBinance.mock.calls.map((c) => c[1])).toEqual([ACC_A, ACC_B]);
     // ...and each account's rows go to that account's client, never the other's.
     expect(getOrderA).toHaveBeenCalledTimes(2);
     expect(getOrderB).toHaveBeenCalledTimes(1);

--- a/apps/worker/__tests__/crons/discovery-explain-wire.test.ts
+++ b/apps/worker/__tests__/crons/discovery-explain-wire.test.ts
@@ -48,7 +48,9 @@ const config: DiscoveryConfig = {
 
 const ticker = (symbol: string, gain: string) => ({
   symbol,
+  baseAsset: symbol.slice(0, -4),
   quoteAsset: 'USDT',
+  isStablecoinOrFiat: false,
   priceChangePercent: gain,
   quoteVolume: '5000000',
   pairVolumeUsd: '5000000',

--- a/apps/worker/__tests__/crons/discovery/quote-price.test.ts
+++ b/apps/worker/__tests__/crons/discovery/quote-price.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Ticker24hrDto } from '@app/binance';
 import { Decimal } from '@app/money';
+import type { Logger } from 'pino';
 import type { AssetPolicy } from '../../../src/crons/discovery/asset-policy.js';
 import type { SymbolAdmission } from '../../../src/crons/discovery/symbol-admission.js';
 import {
@@ -25,7 +26,7 @@ const ticker = (over: Partial<Ticker24hrDto>): Ticker24hrDto => ({
 
 // `logger` is a required option because the cuts below are silent by
 // construction; tests that do not assert on the warn still have to supply one.
-const noopLogger = (): { warn: ReturnType<typeof vi.fn> } => ({ warn: vi.fn() });
+const noopLogger = (): Pick<Logger, 'warn'> => ({ warn: vi.fn<Logger['warn']>() });
 
 /** exchangeInfo facts for one symbol. Base and quote are required, so every fixture states its own split rather than leaving it to be inferred. */
 const adm = (
@@ -218,7 +219,7 @@ describe('toDiscoveryTickers', () => {
     // from every published set. A tokenized equity publishes SPOT/MARGIN groups
     // an account tagged only LEVERAGED/TRD_GRP_025 can never satisfy, so every
     // order it derives is refused with -2010 forever.
-    const warn = vi.fn();
+    const warn = vi.fn<Logger['warn']>();
     const admissionBySymbol = new Map<string, SymbolAdmission>([
       ['ETHUSDT', adm('ETH', 'USDT', { permissionSets: [['SPOT', 'TRD_GRP_025']] })],
       ['CRCLBUSDT', adm('CRCLB', 'USDT', { permissionSets: [['SPOT', 'TRD_GRP_005']] })],

--- a/apps/worker/__tests__/crons/discovery/run.test.ts
+++ b/apps/worker/__tests__/crons/discovery/run.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { DiscoveryConfigSchema } from '@app/contracts';
+import { DiscoveryConfigSchema, type StoredDiscoveryConfig } from '@app/contracts';
 import type { Ticker24hrDto } from '@app/binance';
 import type { Candle } from '@app/strategy-core';
 import {
@@ -135,9 +135,20 @@ const fakePort = (over: Partial<DiscoveryProfilePort> = {}): DiscoveryProfilePor
   notify: vi.fn(async () => undefined),
   enqueueResync: vi.fn(async () => undefined),
   persistExplain: vi.fn(async () => undefined),
-  persistSnapshot: vi.fn(async () => undefined),
+  persistSnapshot: vi.fn<DiscoveryProfilePort['persistSnapshot']>(async () => undefined),
   ...over,
 });
+
+const snapshotFor = (
+  port: DiscoveryProfilePort,
+): Parameters<DiscoveryProfilePort['persistSnapshot']>[0] => {
+  const persistSnapshot = port.persistSnapshot as ReturnType<
+    typeof vi.fn<DiscoveryProfilePort['persistSnapshot']>
+  >;
+  const snapshot = persistSnapshot.mock.calls[0]?.[0];
+  if (!snapshot) throw new Error('expected a persisted discovery snapshot');
+  return snapshot;
+};
 
 // Sibling account-level conflict (#661). Sibling profiles under one account share
 // a wallet, so a candidate whose base asset is the QUOTE of a sibling (C1) or is
@@ -440,7 +451,7 @@ describe('runDiscoveryForProfile', () => {
     const port = fakePort();
     await runCycle(port, cfg, 'USDT');
     expect(port.persistSnapshot).toHaveBeenCalledTimes(1);
-    const snap = (port.persistSnapshot as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const snap = snapshotFor(port);
     // Universe is the full quote-matched ranked ticker set, decimal-strings kept.
     expect(snap.universe).toEqual([
       { symbol: 'AAAUSDT', priceChangePercent: '10', quoteVolume: '1' },
@@ -465,7 +476,7 @@ describe('runDiscoveryForProfile', () => {
     const port = fakePort();
     await runCycle(port, permissiveConfig(), 'USDT');
     expect(port.persistSnapshot).toHaveBeenCalledTimes(1);
-    const snap = (port.persistSnapshot as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const snap = snapshotFor(port);
     expect(snap.funnel).toBeDefined();
     expect(snap.funnel).toMatchObject({
       universe: expect.any(Number),
@@ -494,15 +505,15 @@ describe('runDiscoveryForProfile', () => {
     // that never ran instead of at the missing price history.
     const port = fakePort({ listAutoSymbols: async () => ['ZZZUSDT'] });
     await runCycle(port, permissiveConfig(), 'USDT');
-    const snap = (port.persistSnapshot as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(snap.funnel.probed).toBe(1);
+    const snap = snapshotFor(port);
+    expect(snap.funnel?.probed).toBe(1);
   });
 
   it('persists a snapshot even on a no-op (empty universe) cycle (#436)', async () => {
     const port = fakePort({ getAllTickers: async () => [] });
     await runCycle(port, permissiveConfig(), 'USDT');
     expect(port.persistSnapshot).toHaveBeenCalledTimes(1);
-    const snap = (port.persistSnapshot as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const snap = snapshotFor(port);
     expect(snap.universe).toEqual([]);
     expect(snap.add).toEqual([]);
     expect(snap.desired).toEqual([]);
@@ -648,10 +659,8 @@ describe('runDiscoveryForProfile', () => {
     expect(fetched).not.toContain('S20USDT'); // beyond the cap → skipped this cycle
     // 41 candidates but 16 windows: the segment's denominator is the windows the
     // cap allowed, not the candidate count, or a cap would read as a filter.
-    const snapshot = (port.persistSnapshot as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
-      funnel: { probed: number };
-    };
-    expect(snapshot.funnel.probed).toBe(16);
+    const snapshot = snapshotFor(port);
+    expect(snapshot.funnel?.probed).toBe(16);
   });
 });
 

--- a/apps/worker/__tests__/crons/discovery/run.test.ts
+++ b/apps/worker/__tests__/crons/discovery/run.test.ts
@@ -139,6 +139,7 @@ const fakePort = (over: Partial<DiscoveryProfilePort> = {}): DiscoveryProfilePor
   ...over,
 });
 
+// The port's `persistSnapshot` is a `vi.fn`, but the DiscoveryProfilePort type says nothing about mocks, so reading `.mock.calls` needs the cast back to the spy type it was built with.
 const snapshotFor = (
   port: DiscoveryProfilePort,
 ): Parameters<DiscoveryProfilePort['persistSnapshot']>[0] => {

--- a/apps/worker/__tests__/crons/edge-decay-monitor.cron.test.ts
+++ b/apps/worker/__tests__/crons/edge-decay-monitor.cron.test.ts
@@ -58,7 +58,7 @@ describe('edgeDecayMonitorHandler', () => {
   it('does nothing when assess returns null (not live / gone)', async () => {
     const markNotified = vi.fn(async () => undefined);
     const clearNotified = vi.fn(async () => undefined);
-    const notify = vi.fn(async () => undefined);
+    const notify = vi.fn<EdgeDecayMonitorDeps['notify']>(async () => undefined);
     await edgeDecayMonitorHandler(
       deps({ assess: async () => null, markNotified, clearNotified, notify }),
     )(job);
@@ -69,7 +69,7 @@ describe('edgeDecayMonitorHandler', () => {
 
   it('marks the latch and notifies once on a fresh breach', async () => {
     const markNotified = vi.fn(async () => undefined);
-    const notify = vi.fn(async () => undefined);
+    const notify = vi.fn<EdgeDecayMonitorDeps['notify']>(async () => undefined);
     await edgeDecayMonitorHandler(
       deps({
         assess: async () => assessment({ verdict: 'breached', liveProfitFactor: 0.8 }),
@@ -92,7 +92,7 @@ describe('edgeDecayMonitorHandler', () => {
 
   it('does not alert on a warning verdict', async () => {
     const markNotified = vi.fn(async () => undefined);
-    const notify = vi.fn(async () => undefined);
+    const notify = vi.fn<EdgeDecayMonitorDeps['notify']>(async () => undefined);
     await edgeDecayMonitorHandler(
       deps({
         assess: async () => assessment({ verdict: 'warning' }),
@@ -107,7 +107,7 @@ describe('edgeDecayMonitorHandler', () => {
 
   it('does not re-alert when already notified', async () => {
     const markNotified = vi.fn(async () => undefined);
-    const notify = vi.fn(async () => undefined);
+    const notify = vi.fn<EdgeDecayMonitorDeps['notify']>(async () => undefined);
     await edgeDecayMonitorHandler(
       deps({
         assess: async () => assessment({ verdict: 'breached' }),

--- a/apps/worker/__tests__/crons/equity-snapshot.cron.test.ts
+++ b/apps/worker/__tests__/crons/equity-snapshot.cron.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import pino from 'pino';
 import type { Job } from 'bullmq';
-import type { EquitySnapshotPayload } from '@app/db';
 import type { AccountId, ProfileId, UserId } from '@app/contracts';
 
 import { computeEquitySnapshot } from '../../src/crons/equity-snapshot.js';
@@ -119,15 +118,11 @@ const deps = (over: Partial<EquitySnapshotDeps> = {}): EquitySnapshotDeps => ({
 
 describe('equitySnapshotHandler', () => {
   it('records one snapshot per active profile', async () => {
-    const record = vi.fn(async () => undefined);
+    const record = vi.fn<EquitySnapshotDeps['record']>(async () => undefined);
     await equitySnapshotHandler(deps({ record }))(job);
     expect(record).toHaveBeenCalledTimes(1);
-    const [, , , payload] = record.mock.calls[0] as [
-      UserId,
-      AccountId,
-      ProfileId,
-      EquitySnapshotPayload,
-    ];
+    const payload = record.mock.calls[0]?.[3];
+    if (!payload) throw new Error('expected one equity snapshot');
     // unrealised = (110-100)*1 = 10; net = realised 5 + 10 = 15.
     expect(payload.netPnlQuote).toBe('15');
     expect(payload.benchmarkAsset).toBe('BTC');
@@ -142,7 +137,7 @@ describe('equitySnapshotHandler', () => {
   it('builds the benchmark symbol from the canonical quote, not the stored casing', async () => {
     // `profiles.quote_asset` is allowed to be stored lower or mixed case. Ticker keys carry Binance's upper casing, so a raw concat asks for `BTCusdt`, misses the cache, and records a zero benchmark price — the "vs holding" comparator flatlines while every other leg of the same row is correct.
     const pricesOf = vi.fn(async () => new Map([['BTCUSDT', '110']]));
-    const record = vi.fn(async () => undefined);
+    const record = vi.fn<EquitySnapshotDeps['record']>(async () => undefined);
     await equitySnapshotHandler(
       deps({
         pricesOf,
@@ -155,12 +150,8 @@ describe('equitySnapshotHandler', () => {
       }),
     )(job);
     expect(pricesOf).toHaveBeenCalledWith(['BTCUSDT', 'BTCUSDT']);
-    const [, , , payload] = record.mock.calls[0] as [
-      UserId,
-      AccountId,
-      ProfileId,
-      EquitySnapshotPayload,
-    ];
+    const payload = record.mock.calls[0]?.[3];
+    if (!payload) throw new Error('expected one equity snapshot');
     expect(payload.benchmarkPriceQuote).toBe('110');
     expect(payload.quoteAsset).toBe('USDT');
   });

--- a/apps/worker/__tests__/crons/exchange-info-refresh.test.ts
+++ b/apps/worker/__tests__/crons/exchange-info-refresh.test.ts
@@ -1,15 +1,23 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, type Mock } from 'vitest';
 import pino from 'pino';
 import type { Logger } from 'pino';
 import type { Redis } from 'ioredis';
 import {
   combineExchangeInfoRefresh,
   createExchangeInfoRefresh,
+  type ExchangeInfoRefreshDeps,
 } from '../../src/crons/exchange-info-refresh.js';
 import { CATALOG, type MetricName, type MetricsSink } from '../../src/metrics/catalog.js';
 import { buildSymbolInfoKey } from '../../src/executor/redis-namespace.js';
 
 const silentLogger = pino({ level: 'silent' });
+
+type FetchImpl = NonNullable<ExchangeInfoRefreshDeps['fetchImpl']>;
+type FetchCall = (...args: Parameters<FetchImpl>) => ReturnType<FetchImpl>;
+type FetchSpy = Mock<FetchCall> & Pick<FetchImpl, 'preconnect'>;
+
+const fetchSpy = (implementation: FetchCall): FetchSpy =>
+  Object.assign(vi.fn<FetchCall>(implementation), { preconnect: fetch.preconnect });
 
 interface StubRedis {
   writes: Map<string, string>;
@@ -61,7 +69,7 @@ const jsonResponse = (body: unknown, status = 200): Response =>
 describe('createExchangeInfoRefresh', () => {
   it('writes one symbol-info entry per ASCII-tickered symbol', async () => {
     const redis = stubRedis();
-    const fetchImpl = vi.fn(async () =>
+    const fetchImpl = fetchSpy(async () =>
       jsonResponse({
         symbols: [
           {
@@ -105,8 +113,8 @@ describe('createExchangeInfoRefresh', () => {
       deleted: 0,
       orderRateLimits: { windows: [], headers: new Map() },
     });
-    expect(redis.writes.has(buildSymbolInfoKey('BTCUSDT'))).toBe(true);
-    const btcRaw = redis.writes.get(buildSymbolInfoKey('BTCUSDT'));
+    expect(redis.writes.has(buildSymbolInfoKey('BTCUSDT', 'live'))).toBe(true);
+    const btcRaw = redis.writes.get(buildSymbolInfoKey('BTCUSDT', 'live'));
     if (!btcRaw) throw new Error('test setup: BTCUSDT not written');
     const btc = JSON.parse(btcRaw) as {
       symbol: string;
@@ -131,7 +139,7 @@ describe('createExchangeInfoRefresh', () => {
 
   it('persists the PERCENT_PRICE_BY_SIDE band, which the protective stop prices against', async () => {
     const redis = stubRedis();
-    const fetchImpl = vi.fn(async () =>
+    const fetchImpl = fetchSpy(async () =>
       jsonResponse({
         symbols: [
           {
@@ -165,7 +173,7 @@ describe('createExchangeInfoRefresh', () => {
     const refresh = createExchangeInfoRefresh({ redis, logger: silentLogger, fetchImpl });
     await refresh();
 
-    const raw = redis.writes.get(buildSymbolInfoKey('LINKUSDT'));
+    const raw = redis.writes.get(buildSymbolInfoKey('LINKUSDT', 'live'));
     if (!raw) throw new Error('test setup: LINKUSDT not written');
     const persisted = JSON.parse(raw) as {
       filters: { percentPriceBySide?: Record<string, unknown>; tickSize: string };
@@ -185,7 +193,7 @@ describe('createExchangeInfoRefresh', () => {
 
   it('retains the ORDERS rate-limit rows, which the order governor is built from', async () => {
     const redis = stubRedis();
-    const fetchImpl = vi.fn(async () =>
+    const fetchImpl = fetchSpy(async () =>
       jsonResponse({
         // Testnet's rows, which are HALF live's 100/10s — the reason these are
         // read from the payload rather than hardcoded.
@@ -225,7 +233,7 @@ describe('createExchangeInfoRefresh', () => {
 
   it('skips symbols with non-ASCII tickers (e.g. CJK meme tokens)', async () => {
     const redis = stubRedis();
-    const fetchImpl = vi.fn(async () =>
+    const fetchImpl = fetchSpy(async () =>
       jsonResponse({
         symbols: [
           {
@@ -256,14 +264,14 @@ describe('createExchangeInfoRefresh', () => {
       deleted: 0,
       orderRateLimits: { windows: [], headers: new Map() },
     });
-    expect(redis.writes.has(buildSymbolInfoKey('BTCUSDT'))).toBe(true);
-    expect(redis.writes.has(buildSymbolInfoKey('币安人生USDT'))).toBe(false);
+    expect(redis.writes.has(buildSymbolInfoKey('BTCUSDT', 'live'))).toBe(true);
+    expect(redis.writes.has(buildSymbolInfoKey('币安人生USDT', 'live'))).toBe(false);
   });
 
   it('deletes Redis keys for symbols Binance no longer lists', async () => {
-    const stale = [buildSymbolInfoKey('BUSDUSDT'), buildSymbolInfoKey('LUNAUSDT')];
+    const stale = [buildSymbolInfoKey('BUSDUSDT', 'live'), buildSymbolInfoKey('LUNAUSDT', 'live')];
     const redis = stubRedis(stale);
-    const fetchImpl = vi.fn(async () =>
+    const fetchImpl = fetchSpy(async () =>
       jsonResponse({
         symbols: [
           {
@@ -286,7 +294,7 @@ describe('createExchangeInfoRefresh', () => {
 
   it('throws on per-command pipeline failure so a partial write is not masked', async () => {
     const redis = stubRedis([], { failAt: 1, failError: new Error('OOM command not allowed') });
-    const fetchImpl = vi.fn(async () =>
+    const fetchImpl = fetchSpy(async () =>
       jsonResponse({
         symbols: [
           {
@@ -314,9 +322,9 @@ describe('createExchangeInfoRefresh', () => {
 
   it('refuses to wipe the cache when upstream returns 200 with empty symbols', async () => {
     // Pre-existing cache state from a healthy prior refresh.
-    const existing = [buildSymbolInfoKey('BTCUSDT'), buildSymbolInfoKey('ETHUSDT')];
+    const existing = [buildSymbolInfoKey('BTCUSDT', 'live'), buildSymbolInfoKey('ETHUSDT', 'live')];
     const redis = stubRedis(existing);
-    const fetchImpl = vi.fn(async () => jsonResponse({ symbols: [] }));
+    const fetchImpl = fetchSpy(async () => jsonResponse({ symbols: [] }));
 
     const refresh = createExchangeInfoRefresh({ redis, logger: silentLogger, fetchImpl });
 
@@ -328,7 +336,7 @@ describe('createExchangeInfoRefresh', () => {
 
   it('throws on non-ok upstream response so the cron retries + DLQs', async () => {
     const redis = stubRedis();
-    const fetchImpl = vi.fn(async () => new Response('rate limited', { status: 429 }));
+    const fetchImpl = fetchSpy(async () => new Response('rate limited', { status: 429 }));
 
     const refresh = createExchangeInfoRefresh({ redis, logger: silentLogger, fetchImpl });
 
@@ -337,7 +345,7 @@ describe('createExchangeInfoRefresh', () => {
 
   it('mode=test fetches the testnet host and writes the test keyspace', async () => {
     const redis = stubRedis();
-    const fetchImpl = vi.fn(async () =>
+    const fetchImpl = fetchSpy(async () =>
       jsonResponse({
         symbols: [
           {
@@ -380,12 +388,14 @@ describe('createExchangeInfoRefresh', () => {
     expect(redis.writes.has(buildSymbolInfoKey('BTCUSDT', 'live'))).toBe(false);
     const raw = redis.writes.get(buildSymbolInfoKey('BTCUSDT', 'test'));
     if (!raw) throw new Error('test setup: test-mode BTCUSDT not written');
-    expect((JSON.parse(raw) as { filters: Record<string, string> }).filters.tickSize).toBe('0.1');
+    expect((JSON.parse(raw) as { filters: Record<string, string> }).filters['tickSize']).toBe(
+      '0.1',
+    );
   });
 
   it('handles missing filters gracefully (asset-dust symbols)', async () => {
     const redis = stubRedis();
-    const fetchImpl = vi.fn(async () =>
+    const fetchImpl = fetchSpy(async () =>
       jsonResponse({
         symbols: [
           {
@@ -402,11 +412,11 @@ describe('createExchangeInfoRefresh', () => {
     const refresh = createExchangeInfoRefresh({ redis, logger: silentLogger, fetchImpl });
     await refresh();
 
-    const obsRaw = redis.writes.get(buildSymbolInfoKey('OBSCURE'));
+    const obsRaw = redis.writes.get(buildSymbolInfoKey('OBSCURE', 'live'));
     if (!obsRaw) throw new Error('test setup: OBSCURE not written');
     const obs = JSON.parse(obsRaw) as { filters: Record<string, string> };
-    expect(obs.filters.tickSize).toBe('0'); // safe fallback
-    expect(obs.filters.minNotional).toBe('0');
+    expect(obs.filters['tickSize']).toBe('0'); // safe fallback
+    expect(obs.filters['minNotional']).toBe('0');
   });
 
   // Both collapse to the same all-zero fallback, and until now both did it in
@@ -458,7 +468,7 @@ describe('createExchangeInfoRefresh', () => {
       const metrics = metricsStub();
       // A real filter list, but the LOT_SIZE and NOTIONAL rows the projection
       // requires are missing, so the whole set voids.
-      const fetchImpl = vi.fn(async () =>
+      const fetchImpl = fetchSpy(async () =>
         jsonResponse({
           symbols: [symbolWith([{ filterType: 'PRICE_FILTER', tickSize: '0.001' }])],
         }),
@@ -473,16 +483,18 @@ describe('createExchangeInfoRefresh', () => {
       expect(warn?.ctx).toMatchObject({ mode: 'live', symbols: 1, sample: ['BROKENUSDT'] });
       // Still written, still all-zero: naming the problem must not also drop the
       // symbol out of the cache and DLQ its first tick.
-      const raw = redis.writes.get(buildSymbolInfoKey('BROKENUSDT'));
+      const raw = redis.writes.get(buildSymbolInfoKey('BROKENUSDT', 'live'));
       if (!raw) throw new Error('test setup: BROKENUSDT not written');
-      expect((JSON.parse(raw) as { filters: Record<string, string> }).filters.tickSize).toBe('0');
+      expect((JSON.parse(raw) as { filters: Record<string, string> }).filters['tickSize']).toBe(
+        '0',
+      );
     });
 
     it('C9: an absent filters array stays silent and uncounted', async () => {
       const redis = stubRedis();
       const { logger, warns } = capturingLogger();
       const metrics = metricsStub();
-      const fetchImpl = vi.fn(async () => jsonResponse({ symbols: [symbolWith(undefined)] }));
+      const fetchImpl = fetchSpy(async () => jsonResponse({ symbols: [symbolWith(undefined)] }));
 
       const refresh = createExchangeInfoRefresh({ redis, logger, fetchImpl, metrics });
       await refresh();
@@ -497,7 +509,7 @@ describe('createExchangeInfoRefresh', () => {
       const redis = stubRedis();
       const { logger, warns } = capturingLogger();
       const metrics = metricsStub();
-      const fetchImpl = vi.fn(async () => jsonResponse({ symbols: [symbolWith([])] }));
+      const fetchImpl = fetchSpy(async () => jsonResponse({ symbols: [symbolWith([])] }));
 
       const refresh = createExchangeInfoRefresh({ redis, logger, fetchImpl, metrics });
       await refresh();
@@ -510,7 +522,7 @@ describe('createExchangeInfoRefresh', () => {
       const redis = stubRedis();
       const { logger } = capturingLogger();
       const metrics = metricsStub();
-      const fetchImpl = vi.fn(async () =>
+      const fetchImpl = fetchSpy(async () =>
         jsonResponse({
           symbols: [symbolWith([{ filterType: 'PRICE_FILTER', tickSize: '0.001' }])],
         }),
@@ -544,7 +556,7 @@ describe('createExchangeInfoRefresh', () => {
         status: 'TRADING',
         filters: [{ filterType: 'PRICE_FILTER', tickSize: '0.001' }],
       }));
-      const fetchImpl = vi.fn(async () => jsonResponse({ symbols: broken }));
+      const fetchImpl = fetchSpy(async () => jsonResponse({ symbols: broken }));
 
       const refresh = createExchangeInfoRefresh({ redis, logger, fetchImpl, metrics });
       await refresh();
@@ -588,7 +600,7 @@ describe('createExchangeInfoRefresh', () => {
       const metrics = metricsStub();
       // Published, and complete enough that the seven sizing filters survive —
       // but the multipliers are numbers where Binance sends decimal strings.
-      const fetchImpl = vi.fn(async () =>
+      const fetchImpl = fetchSpy(async () =>
         jsonResponse({
           symbols: [
             complete({
@@ -611,7 +623,7 @@ describe('createExchangeInfoRefresh', () => {
       expect(warns[0]?.ctx).toMatchObject({ mode: 'live', symbols: 1, sample: ['LINKUSDT'] });
       // The rest of the filter set survives, which is exactly why this needs its
       // own signal: nothing else reports the symbol as damaged.
-      const raw = redis.writes.get(buildSymbolInfoKey('LINKUSDT'));
+      const raw = redis.writes.get(buildSymbolInfoKey('LINKUSDT', 'live'));
       if (!raw) throw new Error('test setup: LINKUSDT not written');
       const persisted = JSON.parse(raw) as { filters: Record<string, unknown> };
       expect(persisted.filters['stepSize']).toBe('0.01');
@@ -624,7 +636,7 @@ describe('createExchangeInfoRefresh', () => {
       const redis = stubRedis();
       const { logger, warns } = capturingLogger();
       const metrics = metricsStub();
-      const fetchImpl = vi.fn(async () => jsonResponse({ symbols: [complete(null)] }));
+      const fetchImpl = fetchSpy(async () => jsonResponse({ symbols: [complete(null)] }));
 
       const refresh = createExchangeInfoRefresh({ redis, logger, fetchImpl, metrics });
       await refresh();
@@ -666,7 +678,7 @@ describe('createExchangeInfoRefresh', () => {
       // Published, and the sizing filters survive — but the bounds arrive as
       // decimal-strings where the schema types them as the integers Binance
       // documents, which is the shape drift a quoted numeric field would take.
-      const fetchImpl = vi.fn(async () =>
+      const fetchImpl = fetchSpy(async () =>
         jsonResponse({
           symbols: [
             withTrailing({
@@ -688,7 +700,7 @@ describe('createExchangeInfoRefresh', () => {
       expect(warns[0]?.ctx).toMatchObject({ mode: 'live', symbols: 1, sample: ['LINKUSDT'] });
       // The symbol keeps trading and keeps its band, which is why the counter
       // above is the only thing that can report the loss.
-      const raw = redis.writes.get(buildSymbolInfoKey('LINKUSDT'));
+      const raw = redis.writes.get(buildSymbolInfoKey('LINKUSDT', 'live'));
       if (!raw) throw new Error('test setup: LINKUSDT not written');
       const persisted = JSON.parse(raw) as { filters: Record<string, unknown> };
       expect(persisted.filters['stepSize']).toBe('0.01');
@@ -699,7 +711,7 @@ describe('createExchangeInfoRefresh', () => {
       const redis = stubRedis();
       const { logger, warns } = capturingLogger();
       const metrics = metricsStub();
-      const fetchImpl = vi.fn(async () => jsonResponse({ symbols: [withTrailing(null)] }));
+      const fetchImpl = fetchSpy(async () => jsonResponse({ symbols: [withTrailing(null)] }));
 
       const refresh = createExchangeInfoRefresh({ redis, logger, fetchImpl, metrics });
       await refresh();

--- a/apps/worker/__tests__/crons/exchange-info-refresh.test.ts
+++ b/apps/worker/__tests__/crons/exchange-info-refresh.test.ts
@@ -16,6 +16,7 @@ type FetchImpl = NonNullable<ExchangeInfoRefreshDeps['fetchImpl']>;
 type FetchCall = (...args: Parameters<FetchImpl>) => ReturnType<FetchImpl>;
 type FetchSpy = Mock<FetchCall> & Pick<FetchImpl, 'preconnect'>;
 
+// `fetchImpl` is typed as the global `fetch`, which carries a `preconnect` property a bare `vi.fn` does not, so the spy grafts the real one on to satisfy the type.
 const fetchSpy = (implementation: FetchCall): FetchSpy =>
   Object.assign(vi.fn<FetchCall>(implementation), { preconnect: fetch.preconnect });
 

--- a/apps/worker/__tests__/crons/market-trend.test.ts
+++ b/apps/worker/__tests__/crons/market-trend.test.ts
@@ -3,7 +3,7 @@
 // handler test stubs the fetches and asserts the no-silent-failure skip and
 // the snapshot shape the api route parses back.
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, type Mock } from 'vitest';
 import type { Job } from 'bullmq';
 import type { Logger } from 'pino';
 import { MarketTrendSchema } from '@app/contracts';
@@ -90,7 +90,8 @@ describe('marketTrendHandler', () => {
     await marketTrendHandler(deps)({} as Job);
 
     expect(deps.writeSnapshot).toHaveBeenCalledTimes(1);
-    const json = (deps.writeSnapshot as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const json = (deps.writeSnapshot as Mock<MarketTrendDeps['writeSnapshot']>).mock.calls[0]?.[0];
+    if (json === undefined) throw new Error('expected one market-trend snapshot');
     const snap = MarketTrendSchema.parse(JSON.parse(json));
     expect(snap.computedAtMs).toBe(1_700_000_000_000);
     expect(snap.symbols.map((s) => s.regime)).toEqual(['bull', 'bear']);
@@ -103,7 +104,8 @@ describe('marketTrendHandler', () => {
     });
     await marketTrendHandler(deps)({} as Job);
     expect(deps.writeSnapshot).toHaveBeenCalledTimes(1);
-    const json = (deps.writeSnapshot as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const json = (deps.writeSnapshot as Mock<MarketTrendDeps['writeSnapshot']>).mock.calls[0]?.[0];
+    if (json === undefined) throw new Error('expected one market-trend snapshot');
     const snap = MarketTrendSchema.parse(JSON.parse(json));
     expect(snap.symbols.map((s) => s.symbol)).toEqual(['BTCUSDT']);
   });
@@ -136,7 +138,7 @@ describe('marketTrendHandler', () => {
     // Phase B adds a `writeUsdPriceMap` seam wired to the global Redis key
     // `market-trend:usd-price-map`; the handler builds a symbol→lastPrice map
     // from the 24h tickers so the dashboard can value every held asset.
-    const writeUsdPriceMap = vi.fn(async () => undefined);
+    const writeUsdPriceMap = vi.fn<MarketTrendDeps['writeUsdPriceMap']>(async () => undefined);
     const deps = baseDeps({
       writeUsdPriceMap,
       fetchTickers: vi.fn(async () => [
@@ -148,11 +150,11 @@ describe('marketTrendHandler', () => {
     await marketTrendHandler(deps)({} as Job);
 
     expect(writeUsdPriceMap).toHaveBeenCalledTimes(1);
-    const body = JSON.parse(
-      (writeUsdPriceMap as ReturnType<typeof vi.fn>).mock.calls[0][0] as string,
-    ) as { prices: Record<string, string> };
-    expect(body.prices.ETHUSDT).toBe('2000');
-    expect(body.prices.BTCUSDT).toBe('70000');
+    const body = JSON.parse(writeUsdPriceMap.mock.calls[0]?.[0] ?? '{}') as {
+      prices: Record<string, string>;
+    };
+    expect(body.prices['ETHUSDT']).toBe('2000');
+    expect(body.prices['BTCUSDT']).toBe('70000');
   });
 
   it('skips the usd-price-map write when no ticker carries a price', async () => {

--- a/apps/worker/__tests__/crons/orphan-orders-detect.test.ts
+++ b/apps/worker/__tests__/crons/orphan-orders-detect.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Job } from 'bullmq';
 import type { Logger } from 'pino';
 import type { OpenOrderDto } from '@app/binance';
+import { asAccountId, asProfileId, asUserId } from '@app/contracts';
 
 import {
   createOrphanAlertStore,
@@ -28,18 +29,18 @@ const job = { id: 'job-1', data: {} } as unknown as Job;
 
 // An orphan belongs to the ACCOUNT whose key pair found it, so every fixture
 // profile names one. The two accounts below sit on different environments.
-const ACC_LIVE = 'acc-live-1';
-const ACC_TEST = 'acc-test-1';
+const ACC_LIVE = asAccountId('acc-live-1');
+const ACC_TEST = asAccountId('acc-test-1');
 
-const profile = (profileId: string, accountId: string = ACC_LIVE): ActiveProfile =>
-  ({
-    profileId,
-    accountId,
-    userId: 'u1',
-    operatorId: 'u1',
-    candleInterval: '1h',
-    symbols: ['BTCUSDT'],
-  }) as unknown as ActiveProfile;
+const profile = (profileId: string, accountId = ACC_LIVE): ActiveProfile => ({
+  profileId: asProfileId(profileId),
+  accountId,
+  userId: asUserId('u1'),
+  operatorId: asUserId('u1'),
+  candleInterval: '1h',
+  symbols: ['BTCUSDT'],
+  technicalsIntervals: [],
+});
 
 const mkOrder = (orderId: number, over: Partial<OpenOrderDto> = {}): OpenOrderDto =>
   ({
@@ -88,13 +89,15 @@ const resolveOne =
 
 // The chokepoint is a BATCH seam: one call per account carries every orphan of
 // that account, and answers with one outcome per event (in order).
-type NotifyInput = {
-  category: string;
-  accountId?: string;
-  events: { link?: string; symbol?: string; fields?: { label: string; value: string }[] }[];
-};
+type NotifyInput = Parameters<OrphanOrdersDetectDeps['accountNotify']>[0];
 const notifyAll = (outcome: AccountNotifyOutcome) =>
-  vi.fn(async (input: NotifyInput) => input.events.map(() => outcome));
+  vi.fn<OrphanOrdersDetectDeps['accountNotify']>(async (input) => input.events.map(() => outcome));
+const commitAlertedMock = () =>
+  vi.fn<OrphanOrdersDetectDeps['commitAlerted']>(async () => undefined);
+const writeSnapshotMock = () =>
+  vi.fn<OrphanOrdersDetectDeps['writeSnapshot']>(async () => undefined);
+const recordNotifyGapMock = () =>
+  vi.fn<OrphanOrdersDetectDeps['recordNotifyGap']>(async () => undefined);
 
 const mkDeps = (over: Partial<OrphanOrdersDetectDeps> = {}): OrphanOrdersDetectDeps => ({
   logger: mkLogger(),
@@ -103,11 +106,11 @@ const mkDeps = (over: Partial<OrphanOrdersDetectDeps> = {}): OrphanOrdersDetectD
   listTrackedLiveOrderIds: async () => [],
   confirmPersistedOrphans: async (_accountId, ids) => [...ids], // default: treat all as confirmed
   computeNewOrphans: async (_accountId, ids) => [...ids],
-  commitAlerted: vi.fn(async () => undefined),
-  writeSnapshot: vi.fn(async () => undefined),
+  commitAlerted: commitAlertedMock(),
+  writeSnapshot: writeSnapshotMock(),
   nowMs: () => 1_700_000_000_000,
-  accountNotify: notifyAll('delivered') as unknown as OrphanOrdersDetectDeps['accountNotify'],
-  recordNotifyGap: vi.fn(async () => undefined),
+  accountNotify: notifyAll('delivered'),
+  recordNotifyGap: recordNotifyGapMock(),
   ...over,
 });
 
@@ -141,7 +144,7 @@ describe('orphanOrdersDetectHandler', () => {
     // injected accountNotify dep (which owns the subscription gate + the
     // mode-filtered notifier resolve) rather than fanning out itself.
     const accountNotify = notifyAll('delivered');
-    const commitAlerted = vi.fn(async () => undefined);
+    const commitAlerted = commitAlertedMock();
     const deps = mkDeps({
       resolveBinance: resolveOne(async () => [mkOrder(10), mkOrder(20)]),
       listTrackedLiveOrderIds: async () => [{ binanceOrderId: 20n, accountId: ACC_LIVE }], // 20 tracked; only 10 orphan
@@ -168,8 +171,8 @@ describe('orphanOrdersDetectHandler', () => {
     // the orphan uncommitted would re-warn on every tick and then storm the
     // operator with the whole backlog the moment they re-enable the category.
     const accountNotify = notifyAll('muted');
-    const commitAlerted = vi.fn(async () => undefined);
-    const recordNotifyGap = vi.fn(async () => undefined);
+    const commitAlerted = commitAlertedMock();
+    const recordNotifyGap = recordNotifyGapMock();
     const deps = mkDeps({
       resolveBinance: resolveOne(async () => [mkOrder(10)]),
       listTrackedLiveOrderIds: async () => [],
@@ -188,8 +191,8 @@ describe('orphanOrdersDetectHandler', () => {
     // nobody. That is a gap the operator must be able to find after the fact —
     // unlike a mute, which they chose.
     const accountNotify = notifyAll('no-notifier');
-    const recordNotifyGap = vi.fn(async () => undefined);
-    const commitAlerted = vi.fn(async () => undefined);
+    const recordNotifyGap = recordNotifyGapMock();
+    const commitAlerted = commitAlertedMock();
     const deps = mkDeps({
       resolveBinance: resolveOne(async () => [mkOrder(10)]),
       listTrackedLiveOrderIds: async () => [],
@@ -250,7 +253,7 @@ describe('orphanOrdersDetectHandler', () => {
 
   it('does NOT alert an orphan on its first sighting — two-tick confirmation suppresses the reprice race', async () => {
     const accountNotify = notifyAll('delivered');
-    const commitAlerted = vi.fn(async () => undefined);
+    const commitAlerted = commitAlertedMock();
     const deps = mkDeps({
       resolveBinance: resolveOne(async () => [mkOrder(10)]),
       listTrackedLiveOrderIds: async () => [], // 10 untracked → candidate this tick
@@ -265,7 +268,7 @@ describe('orphanOrdersDetectHandler', () => {
 
   it('alerts ONLY the confirmed orphan when a second candidate is still on its first sighting', async () => {
     const accountNotify = notifyAll('delivered');
-    const commitAlerted = vi.fn(async () => undefined);
+    const commitAlerted = commitAlertedMock();
     const deps = mkDeps({
       resolveBinance: resolveOne(async () => [mkOrder(10), mkOrder(11)]),
       listTrackedLiveOrderIds: async () => [], // both untracked → both candidates
@@ -282,7 +285,7 @@ describe('orphanOrdersDetectHandler', () => {
   });
 
   it('does NOT commit an orphan whose only notifier send failed (re-alerts next tick)', async () => {
-    const commitAlerted = vi.fn(async () => undefined);
+    const commitAlerted = commitAlertedMock();
     const deps = mkDeps({
       resolveBinance: resolveOne(async () => [mkOrder(10)]),
       listTrackedLiveOrderIds: async () => [],
@@ -294,7 +297,7 @@ describe('orphanOrdersDetectHandler', () => {
   });
 
   it('writes the full current orphan set to the snapshot (string ids, computed-at stamp)', async () => {
-    const writeSnapshot = vi.fn(async () => undefined);
+    const writeSnapshot = writeSnapshotMock();
     const deps = mkDeps({
       resolveBinance: resolveOne(async () => [mkOrder(10), mkOrder(20)]),
       listTrackedLiveOrderIds: async () => [{ binanceOrderId: 20n, accountId: ACC_LIVE }], // 20 tracked; only 10 orphan
@@ -330,7 +333,7 @@ describe('orphanOrdersDetectHandler', () => {
   });
 
   it('still writes an empty snapshot when nothing is orphaned (clears the adopt UI)', async () => {
-    const writeSnapshot = vi.fn(async () => undefined);
+    const writeSnapshot = writeSnapshotMock();
     const deps = mkDeps({
       resolveBinance: resolveOne(async () => [mkOrder(10)]),
       listTrackedLiveOrderIds: async () => [{ binanceOrderId: 10n, accountId: ACC_LIVE }], // everything tracked
@@ -389,7 +392,7 @@ describe('orphanOrdersDetectHandler', () => {
             rest: { getOpenOrders: async () => [mkOrder(10)] },
             mode: 'live',
           }) as unknown as OrphanOrdersDetectDeps['resolveBinance'];
-    const writeSnapshot = vi.fn(async () => undefined);
+    const writeSnapshot = writeSnapshotMock();
     const deps = mkDeps({
       listActive: () => [profile('pTest', ACC_TEST), profile('pLive', ACC_LIVE)],
       resolveBinance,
@@ -426,7 +429,7 @@ describe('orphanOrdersDetectHandler', () => {
             },
             mode: 'live',
           }) as unknown as OrphanOrdersDetectDeps['resolveBinance'];
-    const writeSnapshot = vi.fn(async () => undefined);
+    const writeSnapshot = writeSnapshotMock();
     const logger = mkLogger();
     const deps = mkDeps({
       logger,
@@ -465,7 +468,7 @@ describe('orphanOrdersDetectHandler', () => {
           }) as unknown as OrphanOrdersDetectDeps['resolveBinance'];
     const confirmPersistedOrphans = vi.fn(async (_a: unknown, ids: readonly string[]) => [...ids]);
     const computeNewOrphans = vi.fn(async (_a: unknown, ids: readonly string[]) => [...ids]);
-    const commitAlerted = vi.fn(async () => undefined);
+    const commitAlerted = commitAlertedMock();
     const deps = mkDeps({
       listActive: () => [profile('pTest', ACC_TEST), profile('pLive', ACC_LIVE)],
       resolveBinance,

--- a/apps/worker/__tests__/crons/portfolio-risk.cron.test.ts
+++ b/apps/worker/__tests__/crons/portfolio-risk.cron.test.ts
@@ -84,7 +84,7 @@ describe('portfolioRiskHandler', () => {
   });
 
   it('notifies the operator on the transition into halt', async () => {
-    const notify = vi.fn(async () => undefined);
+    const notify = vi.fn<PortfolioRiskDeps['notify']>(async () => undefined);
     await portfolioRiskHandler(
       deps({
         assess: async () => ({ limitQuote: '5', realisedPnl: '-6' }),
@@ -102,7 +102,7 @@ describe('portfolioRiskHandler', () => {
   });
 
   it('does not re-notify while already halted (but still re-sets the flag)', async () => {
-    const notify = vi.fn(async () => undefined);
+    const notify = vi.fn<PortfolioRiskDeps['notify']>(async () => undefined);
     const setEntryHalt = vi.fn(async () => undefined);
     await portfolioRiskHandler(
       deps({

--- a/apps/worker/__tests__/crons/register-crons.test.ts
+++ b/apps/worker/__tests__/crons/register-crons.test.ts
@@ -187,7 +187,9 @@ const buildCrons = (overrides?: Partial<Record<string, Partial<CronDef>>>): read
         listActive: () => [],
         resolveBinance: vi.fn(async () => null),
         persistAccount: vi.fn(async () => undefined),
+        persistAccountPermissions: vi.fn(async () => undefined),
         lastWsEventMs: vi.fn(async () => null),
+        accountInfoExists: vi.fn(async () => false),
       }),
     }),
     defineCron({
@@ -204,6 +206,7 @@ const buildCrons = (overrides?: Partial<Record<string, Partial<CronDef>>>): read
         finalize: vi.fn(async () => true),
         releaseClaim: vi.fn(async () => undefined),
         reapStaleProcessing: vi.fn(async () => 0),
+        reapExpiredOverrides: vi.fn(async () => ({ expired: 0, unresolved: [] })),
       }),
     }),
     defineCron({
@@ -215,12 +218,13 @@ const buildCrons = (overrides?: Partial<Record<string, Partial<CronDef>>>): read
         listActive: () => [],
         resolveBinance: vi.fn(async () => null),
         listTrackedLiveOrderIds: vi.fn(async () => []),
+        confirmPersistedOrphans: vi.fn(async () => []),
         computeNewOrphans: vi.fn(async () => []),
         commitAlerted: vi.fn(async () => undefined),
-        resolveNotifiers: vi.fn(async () => []),
-        notifyProviders: { get: () => undefined } as unknown as Parameters<
-          typeof orphanOrdersDetectHandler
-        >[0]['notifyProviders'],
+        writeSnapshot: vi.fn(async () => undefined),
+        nowMs: () => 1_700_000_000_000,
+        accountNotify: vi.fn(async (input) => input.events.map(() => 'delivered' as const)),
+        recordNotifyGap: vi.fn(async () => undefined),
       }),
     }),
   ];
@@ -293,16 +297,17 @@ describe('registerCrons', () => {
 
     await registerCrons({ queueSet: stub.queueSet, logger: silentLogger, redis: opsRedis, crons });
     const listeners = stub.workerListeners['technicals-compute'];
-    if (!listeners?.completed || !listeners.failed) throw new Error('listeners not attached');
+    if (!listeners?.['completed'] || !listeners['failed'])
+      throw new Error('listeners not attached');
 
     // A 5s run leaves 25s of the 30s period → next is delayed 25s.
-    listeners.completed({ processedOn: 1_000, finishedOn: 6_000 });
+    listeners['completed']({ processedOn: 1_000, finishedOn: 6_000 });
     // A run that overruns the period collapses to back-to-back (delay 0).
-    listeners.completed({ processedOn: 1_000, finishedOn: 41_000 });
+    listeners['completed']({ processedOn: 1_000, finishedOn: 41_000 });
     // A terminal failure (retry budget spent) still re-arms so the loop cannot
     // silently stop. technicals-compute uses attempts 1, so the first failure is
     // terminal.
-    listeners.failed({
+    listeners['failed']({
       processedOn: 1_000,
       finishedOn: 2_000,
       attemptsMade: 1,
@@ -328,10 +333,10 @@ describe('registerCrons', () => {
       metrics,
     });
     const listeners = stub.workerListeners['technicals-compute'];
-    if (!listeners?.completed) throw new Error('completed listener not attached');
+    if (!listeners?.['completed']) throw new Error('completed listener not attached');
 
     // 40s of work against the 30s period technicals-compute is defined with.
-    listeners.completed({ processedOn: 1_000, finishedOn: 41_000 });
+    listeners['completed']({ processedOn: 1_000, finishedOn: 41_000 });
 
     expect(metrics.record).toHaveBeenCalledWith(CRON_OVERRUN, 1, { cron: 'technicals-compute' });
     expect(metrics.record).toHaveBeenCalledTimes(1);
@@ -364,10 +369,10 @@ describe('registerCrons', () => {
       metrics,
     });
     const listeners = stub.workerListeners['technicals-compute'];
-    if (!listeners?.completed) throw new Error('completed listener not attached');
+    if (!listeners?.['completed']) throw new Error('completed listener not attached');
 
     // 5s of work against the same 30s period.
-    listeners.completed({ processedOn: 1_000, finishedOn: 6_000 });
+    listeners['completed']({ processedOn: 1_000, finishedOn: 6_000 });
 
     expect(metrics.record).not.toHaveBeenCalled();
   });
@@ -381,10 +386,10 @@ describe('registerCrons', () => {
 
     await registerCrons({ queueSet: stub.queueSet, logger: silentLogger, redis: opsRedis, crons });
     const listeners = stub.workerListeners['technicals-compute'];
-    if (!listeners?.failed) throw new Error('failed listener not attached');
+    if (!listeners?.['failed']) throw new Error('failed listener not attached');
 
     // attemptsMade 1 of 3 → BullMQ will retry → must NOT re-arm.
-    listeners.failed({
+    listeners['failed']({
       processedOn: 1_000,
       finishedOn: 2_000,
       attemptsMade: 1,
@@ -393,7 +398,7 @@ describe('registerCrons', () => {
     expect(stub.added.filter((a) => a.queue === 'technicals-compute')).toHaveLength(0);
 
     // The terminal attempt re-arms exactly once.
-    listeners.failed({
+    listeners['failed']({
       processedOn: 1_000,
       finishedOn: 2_000,
       attemptsMade: 3,

--- a/apps/worker/__tests__/crons/stale-order-reap.cron.test.ts
+++ b/apps/worker/__tests__/crons/stale-order-reap.cron.test.ts
@@ -6,8 +6,9 @@ import { buildStaleOrderReapCron } from '../../src/crons/stale-order-reap.cron.j
 import { buildCrons } from '../../src/crons/index.js';
 import type { BootContext } from '../../src/boot/boot-context.js';
 
+type RunReaper = typeof import('../../src/boot/reap-stale-orders.js').runStaleOrderReaper;
 const runReaper = vi.hoisted(() =>
-  vi.fn(async () => ({ checked: 0, reaped: 0, reclaimed: 0, failed: 0 })),
+  vi.fn<RunReaper>(async () => ({ checked: 0, reaped: 0, reclaimed: 0, failed: 0 })),
 );
 vi.mock('../../src/boot/reap-stale-orders.js', () => ({ runStaleOrderReaper: runReaper }));
 

--- a/apps/worker/__tests__/crons/technicals-compute-governor.test.ts
+++ b/apps/worker/__tests__/crons/technicals-compute-governor.test.ts
@@ -40,7 +40,7 @@ const klineRow = (openTimeMs: number, closeTimeMs: number): unknown[] => [
 ];
 
 const stubFetch = (status = 200, requests: string[] = []): typeof globalThis.fetch =>
-  (async (input) => {
+  (async (input: Parameters<typeof globalThis.fetch>[0]) => {
     requests.push(String(input));
     return new Response(
       JSON.stringify(

--- a/apps/worker/__tests__/event-router/event-router.test.ts
+++ b/apps/worker/__tests__/event-router/event-router.test.ts
@@ -11,15 +11,19 @@ import type { TickJobData } from 'queues/job-payloads.js';
 const noopLogger = pino({ level: 'silent' });
 
 const makeProfileManager = (overrides?: Partial<ProfileManager>): ProfileManager => ({
+  setMarket: vi.fn(),
   start: vi.fn(),
+  reconcile: vi.fn(),
   enable: vi.fn(),
   disable: vi.fn(),
   setSymbols: vi.fn(),
+  setTechnicalsIntervals: vi.fn(() => false),
   profilesUsing: () => [],
   symbolsFor: () => [],
   userOf: () => undefined,
   operatorOf: () => undefined,
   accountOf: () => undefined,
+  listActive: () => [],
   shutdown: vi.fn(),
   ...overrides,
 });
@@ -274,6 +278,9 @@ describe('EventRouter', () => {
       qtyLastFilled: '0',
       cumQty: '1',
       cumQuoteQty: '50',
+      commission: '0',
+      commissionAsset: '',
+      tradeId: 1,
       eventTimeMs: 0,
     });
     expect(tickQueue.add).toHaveBeenCalledTimes(1);
@@ -323,6 +330,9 @@ describe('EventRouter', () => {
       qtyLastFilled: '0',
       cumQty: '1',
       cumQuoteQty: '50',
+      commission: '0',
+      commissionAsset: '',
+      tradeId: 1,
       eventTimeMs: 0,
     });
     expect(classifyOrder).toHaveBeenCalledWith(
@@ -374,6 +384,9 @@ describe('EventRouter', () => {
       qtyLastFilled: '0',
       cumQty: '3',
       cumQuoteQty: '150',
+      commission: '0',
+      commissionAsset: '',
+      tradeId: 1,
       eventTimeMs: 0,
     });
     expect(reconcileDetachedFill).toHaveBeenCalledWith({
@@ -427,6 +440,9 @@ describe('EventRouter', () => {
       qtyLastFilled: '0',
       cumQty: '3',
       cumQuoteQty: '150',
+      commission: '0',
+      commissionAsset: '',
+      tradeId: 1,
       eventTimeMs: 1_699_999_999_111,
     });
     expect(reconcileDetachedFill).toHaveBeenCalledWith(
@@ -467,6 +483,9 @@ describe('EventRouter', () => {
         qtyLastFilled: '0',
         cumQty: '0',
         cumQuoteQty: '0',
+        commission: '0',
+        commissionAsset: '',
+        tradeId: 1,
         eventTimeMs: 0,
       }),
     ).resolves.toBeUndefined();
@@ -507,6 +526,9 @@ describe('EventRouter', () => {
       qtyLastFilled: '0',
       cumQty: '1',
       cumQuoteQty: '50',
+      commission: '0',
+      commissionAsset: '',
+      tradeId: 1,
       eventTimeMs: 0,
     });
     expect(classifyOrder).toHaveBeenCalledWith(
@@ -557,6 +579,9 @@ describe('EventRouter', () => {
       qtyLastFilled: '0',
       cumQty: '1',
       cumQuoteQty: '50',
+      commission: '0',
+      commissionAsset: '',
+      tradeId: 1,
       eventTimeMs: 0,
     });
     // The key carries the account but NO profile segment: siblings share it.
@@ -813,6 +838,9 @@ describe('EventRouter', () => {
       qtyLastFilled: '0',
       cumQty: '1',
       cumQuoteQty: '50',
+      commission: '0',
+      commissionAsset: '',
+      tradeId: 1,
       eventTimeMs: 0,
     });
     // Remove-by-orderId via the atomic Lua, TTL refreshed (last ARGV).
@@ -856,6 +884,9 @@ describe('EventRouter', () => {
       qtyLastFilled: '0',
       cumQty: '0.4',
       cumQuoteQty: '20',
+      commission: '0',
+      commissionAsset: '',
+      tradeId: 1,
       eventTimeMs: 0,
     });
     // patch: orderId, executedQty←cumQty, cumQuote←cumQuoteQty, status, ttl.
@@ -905,6 +936,9 @@ describe('EventRouter', () => {
       qtyLastFilled: '0',
       cumQty: '0.4',
       cumQuoteQty: '20',
+      commission: '0',
+      commissionAsset: '',
+      tradeId: 1,
       eventTimeMs: 0,
     });
     expect(redis.eval).toHaveBeenCalledWith(

--- a/apps/worker/__tests__/event-router/execution-report-commission.test.ts
+++ b/apps/worker/__tests__/event-router/execution-report-commission.test.ts
@@ -40,7 +40,7 @@ const makeProfileManager = (): ProfileManager =>
   }) as unknown as ProfileManager;
 
 const makeRouter = () => {
-  const adopt = vi.fn(async () => undefined);
+  const adopt = vi.fn<FillAdopter['adopt']>(async () => undefined);
   const tickQueue = { add: vi.fn(async () => ({ id: 'j' })) } as unknown as Queue<TickJobData>;
   const redis = {
     set: vi.fn(async () => 'OK'),

--- a/apps/worker/__tests__/executor/decisions/cancel-order.test.ts
+++ b/apps/worker/__tests__/executor/decisions/cancel-order.test.ts
@@ -3,8 +3,8 @@ import { pino } from 'pino';
 import type { Redis } from 'ioredis';
 import { BinanceApiError, type BinanceRestClient } from '@app/binance';
 import type { NotifyProviderRegistry } from '@app/notify';
-import type { Decision, ExecutorContext } from '@app/strategy-core';
-import { asProfileId, asUserId } from '@app/contracts';
+import { createRegistry, type Decision, type ExecutorContext } from '@app/strategy-core';
+import { asAccountId, asProfileId, asUserId } from '@app/contracts';
 
 import { cancelOrderHandler } from '../../../src/executor/decisions/cancel-order.js';
 import type { DecisionDeps } from '../../../src/executor/decisions/_types.js';
@@ -14,7 +14,9 @@ import type { ProfilePersistence } from '../../../src/profile-bindings/persisten
 
 const USER = asUserId('00000000-0000-0000-0000-0000000000aa');
 const PROFILE = asProfileId('00000000-0000-0000-0000-0000000000bb');
-const CTX: ExecutorContext = { userId: USER, profileId: PROFILE };
+const ACCOUNT = asAccountId('00000000-0000-0000-0000-0000000000cc');
+const CLOCK = { nowMs: () => 1_700_000_000_000 };
+const CTX: ExecutorContext = { userId: USER, profileId: PROFILE, clock: CLOCK };
 
 const CANCEL: Extract<Decision, { type: 'cancel-order' }> = {
   type: 'cancel-order',
@@ -115,7 +117,13 @@ const buildBindings = (
     ...rest,
     persistence: {
       persistOrder: vi.fn() as unknown as ProfilePersistence['persistOrder'],
-      resolveOrderSlot: async () => ({ symbol: 'BTCUSDT', intent: 'grid-buy' }),
+      resolveOrderSlot: async () => ({
+        symbol: 'BTCUSDT',
+        intent: 'grid-buy',
+        side: 'BUY',
+        remainingQty: '1',
+        price: '1',
+      }),
       persistTrackingOrder: vi.fn(async () => undefined),
       closeOrder: vi.fn(async () => undefined),
       recordBookkeepingFailure: vi.fn(async () => undefined),
@@ -128,10 +136,12 @@ const buildDeps = (bindings: ProfileExecutorBindings, redis: Redis = fakeRedis()
   const registry: Partial<NotifyProviderRegistry> = { get: () => undefined, list: () => [] };
   return {
     redis,
+    accountId: ACCOUNT,
     logger: pino({ level: 'silent' }),
-    clock: { nowMs: () => 1_700_000_000_000 },
+    clock: CLOCK,
     weightTtlSeconds: 120,
     notifyRegistry: registry as NotifyProviderRegistry,
+    strategies: createRegistry(),
     resolveProfile: async () => bindings,
     cancelLedger: createCancelLedger(),
   };
@@ -238,7 +248,11 @@ describe('cancelOrderHandler', () => {
     vi
       .fn()
       .mockRejectedValue(
-        new BinanceApiError({ status: 400, code: -2011, msg: 'Unknown order sent.' }, false),
+        new BinanceApiError(
+          { status: 400, code: -2011, msg: 'Unknown order sent.' },
+          false,
+          'rejected',
+        ),
       );
 
   it('on -2011 racing a FILL, records the row FILLED with the true executed quantity and raw', async () => {
@@ -331,10 +345,8 @@ describe('cancelOrderHandler', () => {
       enqueueSymbolReconcile: vi.fn(async () => {
         throw new Error('redis down');
       }),
+      logger: { error } as unknown as DecisionDeps['logger'],
     } as DecisionDeps;
-    (deps as { logger: { error: typeof error } }).logger = {
-      error,
-    } as unknown as DecisionDeps['logger'];
 
     const result = await cancelOrderHandler(deps, CTX, CANCEL);
 
@@ -357,10 +369,11 @@ describe('cancelOrderHandler', () => {
       persistence: { closeOrder },
     });
     const enqueueSymbolReconcile = vi.fn();
-    const deps = { ...buildDeps(bindings), enqueueSymbolReconcile } as DecisionDeps;
-    (deps as { logger: { warn: typeof warn } }).logger = {
-      warn,
-    } as unknown as DecisionDeps['logger'];
+    const deps = {
+      ...buildDeps(bindings),
+      enqueueSymbolReconcile,
+      logger: { warn } as unknown as DecisionDeps['logger'],
+    } as DecisionDeps;
 
     const result = await cancelOrderHandler(deps, CTX, CANCEL);
 
@@ -402,10 +415,11 @@ describe('cancelOrderHandler', () => {
       persistence: { closeOrder },
     });
     const enqueueSymbolReconcile = vi.fn();
-    const deps = { ...buildDeps(bindings), enqueueSymbolReconcile } as DecisionDeps;
-    (deps as { logger: { warn: typeof warn } }).logger = {
-      warn,
-    } as unknown as DecisionDeps['logger'];
+    const deps = {
+      ...buildDeps(bindings),
+      enqueueSymbolReconcile,
+      logger: { warn } as unknown as DecisionDeps['logger'],
+    } as DecisionDeps;
 
     const result = await cancelOrderHandler(deps, CTX, CANCEL);
 
@@ -441,7 +455,13 @@ describe('cancelOrderHandler', () => {
   });
 
   it('prefers decision.symbol over the local lookup when both are present', async () => {
-    const resolveOrderSlot = vi.fn(async () => ({ symbol: 'BTCUSDT', intent: 'grid-buy' }));
+    const resolveOrderSlot = vi.fn(async () => ({
+      symbol: 'BTCUSDT',
+      intent: 'grid-buy',
+      side: 'BUY',
+      remainingQty: '1',
+      price: '1',
+    }));
     const cancelOrder = vi
       .fn()
       .mockResolvedValue({ orderId: 42, status: 'CANCELED', transactTime: 1_700_000_000_333 });

--- a/apps/worker/__tests__/executor/decisions/emit-event.test.ts
+++ b/apps/worker/__tests__/executor/decisions/emit-event.test.ts
@@ -20,6 +20,7 @@ const stubRegistry: StrategyRegistry = {
   register: () => undefined,
   list: () => [STUB_STRATEGY],
   get: (name) => (name === 'stub' ? STUB_STRATEGY : undefined),
+  describeForProfile: () => ({ status: 'current', strategy: STUB_STRATEGY }),
 };
 
 const CTX = {

--- a/apps/worker/__tests__/executor/decisions/place-order.test.ts
+++ b/apps/worker/__tests__/executor/decisions/place-order.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 import { pino } from 'pino';
 import type { Redis } from 'ioredis';
-import { BinanceApiError, OrderBudgetUnavailableError, type BinanceRestClient } from '@app/binance';
+import {
+  BinanceApiError,
+  OrderBudgetUnavailableError,
+  type BinanceErrorPayload,
+  type BinanceRestClient,
+} from '@app/binance';
 import type { NotifyProviderRegistry, AnyNotifyProvider } from '@app/notify';
-import type { Decision, ExecutorContext } from '@app/strategy-core';
+import { createRegistry, type Decision, type ExecutorContext } from '@app/strategy-core';
 import { asAccountId, asProfileId, asUserId } from '@app/contracts';
 
 import { placeOrderHandler } from '../../../src/executor/decisions/place-order.js';
@@ -18,7 +23,20 @@ import type { ProfilePersistence } from '../../../src/profile-bindings/persisten
 const USER = asUserId('00000000-0000-0000-0000-0000000000aa');
 const PROFILE = asProfileId('00000000-0000-0000-0000-0000000000bb');
 const ACCOUNT = asAccountId('00000000-0000-0000-0000-0000000000cc');
-const CTX: ExecutorContext = { userId: USER, profileId: PROFILE };
+const CLOCK = { nowMs: () => 1_700_000_000_000 };
+const CTX: ExecutorContext = { userId: USER, profileId: PROFILE, clock: CLOCK };
+
+const placeOrderMock = (implementation: BinanceRestClient['placeOrder']) =>
+  vi.fn<BinanceRestClient['placeOrder']>(implementation);
+const persistOrderMock = (implementation: ProfilePersistence['persistOrder']) =>
+  vi.fn<ProfilePersistence['persistOrder']>(implementation);
+const recordBookkeepingFailureMock = (
+  implementation: ProfilePersistence['recordBookkeepingFailure'],
+) => vi.fn<ProfilePersistence['recordBookkeepingFailure']>(implementation);
+const recordNotifierGapMock = (implementation: ProfilePersistence['recordNotifierGap']) =>
+  vi.fn<ProfilePersistence['recordNotifierGap']>(implementation);
+const rejectedBinanceError = (payload: BinanceErrorPayload): BinanceApiError =>
+  new BinanceApiError(payload, false, 'rejected');
 
 const PLACE: Extract<Decision, { type: 'place-order' }> = {
   type: 'place-order',
@@ -71,13 +89,13 @@ const buildBindings = (
     quoteAsset: 'USDT',
     ...rest,
     persistence: {
-      persistOrder: vi.fn(async () => undefined) as unknown as ProfilePersistence['persistOrder'],
+      persistOrder: persistOrderMock(async () => undefined),
       resolveOrderSlot: async () => null,
       persistTrackingOrder: vi.fn(async () => undefined),
       closeOrder: async () => undefined,
-      recordBookkeepingFailure: vi.fn(async () => undefined),
+      recordBookkeepingFailure: recordBookkeepingFailureMock(async () => undefined),
       listEnabledNotifiers: vi.fn(async () => [ENABLED_SLACK_ROW]),
-      recordNotifierGap: vi.fn(async () => undefined),
+      recordNotifierGap: recordNotifierGapMock(async () => undefined),
       ...persistenceOverrides,
     },
   } as ProfileExecutorBindings;
@@ -93,10 +111,12 @@ const buildDeps = (bindings: ProfileExecutorBindings, redis: Redis = fakeRedis()
   };
   return {
     redis,
+    accountId: ACCOUNT,
     logger: pino({ level: 'silent' }),
-    clock: { nowMs: () => 1_700_000_000_000 },
+    clock: CLOCK,
     weightTtlSeconds: 120,
     notifyRegistry: registry as NotifyProviderRegistry,
+    strategies: createRegistry(),
     resolveProfile: async () => bindings,
     cancelLedger: createCancelLedger(),
   };
@@ -137,7 +157,7 @@ describe('placeOrderHandler', () => {
   });
 
   it('records an accepted MARKET placement so the very next identical one is suppressed', async () => {
-    const placeOrder = vi.fn(async () => ({
+    const placeOrder = placeOrderMock(async () => ({
       orderId: 42,
       clientOrderId: 'client-1',
       status: 'FILLED',
@@ -156,7 +176,7 @@ describe('placeOrderHandler', () => {
   });
 
   it('does NOT dedup a LIMIT order (resting order repricing legitimately reuses the clientOrderId)', async () => {
-    const placeOrder = vi.fn(async () => ({
+    const placeOrder = placeOrderMock(async () => ({
       orderId: 43,
       clientOrderId: 'client-1',
       status: 'NEW',
@@ -177,7 +197,7 @@ describe('placeOrderHandler', () => {
   });
 
   it('a SELL forgets the symbol dedup so a legit re-entry (same stable clientOrderId) is NOT suppressed', async () => {
-    const placeOrder = vi.fn(async () => ({
+    const placeOrder = placeOrderMock(async () => ({
       orderId: 42,
       clientOrderId: 'client-1',
       status: 'FILLED',
@@ -200,7 +220,7 @@ describe('placeOrderHandler', () => {
   });
 
   it('records the dedup on accept even when post-submit bookkeeping fails, so the next identical MARKET order is suppressed', async () => {
-    const placeOrder = vi.fn(async () => ({
+    const placeOrder = placeOrderMock(async () => ({
       orderId: 42,
       clientOrderId: 'client-1',
       status: 'FILLED',
@@ -231,10 +251,10 @@ describe('placeOrderHandler', () => {
         status: 'FILLED',
       })),
     } as unknown as Partial<BinanceRestClient>);
-    const persistOrder = vi.fn(async () => {
+    const persistOrder = persistOrderMock(async () => {
       throw new Error('disk full');
     });
-    const recordBookkeepingFailure = vi.fn(async () => undefined);
+    const recordBookkeepingFailure = recordBookkeepingFailureMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -351,13 +371,13 @@ describe('placeOrderHandler', () => {
         status: 'FILLED',
       })),
     } as unknown as Partial<BinanceRestClient>);
-    const persistOrder = vi.fn(async () => {
+    const persistOrder = persistOrderMock(async () => {
       const e = new Error('Failed query: insert into orders ...');
       (e as { cause?: unknown }).cause =
         'null value in column "status" violates not-null constraint';
       throw e;
     });
-    const recordBookkeepingFailure = vi.fn(async () => undefined);
+    const recordBookkeepingFailure = recordBookkeepingFailureMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -386,11 +406,11 @@ describe('placeOrderHandler', () => {
         status: 'FILLED',
       })),
     } as unknown as Partial<BinanceRestClient>);
-    const persistOrder = vi.fn(async () => {
+    const persistOrder = persistOrderMock(async () => {
       throw new Error('disk full');
     });
-    const recordBookkeepingFailure = vi.fn(async () => undefined);
-    const recordNotifierGap = vi.fn(async () => undefined);
+    const recordBookkeepingFailure = recordBookkeepingFailureMock(async () => undefined);
+    const recordNotifierGap = recordNotifierGapMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -426,10 +446,10 @@ describe('placeOrderHandler', () => {
         status: 'FILLED',
       })),
     } as unknown as Partial<BinanceRestClient>);
-    const persistOrder = vi.fn(async () => {
+    const persistOrder = persistOrderMock(async () => {
       throw new Error('disk full');
     });
-    const recordBookkeepingFailure = vi.fn(async () => undefined);
+    const recordBookkeepingFailure = recordBookkeepingFailureMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -462,7 +482,7 @@ describe('placeOrderHandler', () => {
 
   it('weight-throttle on a profile with no enabled notifiers writes a binance-weight-throttle gap and returns retryable', async () => {
     const binance = fakeBinance();
-    const recordNotifierGap = vi.fn(async () => undefined);
+    const recordNotifierGap = recordNotifierGapMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       weightLimit1m: 100,
@@ -494,7 +514,7 @@ describe('placeOrderHandler', () => {
     const binance = fakeBinance({
       placeOrder: vi.fn(async () => ({ orderId: 99, clientOrderId: 'client-1' })),
     } as unknown as Partial<BinanceRestClient>);
-    const persistOrder = vi.fn(async () => undefined);
+    const persistOrder = persistOrderMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -616,18 +636,18 @@ describe('placeOrderHandler', () => {
       (c) => c[3] === 'upsert',
     );
     const cached = JSON.parse(String(upsert?.[4])) as Record<string, unknown>;
-    expect(cached.trailingDelta).toBe(1551);
+    expect(cached['trailingDelta']).toBe(1551);
     // NOT '0'. A zero here is what renders a stop priced at nothing in the UI;
     // the empty string is the same "absent" sentinel a missing stopPrice uses,
     // and every reader parses it to unknown rather than to a real price.
-    expect(cached.price).toBe('');
+    expect(cached['price']).toBe('');
   });
 
   it('forwards intent.meta to persistOrder so strategy order metadata lands in orders.meta', async () => {
     const binance = fakeBinance({
       placeOrder: vi.fn(async () => ({ orderId: 7, clientOrderId: 'client-1', status: 'NEW' })),
     } as unknown as Partial<BinanceRestClient>);
-    const persistOrder = vi.fn(async () => undefined);
+    const persistOrder = persistOrderMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -653,7 +673,7 @@ describe('placeOrderHandler', () => {
     const binance = fakeBinance({
       placeOrder: vi.fn(async () => ({ orderId: 8, clientOrderId: 'client-1', status: 'NEW' })),
     } as unknown as Partial<BinanceRestClient>);
-    const persistOrder = vi.fn(async () => undefined);
+    const persistOrder = persistOrderMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -673,8 +693,12 @@ describe('placeOrderHandler', () => {
     // -1021 recovery (server-time resync + one retry) now lives in the binance
     // client's call(). A -1021 that surfaces here is a persistent host-clock
     // skew, so place-order classifies it non-retryable and calls placeOrder once.
-    const placeOrder = vi.fn(async () => {
-      throw new BinanceApiError({ status: 400, code: -1021, message: 'recvWindow drift' });
+    const placeOrder = placeOrderMock(async () => {
+      throw new BinanceApiError(
+        { status: 400, code: -1021, msg: 'recvWindow drift' },
+        false,
+        'rejected',
+      );
     });
     const binance = fakeBinance({ placeOrder } as unknown as Partial<BinanceRestClient>);
     const bindings = buildBindings({ binance });
@@ -688,11 +712,11 @@ describe('placeOrderHandler', () => {
   });
 
   it('illegal-value (-1100..-1199) emergency code fires an emergency-notify to Slack', async () => {
-    const placeOrder = vi.fn(async () => {
-      throw new BinanceApiError({
+    const placeOrder = placeOrderMock(async () => {
+      throw rejectedBinanceError({
         status: 400,
         code: -1102,
-        message: 'mandatory parameter missing',
+        msg: 'mandatory parameter missing',
       });
     });
     const binance = fakeBinance({ placeOrder } as unknown as Partial<BinanceRestClient>);
@@ -745,7 +769,7 @@ describe('placeOrderHandler', () => {
       false,
       'rejected',
     );
-    const placeOrder = vi.fn(async () => {
+    const placeOrder = placeOrderMock(async () => {
       throw cause;
     });
     const binance = fakeBinance({ placeOrder } as unknown as Partial<BinanceRestClient>);
@@ -778,11 +802,11 @@ describe('placeOrderHandler', () => {
     // that the position was already sold and the fill never reached the stream.
     // Repair the state — but do NOT make the order retryable: a SELL retrying
     // against a balance that is not coming back loops forever.
-    const placeOrder = vi.fn(async () => {
-      throw new BinanceApiError({
+    const placeOrder = placeOrderMock(async () => {
+      throw rejectedBinanceError({
         status: 400,
         code: -2010,
-        message: 'Account has insufficient balance for requested action.',
+        msg: 'Account has insufficient balance for requested action.',
       });
     });
     const binance = fakeBinance({ placeOrder } as unknown as Partial<BinanceRestClient>);
@@ -818,7 +842,7 @@ describe('placeOrderHandler', () => {
     // getMyTrades only when the refusal implies a balance the stream missed. A
     // permission refusal implies nothing about the position and never clears,
     // so reconciling on it just spends weight on every tick, forever.
-    const placeOrder = vi.fn(async () => {
+    const placeOrder = placeOrderMock(async () => {
       throw new BinanceApiError(
         {
           status: 400,
@@ -845,11 +869,11 @@ describe('placeOrderHandler', () => {
   });
 
   it('-2010 on a BUY enqueues nothing: a short quote balance says nothing about the position', async () => {
-    const placeOrder = vi.fn(async () => {
-      throw new BinanceApiError({
+    const placeOrder = placeOrderMock(async () => {
+      throw rejectedBinanceError({
         status: 400,
         code: -2010,
-        message: 'Account has insufficient balance for requested action.',
+        msg: 'Account has insufficient balance for requested action.',
       });
     });
     const binance = fakeBinance({ placeOrder } as unknown as Partial<BinanceRestClient>);
@@ -866,15 +890,15 @@ describe('placeOrderHandler', () => {
   });
 
   it('binance-emergency on a profile with no enabled notifiers writes a gap action_log', async () => {
-    const placeOrder = vi.fn(async () => {
-      throw new BinanceApiError({
+    const placeOrder = placeOrderMock(async () => {
+      throw rejectedBinanceError({
         status: 400,
         code: -1102,
-        message: 'mandatory parameter missing',
+        msg: 'mandatory parameter missing',
       });
     });
     const binance = fakeBinance({ placeOrder } as unknown as Partial<BinanceRestClient>);
-    const recordNotifierGap = vi.fn(async () => undefined);
+    const recordNotifierGap = recordNotifierGapMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -895,15 +919,15 @@ describe('placeOrderHandler', () => {
   });
 
   it('throttle suppresses a second gap action_log within the window for the same topic', async () => {
-    const placeOrder = vi.fn(async () => {
-      throw new BinanceApiError({
+    const placeOrder = placeOrderMock(async () => {
+      throw rejectedBinanceError({
         status: 400,
         code: -1102,
-        message: 'mandatory parameter missing',
+        msg: 'mandatory parameter missing',
       });
     });
     const binance = fakeBinance({ placeOrder } as unknown as Partial<BinanceRestClient>);
-    const recordNotifierGap = vi.fn(async () => undefined);
+    const recordNotifierGap = recordNotifierGapMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -916,7 +940,10 @@ describe('placeOrderHandler', () => {
       .fn<(key: string) => Promise<boolean>>()
       .mockResolvedValueOnce(true)
       .mockResolvedValue(false);
-    const deps: DecisionDeps = { ...buildDeps(bindings), notifierGapThrottle: { allow } };
+    const deps: DecisionDeps = {
+      ...buildDeps(bindings),
+      notifierGapThrottle: { allow, release: vi.fn(async () => undefined) },
+    };
 
     await placeOrderHandler(deps, CTX, PLACE);
     await placeOrderHandler(deps, CTX, PLACE);
@@ -927,15 +954,15 @@ describe('placeOrderHandler', () => {
   });
 
   it('binance-emergency with enabled notifiers does NOT write a gap action_log', async () => {
-    const placeOrder = vi.fn(async () => {
-      throw new BinanceApiError({
+    const placeOrder = placeOrderMock(async () => {
+      throw rejectedBinanceError({
         status: 400,
         code: -1102,
-        message: 'mandatory parameter missing',
+        msg: 'mandatory parameter missing',
       });
     });
     const binance = fakeBinance({ placeOrder } as unknown as Partial<BinanceRestClient>);
-    const recordNotifierGap = vi.fn(async () => undefined);
+    const recordNotifierGap = recordNotifierGapMock(async () => undefined);
     const provider: AnyNotifyProvider = {
       name: 'slack',
       send: vi.fn(async () => undefined),
@@ -963,15 +990,15 @@ describe('placeOrderHandler', () => {
   });
 
   it('records a gap when an enabled notifier resolves to an unregistered provider (no silent failure)', async () => {
-    const placeOrder = vi.fn(async () => {
-      throw new BinanceApiError({
+    const placeOrder = placeOrderMock(async () => {
+      throw rejectedBinanceError({
         status: 400,
         code: -1102,
-        message: 'mandatory parameter missing',
+        msg: 'mandatory parameter missing',
       });
     });
     const binance = fakeBinance({ placeOrder } as unknown as Partial<BinanceRestClient>);
-    const recordNotifierGap = vi.fn(async () => undefined);
+    const recordNotifierGap = recordNotifierGapMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -994,11 +1021,11 @@ describe('placeOrderHandler', () => {
   });
 
   it('fans out to every registered notifier even when one provider send throws', async () => {
-    const placeOrder = vi.fn(async () => {
-      throw new BinanceApiError({
+    const placeOrder = placeOrderMock(async () => {
+      throw rejectedBinanceError({
         status: 400,
         code: -1102,
-        message: 'mandatory parameter missing',
+        msg: 'mandatory parameter missing',
       });
     });
     const binance = fakeBinance({ placeOrder } as unknown as Partial<BinanceRestClient>);
@@ -1016,7 +1043,7 @@ describe('placeOrderHandler', () => {
       get: (n) => (n === 'slack' ? slack : n === 'telegram' ? telegram : undefined),
       list: () => [slack, telegram],
     };
-    const recordNotifierGap = vi.fn(async () => undefined);
+    const recordNotifierGap = recordNotifierGapMock(async () => undefined);
     const bindings = buildBindings({
       binance,
       persistence: {
@@ -1106,10 +1133,10 @@ describe('placeOrderHandler', () => {
     // the wire it is rejected with -2010.
     const binance = fakeBinance({
       placeOrder: vi.fn(async () => {
-        throw new BinanceApiError({
+        throw rejectedBinanceError({
           status: 400,
           code: -2010,
-          message: 'Account has insufficient balance for requested action.',
+          msg: 'Account has insufficient balance for requested action.',
         });
       }),
     } as unknown as Partial<BinanceRestClient>);

--- a/apps/worker/__tests__/executor/event-emitter.test.ts
+++ b/apps/worker/__tests__/executor/event-emitter.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Redis } from 'ioredis';
-import { asProfileId, asUserId } from '@app/contracts';
+import { asAccountId, asProfileId } from '@app/contracts';
 import { emitEvent, type EventEmitterDeps } from '../../src/executor/event-emitter.js';
 
-const USER = asUserId('11111111-1111-1111-1111-111111111111');
+const ACCOUNT = asAccountId('11111111-1111-1111-1111-111111111111');
 const PROFILE = asProfileId('22222222-2222-2222-2222-222222222222');
-const CHANNEL = `events:${USER}:${PROFILE}`;
+const CHANNEL = `events:${ACCOUNT}:${PROFILE}`;
 const TS_MS = 1_700_000_000_000;
 const TS_ISO = '2023-11-14T22:13:20.000Z';
 
@@ -32,7 +32,7 @@ describe('emitEvent', () => {
   it('publishes the WsEvent envelope and appends matching stream fields', async () => {
     const { redis, incr, publish, xadd } = fakeRedis();
 
-    await emitEvent(deps(redis), USER, PROFILE, 'orders', { orderId: 42 });
+    await emitEvent(deps(redis), ACCOUNT, PROFILE, 'orders', { orderId: 42 });
 
     expect(incr).toHaveBeenCalledWith(`${CHANNEL}:seq`);
     // Live pub/sub body is the WsEvent envelope verbatim.
@@ -62,8 +62,16 @@ describe('emitEvent', () => {
   it('assigns a monotonic seq per call', async () => {
     const { redis, publish } = fakeRedis();
 
-    await emitEvent(deps(redis), USER, PROFILE, 'logs', { msg: 'a' });
-    await emitEvent(deps(redis), USER, PROFILE, 'logs', { msg: 'b' });
+    await emitEvent(deps(redis), ACCOUNT, PROFILE, 'logs', {
+      symbol: null,
+      level: 'info',
+      msg: 'a',
+    });
+    await emitEvent(deps(redis), ACCOUNT, PROFILE, 'logs', {
+      symbol: null,
+      level: 'info',
+      msg: 'b',
+    });
 
     expect(JSON.parse(publish.mock.calls[0]?.[1] as string).seq).toBe(1);
     expect(JSON.parse(publish.mock.calls[1]?.[1] as string).seq).toBe(2);

--- a/apps/worker/__tests__/executor/exit-after-cancel.test.ts
+++ b/apps/worker/__tests__/executor/exit-after-cancel.test.ts
@@ -17,7 +17,7 @@ import { pino } from 'pino';
 import type { Redis } from 'ioredis';
 import type { BinanceRestClient } from '@app/binance';
 import type { NotifyProviderRegistry } from '@app/notify';
-import type { Decision, ExecutorContext, StrategyRegistry } from '@app/strategy-core';
+import type { Decision, StrategyRegistry, TickExecutorContext } from '@app/strategy-core';
 import { asAccountId, asProfileId, asUserId } from '@app/contracts';
 
 import {
@@ -30,7 +30,12 @@ import type { ProfilePersistence } from '../../src/profile-bindings/persistence.
 const USER = asUserId('00000000-0000-0000-0000-0000000000aa');
 const PROFILE = asProfileId('00000000-0000-0000-0000-0000000000bb');
 const ACCOUNT = asAccountId('00000000-0000-0000-0000-0000000000cc');
-const CTX: ExecutorContext = { userId: USER, profileId: PROFILE, clock: { nowMs: () => 0 } };
+const CTX: TickExecutorContext = {
+  userId: USER,
+  profileId: PROFILE,
+  clock: { nowMs: () => 0 },
+  strategyName: 'trailing-trade',
+};
 
 // The position, entirely locked by our own resting stop: free 0, locked 189.87.
 const ACCOUNT_INFO = JSON.stringify({
@@ -126,7 +131,7 @@ const buildExecutor = (bindings: ProfileExecutorBindings, redis: Redis) =>
     strategies: {} as unknown as StrategyRegistry,
     logger: pino({ level: 'silent' }),
     resolveProfile: async () => bindings,
-    notifierGapThrottle: { allow: async () => true },
+    notifierGapThrottle: { allow: async () => true, release: async () => undefined },
   });
 
 const fakeBinance = (over: Partial<BinanceRestClient> = {}): BinanceRestClient =>

--- a/apps/worker/__tests__/executor/fill-adopter-concurrent.test.ts
+++ b/apps/worker/__tests__/executor/fill-adopter-concurrent.test.ts
@@ -16,7 +16,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Logger } from 'pino';
 import type { Redis } from 'ioredis';
-import { asProfileId, asUserId } from '@app/contracts';
+import { asAccountId, asProfileId, asUserId } from '@app/contracts';
 import { trailingTradePositionAdapter } from '@app/strategy-trailing-trade';
 
 import { createFillAdopter } from '../../src/executor/fill-adopter.js';
@@ -75,6 +75,7 @@ vi.mock('@app/db', async (importOriginal) => {
 const silentLogger = new Proxy({} as Logger, { get: () => () => undefined }) as Logger;
 
 const USER_ID = asUserId('00000000-0000-0000-0000-000000000001');
+const ACCOUNT_ID = asAccountId('00000000-0000-0000-0000-000000000003');
 const PROFILE_ID = asProfileId('00000000-0000-0000-0000-000000000002');
 
 const makeRedisStub = (): { redis: Redis; store: Map<string, unknown> } => {
@@ -127,7 +128,7 @@ const makeAdopter = () => {
       _v: string,
       _expectedVersion: number | null,
     ): Promise<boolean> => {
-      store.set(buildSymbolStateKey(USER_ID, PROFILE_ID, sym), JSON.stringify(next));
+      store.set(buildSymbolStateKey(ACCOUNT_ID, PROFILE_ID, sym), JSON.stringify(next));
       repoMocks.persistSymbolState(sym, next);
       return true;
     },
@@ -165,6 +166,12 @@ const makeAdopter = () => {
     logger: silentLogger,
     statePort,
     registry,
+    pipelineQueue: { add: vi.fn() } as unknown as Parameters<
+      typeof createFillAdopter
+    >[0]['pipelineQueue'],
+    symbolInfo: {
+      get: vi.fn(async () => ({ baseAsset: 'BTC', filters: { stepSize: '0.00000001' } })),
+    } as unknown as Parameters<typeof createFillAdopter>[0]['symbolInfo'],
   });
   return { adopter, store, persistSymbolState };
 };
@@ -248,7 +255,8 @@ const FIXTURES: readonly SymbolFixture[] = [
 ];
 
 const mkFill = (f: SymbolFixture) => ({
-  userId: USER_ID,
+  operatorId: USER_ID,
+  accountId: ACCOUNT_ID,
   profileId: PROFILE_ID,
   symbol: f.symbol,
   orderId: f.orderId,
@@ -315,7 +323,7 @@ describe('createFillAdopter — 3-symbol concurrent BUYs (per-(profile, symbol) 
     // adopt: a global-write bug would land the last-written marker on
     // every key.
     for (const f of FIXTURES) {
-      const key = buildSymbolStateKey(USER_ID, PROFILE_ID, f.symbol);
+      const key = buildSymbolStateKey(ACCOUNT_ID, PROFILE_ID, f.symbol);
       const body = JSON.parse(String(store.get(key))) as Record<string, unknown>;
       expect(body['marker']).toBe(f.symbol);
       expect(body['avgEntryPrice']).toBe(f.expectedLbp);

--- a/apps/worker/__tests__/executor/fill-backfiller.test.ts
+++ b/apps/worker/__tests__/executor/fill-backfiller.test.ts
@@ -55,7 +55,10 @@ const makeDeps = (opts: { client?: null; trades?: MyTradeDto[]; adoptThrowsOn?: 
   const resolveBinanceClient = vi.fn(async () =>
     opts.client === null ? null : ({ getMyTrades } as unknown as never),
   );
-  const fillAdopter: FillAdopter = { adopt };
+  const fillAdopter: FillAdopter = {
+    adopt,
+    reconcileDetachedFill: vi.fn(async () => undefined),
+  };
   const deps = {
     db: {} as never,
     resolveBinanceClient,

--- a/apps/worker/__tests__/executor/fundable.test.ts
+++ b/apps/worker/__tests__/executor/fundable.test.ts
@@ -5,6 +5,7 @@ import type { AccountSnapshot } from '@app/strategy-core';
 import { fundable } from '../../src/executor/fundable.js';
 
 const snapshot = (rows: Record<string, [string, string]>): AccountSnapshot => ({
+  readable: true,
   balances: Object.fromEntries(
     Object.entries(rows).map(([asset, [free, locked]]) => [
       asset,
@@ -104,7 +105,7 @@ describe('fundable', () => {
       symbol: 'ENAUSDT',
       quoteAsset: 'USDT',
       params: { type: 'MARKET', quantity: '1' },
-      account: { balances: {} },
+      account: { balances: {}, readable: true },
     });
     expect(out.kind).toBe('unknown');
   });

--- a/apps/worker/__tests__/executor/live-executor-apply-all.test.ts
+++ b/apps/worker/__tests__/executor/live-executor-apply-all.test.ts
@@ -19,6 +19,7 @@ import type { Redis } from 'ioredis';
 import type { Decision, DecisionResult, TickExecutorContext } from '@app/strategy-core';
 import type { NotifyProviderRegistry } from '@app/notify';
 import type { StrategyRegistry } from '@app/strategy-registry';
+import { asAccountId, asProfileId, asUserId } from '@app/contracts';
 
 const { placeOrderSpy, cancelOrderSpy, setKvSpy, emitEventSpy } = vi.hoisted(() => ({
   placeOrderSpy: vi.fn(),
@@ -42,9 +43,9 @@ vi.mock('../../src/executor/decisions/emit-event.js', () => ({
 
 import { createLiveExecutor } from '../../src/executor/live-executor.js';
 
-const USER = 'u-1';
-const ACCOUNT = 'a-1';
-const PROFILE = 'p-1';
+const USER = asUserId('u-1');
+const ACCOUNT = asAccountId('a-1');
+const PROFILE = asProfileId('p-1');
 
 // applyAll is the tick path, so its ctx is the strategyName-required narrowing.
 const CTX: TickExecutorContext = {
@@ -79,7 +80,7 @@ const buildExecutor = () =>
     strategies: {} as unknown as StrategyRegistry,
     logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() } as unknown as Logger,
     resolveProfile: vi.fn(async () => ({}) as never),
-    notifierGapThrottle: { allow: async () => true },
+    notifierGapThrottle: { allow: async () => true, release: async () => undefined },
   });
 
 const OK: DecisionResult = { ok: true };

--- a/apps/worker/__tests__/executor/live-executor-scope.test.ts
+++ b/apps/worker/__tests__/executor/live-executor-scope.test.ts
@@ -8,7 +8,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Logger } from 'pino';
 import type { Redis } from 'ioredis';
-import type { Decision, ExecutorContext } from '@app/strategy-core';
+import type { Decision, TickExecutorContext } from '@app/strategy-core';
+import { asAccountId, asProfileId, asUserId } from '@app/contracts';
 import type { ProfileScope } from '@app/db';
 import type { NotifyProviderRegistry } from '@app/notify';
 import type { StrategyRegistry } from '@app/strategy-registry';
@@ -18,11 +19,11 @@ import {
   type ProfileExecutorBindings,
 } from '../../src/executor/live-executor.js';
 
-const USER = 'u-1';
-const ACCOUNT = 'a-1';
-const PROFILE = 'p-1';
+const USER = asUserId('u-1');
+const ACCOUNT = asAccountId('a-1');
+const PROFILE = asProfileId('p-1');
 
-const CTX: ExecutorContext = {
+const CTX: TickExecutorContext = {
   userId: USER,
   profileId: PROFILE,
   clock: { nowMs: () => 0 },
@@ -44,7 +45,7 @@ const buildExecutor = (resolveProfile: ReturnType<typeof vi.fn>) =>
     strategies: {} as unknown as StrategyRegistry,
     logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } as unknown as Logger,
     resolveProfile: resolveProfile as never,
-    notifierGapThrottle: { allow: async () => true },
+    notifierGapThrottle: { allow: async () => true, release: async () => undefined },
   });
 
 const SET_KV: Decision = { type: 'set-kv', key: 'tt:regime', value: 1 };

--- a/apps/worker/__tests__/executor/live-executor-single-place.test.ts
+++ b/apps/worker/__tests__/executor/live-executor-single-place.test.ts
@@ -12,7 +12,8 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Logger } from 'pino';
 import type { Redis } from 'ioredis';
-import type { Decision, DecisionResult, ExecutorContext } from '@app/strategy-core';
+import type { Decision, DecisionResult, TickExecutorContext } from '@app/strategy-core';
+import { asAccountId } from '@app/contracts';
 import type { NotifyProviderRegistry } from '@app/notify';
 import type { StrategyRegistry } from '@app/strategy-registry';
 
@@ -24,12 +25,13 @@ vi.mock('../../src/executor/decisions/place-order.js', () => ({
 
 import { createLiveExecutor, MultiPlacementError } from '../../src/executor/live-executor.js';
 
-const CTX: ExecutorContext = {
+const CTX: TickExecutorContext = {
   userId: 'u-1',
   profileId: 'p-1',
   clock: { nowMs: () => 0 },
   strategyName: 'trailing-trade',
 };
+const ACCOUNT = asAccountId('a-1');
 
 const place = (clientOrderId: string): Decision => ({
   type: 'place-order',
@@ -47,7 +49,7 @@ const buildExecutor = () =>
     strategies: {} as unknown as StrategyRegistry,
     logger: mkLogger(),
     resolveProfile: vi.fn(async () => ({}) as never),
-    notifierGapThrottle: { allow: async () => true },
+    notifierGapThrottle: { allow: async () => true, release: async () => undefined },
   });
 
 beforeEach(() => {
@@ -58,7 +60,7 @@ beforeEach(() => {
 describe('LiveExecutor.applyAll — one placement per tick', () => {
   it('throws MultiPlacementError carrying the profile and placement count', async () => {
     const err = await buildExecutor()
-      .applyAll(CTX, 'a-1', [place('coid-1'), place('coid-2')])
+      .applyAll(CTX, ACCOUNT, [place('coid-1'), place('coid-2')])
       .then(
         () => undefined,
         (e: unknown) => e,
@@ -71,7 +73,7 @@ describe('LiveExecutor.applyAll — one placement per tick', () => {
   });
 
   it('applies the single-placement tick every strategy actually emits', async () => {
-    const applied = await buildExecutor().applyAll(CTX, 'a-1', [place('coid-1')]);
+    const applied = await buildExecutor().applyAll(CTX, ACCOUNT, [place('coid-1')]);
     expect(applied).toHaveLength(1);
     expect(placeOrderSpy).toHaveBeenCalledTimes(1);
   });

--- a/apps/worker/__tests__/executor/notifier-gap-throttle.test.ts
+++ b/apps/worker/__tests__/executor/notifier-gap-throttle.test.ts
@@ -28,7 +28,18 @@ const fakeLogger = () => ({ warn: vi.fn() }) as unknown as Logger;
 describe('createNotifierGapThrottle', () => {
   it('allows when Redis SET NX succeeds and suppresses when it is already set', async () => {
     // 'OK' → key was absent (window opened); null → key present (suppressed).
-    const set = vi.fn<Redis['set']>().mockResolvedValueOnce('OK').mockResolvedValue(null);
+    const set = vi
+      .fn<
+        (
+          key: string,
+          value: string,
+          mode: 'PX',
+          ttl: number,
+          condition: 'NX',
+        ) => Promise<'OK' | null>
+      >()
+      .mockResolvedValueOnce('OK')
+      .mockResolvedValue(null);
     const redis = { set } as unknown as Redis;
     const t = createNotifierGapThrottle({ redis, logger: fakeLogger(), windowMs: 1000 });
 

--- a/apps/worker/__tests__/executor/order-budget-defer.test.ts
+++ b/apps/worker/__tests__/executor/order-budget-defer.test.ts
@@ -12,10 +12,11 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Logger } from 'pino';
 import type { Redis } from 'ioredis';
-import type { Decision, DecisionResult, ExecutorContext } from '@app/strategy-core';
+import type { Decision, DecisionResult, TickExecutorContext } from '@app/strategy-core';
 import type { NotifyProviderRegistry } from '@app/notify';
 import type { StrategyRegistry } from '@app/strategy-registry';
 import type { OrderRateGovernor } from '@app/binance';
+import { asAccountId } from '@app/contracts';
 
 const { placeOrderSpy, cancelOrderSpy } = vi.hoisted(() => ({
   placeOrderSpy: vi.fn(),
@@ -33,12 +34,13 @@ import { createLiveExecutor } from '../../src/executor/live-executor.js';
 import type { ProfileExecutorBindings } from '../../src/executor/live-executor.js';
 import type { MetricsSink } from '../../src/metrics/catalog.js';
 
-const CTX: ExecutorContext = {
+const CTX: TickExecutorContext = {
   userId: '11111111-1111-4111-8111-111111111111',
   profileId: '22222222-2222-4222-8222-222222222222',
   clock: { nowMs: () => 0 },
   strategyName: 'momentum',
 };
+const ACCOUNT = asAccountId('a-1');
 
 const rearmPlace: Decision = {
   type: 'place-order',
@@ -84,7 +86,7 @@ const buildExecutor = (bindings: Partial<ProfileExecutorBindings> | null) => {
     logger,
     metrics,
     resolveProfile: vi.fn(async () => bindings as ProfileExecutorBindings | null),
-    notifierGapThrottle: { allow: async () => true },
+    notifierGapThrottle: { allow: async () => true, release: async () => undefined },
   });
   return { executor, logger, metrics };
 };
@@ -100,7 +102,7 @@ describe('LiveExecutor.applyAll — ORDERS budget deferral', () => {
     const orderGovernor = governor(false);
     const { executor, logger, metrics } = buildExecutor({ orderGovernor });
 
-    const applied = await executor.applyAll(CTX, 'a-1', [supersedeCancel, rearmPlace]);
+    const applied = await executor.applyAll(CTX, ACCOUNT, [supersedeCancel, rearmPlace]);
 
     // Nothing reached Binance: the stop already resting is still the protection.
     expect(cancelOrderSpy).not.toHaveBeenCalled();
@@ -135,7 +137,7 @@ describe('LiveExecutor.applyAll — ORDERS budget deferral', () => {
   it('applies the re-arm pair when headroom exists', async () => {
     const { executor, metrics } = buildExecutor({ orderGovernor: governor(true) });
 
-    const applied = await executor.applyAll(CTX, 'a-1', [supersedeCancel, rearmPlace]);
+    const applied = await executor.applyAll(CTX, ACCOUNT, [supersedeCancel, rearmPlace]);
 
     expect(cancelOrderSpy).toHaveBeenCalledTimes(1);
     expect(placeOrderSpy).toHaveBeenCalledTimes(1);
@@ -151,7 +153,7 @@ describe('LiveExecutor.applyAll — ORDERS budget deferral', () => {
     const orderGovernor = governor(false);
     const { executor } = buildExecutor({ orderGovernor });
 
-    const applied = await executor.applyAll(CTX, 'a-1', [supersedeCancel, exitPlace]);
+    const applied = await executor.applyAll(CTX, ACCOUNT, [supersedeCancel, exitPlace]);
 
     expect(orderGovernor.hasHeadroom).not.toHaveBeenCalled();
     expect(placeOrderSpy).toHaveBeenCalledTimes(1);
@@ -161,7 +163,7 @@ describe('LiveExecutor.applyAll — ORDERS budget deferral', () => {
   it('runs the non-order decisions of a deferred batch — only orders are budget-bound', async () => {
     const { executor } = buildExecutor({ orderGovernor: governor(false) });
 
-    const applied = await executor.applyAll(CTX, 'a-1', [rearmPlace, setKv]);
+    const applied = await executor.applyAll(CTX, ACCOUNT, [rearmPlace, setKv]);
 
     expect(placeOrderSpy).not.toHaveBeenCalled();
     expect(applied[1]?.decision).toBe(setKv);
@@ -175,7 +177,7 @@ describe('LiveExecutor.applyAll — ORDERS budget deferral', () => {
     // The posture when exchangeInfo published no ORDERS rows: unaccounted, not blocked.
     const { executor } = buildExecutor({});
 
-    await executor.applyAll(CTX, 'a-1', [supersedeCancel, rearmPlace]);
+    await executor.applyAll(CTX, ACCOUNT, [supersedeCancel, rearmPlace]);
 
     expect(placeOrderSpy).toHaveBeenCalledTimes(1);
   });
@@ -183,7 +185,7 @@ describe('LiveExecutor.applyAll — ORDERS budget deferral', () => {
   it('applies the re-arm when the profile no longer resolves, leaving the refusal to the handlers', async () => {
     const { executor } = buildExecutor(null);
 
-    const applied = await executor.applyAll(CTX, 'a-1', [rearmPlace]);
+    const applied = await executor.applyAll(CTX, ACCOUNT, [rearmPlace]);
 
     expect(placeOrderSpy).toHaveBeenCalledTimes(1);
     expect(applied[0]?.result.ok).toBe(true);

--- a/apps/worker/__tests__/executor/redis-namespace.test.ts
+++ b/apps/worker/__tests__/executor/redis-namespace.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { asAccountId, asProfileId, asUserId } from '@app/contracts';
+import { asAccountId, asProfileId } from '@app/contracts';
 import {
   buildAccountInfoKey,
   buildDisableActionKey,
@@ -18,21 +18,25 @@ describe('catalogued profile key builders', () => {
   // These builders are thin wrappers over `@app/db`'s `profileKey`; the
   // assertions pin the worker-side bytes so a catalogue suffix change cannot
   // silently desync the worker writer from the projection / API reader.
-  const userId = asUserId('user-1');
+  const accountId = asAccountId('user-1');
   const profileId = asProfileId('profile-1');
   const prefix = 'tenant:user-1:profile:profile-1:';
 
   it('produce the tenant-prefixed key for each catalogue entry', () => {
-    expect(buildKillSwitchKey(userId, profileId)).toBe(`${prefix}kill-switch`);
-    expect(buildSymbolStateKey(userId, profileId, 'BTCUSDT')).toBe(`${prefix}symbol-state:BTCUSDT`);
-    expect(buildOrderRefusalKey(userId, profileId, 'BTCUSDT')).toBe(
+    expect(buildKillSwitchKey(accountId, profileId)).toBe(`${prefix}kill-switch`);
+    expect(buildSymbolStateKey(accountId, profileId, 'BTCUSDT')).toBe(
+      `${prefix}symbol-state:BTCUSDT`,
+    );
+    expect(buildOrderRefusalKey(accountId, profileId, 'BTCUSDT')).toBe(
       `${prefix}order-refusal:BTCUSDT`,
     );
-    expect(buildProfileTickMetaKey(userId, profileId)).toBe(`${prefix}profile-tick-meta`);
-    expect(buildAccountInfoKey(userId, profileId)).toBe(`${prefix}account-info`);
-    expect(buildDustEligibleKey(userId, profileId)).toBe(`${prefix}dust-eligible`);
-    expect(buildUserStreamEventKey(userId, profileId)).toBe(`${prefix}user-stream:last-event`);
-    expect(buildWeightKey(userId, profileId, 29_142_001)).toBe(`${prefix}binance:weight:29142001`);
+    expect(buildProfileTickMetaKey(accountId, profileId)).toBe(`${prefix}profile-tick-meta`);
+    expect(buildAccountInfoKey(accountId, profileId)).toBe(`${prefix}account-info`);
+    expect(buildDustEligibleKey(accountId, profileId)).toBe(`${prefix}dust-eligible`);
+    expect(buildUserStreamEventKey(accountId, profileId)).toBe(`${prefix}user-stream:last-event`);
+    expect(buildWeightKey(accountId, profileId, 29_142_001)).toBe(
+      `${prefix}binance:weight:29142001`,
+    );
   });
 });
 

--- a/apps/worker/__tests__/executor/safe-notify.test.ts
+++ b/apps/worker/__tests__/executor/safe-notify.test.ts
@@ -14,7 +14,7 @@ describe('safeNotify', () => {
     const provider = fakeProvider('slack', send);
     const ok = await safeNotify(
       provider,
-      { severity: 'info', topic: 't', payload: {} },
+      { severity: 'info', topic: 't', title: 'Test notification' },
       { webhook: 'https://x' },
       logger,
     );
@@ -29,7 +29,7 @@ describe('safeNotify', () => {
     });
     const ok = await safeNotify(
       provider,
-      { severity: 'error', topic: 't', payload: {} },
+      { severity: 'error', topic: 't', title: 'Test notification' },
       {},
       logger,
     );
@@ -42,7 +42,7 @@ describe('safeNotify', () => {
     });
     const ok = await safeNotify(
       provider,
-      { severity: 'error', topic: 't', payload: {} },
+      { severity: 'error', topic: 't', title: 'Test notification' },
       {},
       logger,
     );
@@ -55,7 +55,7 @@ describe('safeNotify', () => {
     });
     const ok = await safeNotify(
       provider,
-      { severity: 'error', topic: 't', payload: {} },
+      { severity: 'error', topic: 't', title: 'Test notification' },
       {},
       logger,
     );

--- a/apps/worker/__tests__/executor/weight-limiter.test.ts
+++ b/apps/worker/__tests__/executor/weight-limiter.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Redis } from 'ioredis';
-import { asProfileId, asUserId } from '@app/contracts';
+import { asAccountId, asProfileId } from '@app/contracts';
 import { readCurrentWeight, recordWeight } from '../../src/executor/weight-limiter.js';
 
-const USER = asUserId('00000000-0000-0000-0000-0000000000aa');
+const ACCOUNT = asAccountId('00000000-0000-0000-0000-0000000000aa');
 const PROFILE = asProfileId('00000000-0000-0000-0000-0000000000bb');
 
 const fixedClock = (ms: number): { nowMs(): number } => ({ nowMs: () => ms });
@@ -23,14 +23,14 @@ describe('weight-limiter', () => {
   it('recordWeight is a no-op when Binance returned no weight header', async () => {
     const set = vi.fn();
     const redis = { set } as unknown as Redis;
-    await recordWeight({ redis, clock: fixedClock(0) }, USER, PROFILE, undefined);
+    await recordWeight({ redis, clock: fixedClock(0) }, ACCOUNT, PROFILE, undefined);
     expect(set).not.toHaveBeenCalled();
   });
 
   it('recordWeight writes the bucketed key with EX 120 by default', async () => {
     const set = vi.fn(async () => 'OK');
     const redis = { set } as unknown as Redis;
-    await recordWeight({ redis, clock: fixedClock(1_700_000_000_000) }, USER, PROFILE, 450);
+    await recordWeight({ redis, clock: fixedClock(1_700_000_000_000) }, ACCOUNT, PROFILE, 450);
     expect(set).toHaveBeenCalledOnce();
     const args = set.mock.calls[0] as unknown[];
     expect(args[1]).toBe('450');
@@ -40,14 +40,14 @@ describe('weight-limiter', () => {
 
   it('readCurrentWeight returns 0 when the bucket key is absent', async () => {
     const redis = fakeRedis(new Map());
-    const w = await readCurrentWeight({ redis, clock: fixedClock(0) }, USER, PROFILE);
+    const w = await readCurrentWeight({ redis, clock: fixedClock(0) }, ACCOUNT, PROFILE);
     expect(w).toBe(0);
   });
 
   it('readCurrentWeight parses an integer from the stored value', async () => {
     const clock = fixedClock(1_700_000_000_000);
     const redis = fakeRedis();
-    await recordWeight({ redis, clock }, USER, PROFILE, 789);
-    expect(await readCurrentWeight({ redis, clock }, USER, PROFILE)).toBe(789);
+    await recordWeight({ redis, clock }, ACCOUNT, PROFILE, 789);
+    expect(await readCurrentWeight({ redis, clock }, ACCOUNT, PROFILE)).toBe(789);
   });
 });

--- a/apps/worker/__tests__/integration/multi-symbol-state-isolation.test.ts
+++ b/apps/worker/__tests__/integration/multi-symbol-state-isolation.test.ts
@@ -90,11 +90,20 @@ const buildStubStrategy = (): Strategy<unknown, SymbolMarkerState> => {
     version: '2.0.0',
     displayName: 'Symbol-marker stub',
     description: 'integration-test strategy that stamps the per-symbol slice with its symbol',
-    capabilities: { candleIntervals: ['1h'] },
-    configSchema: empty as unknown as z.ZodType<unknown>,
+    capabilities: {
+      candleIntervals: ['1h'],
+      needsUserDataStream: false,
+      needsMiniTicker: false,
+      bundleProviders: [],
+      operatorActions: [],
+    },
+    configSchema: empty,
+    overrideConfigSchema: empty,
     stateSchema,
     bundleSchema: empty as unknown as z.ZodType<Readonly<Record<string, never>>>,
     events: {},
+    defaultConfig: {},
+    previewLevels: () => ({ sections: [] }),
     initialState: () => ({
       schemaVersion: '2.0.0',
       markerSymbol: null,
@@ -148,6 +157,7 @@ const buildColdLoad = (): SnapshotColdLoad => {
     loadAccountDeployedQuote: async () => '0',
     loadOpenOrders: async (): Promise<readonly OpenOrder[]> => [],
     loadSymbolState: async () => null,
+    loadProfileKv: async () => ({}),
   };
 };
 
@@ -190,6 +200,7 @@ const buildMarketDataPort = (): MarketDataPort => ({
         low: close,
         close,
         volume: '1',
+        isClosed: true as const,
       },
     ];
   },
@@ -337,7 +348,12 @@ const buildHarness = async (): Promise<Harness> => {
       quoteAsset: 'USDT',
       weightLimit1m: 1200,
       candleInterval: '1h',
-      technicalsConfig: { useOnlyWithinMin: 2, ifExpires: 'do-not-buy' },
+      technicalsConfig: {
+        useOnlyWithinMin: 2,
+        ifExpires: 'do-not-buy',
+        entryConfirmReads: 1,
+        intervals: [],
+      },
       needsAccountDeployedQuote: false,
       reserveBaseQuantity: null,
     }),

--- a/apps/worker/__tests__/integration/tick-and-audit-drain.test.ts
+++ b/apps/worker/__tests__/integration/tick-and-audit-drain.test.ts
@@ -103,11 +103,20 @@ const buildStubStrategy = (): Strategy<unknown, StubState> => {
     version: '1.0.0',
     displayName: 'Stub place-buy',
     description: 'integration-test strategy that emits one place-order per tick',
-    capabilities: { candleIntervals: ['1h'] },
-    configSchema: empty as unknown as z.ZodType<unknown>,
+    capabilities: {
+      candleIntervals: ['1h'],
+      needsUserDataStream: false,
+      needsMiniTicker: false,
+      bundleProviders: [],
+      operatorActions: [],
+    },
+    configSchema: empty,
+    overrideConfigSchema: empty,
     stateSchema,
     bundleSchema: empty as unknown as z.ZodType<Readonly<Record<string, never>>>,
     events: {},
+    defaultConfig: {},
+    previewLevels: () => ({ sections: [] }),
     initialState: () => ({ tickCount: 0 }),
     tick: (input) => {
       const next: StubState = { tickCount: input.state.tickCount + 1 };
@@ -204,6 +213,7 @@ const buildColdLoad = (): SnapshotColdLoad => {
     loadAccountDeployedQuote: async () => '0',
     loadOpenOrders: async (): Promise<readonly OpenOrder[]> => [],
     loadSymbolState: async () => null,
+    loadProfileKv: async () => ({}),
   };
 };
 
@@ -277,7 +287,7 @@ const buildHarness = async (): Promise<Harness> => {
     logger,
     registry,
     coldLoad,
-    persistSymbolState: async () => undefined,
+    persistSymbolState: async () => true,
   });
 
   const handler = createTickHandler({
@@ -311,7 +321,12 @@ const buildHarness = async (): Promise<Harness> => {
       quoteAsset: 'USDT',
       weightLimit1m: 1200,
       candleInterval: '1h',
-      technicalsConfig: { useOnlyWithinMin: 2, ifExpires: 'do-not-buy' },
+      technicalsConfig: {
+        useOnlyWithinMin: 2,
+        ifExpires: 'do-not-buy',
+        entryConfirmReads: 1,
+        intervals: [],
+      },
       needsAccountDeployedQuote: false,
       reserveBaseQuantity: null,
     }),

--- a/apps/worker/__tests__/integration/tick-tv-bundle.test.ts
+++ b/apps/worker/__tests__/integration/tick-tv-bundle.test.ts
@@ -12,9 +12,8 @@ import { Redis } from 'ioredis';
 import { pino } from 'pino';
 
 import {
+  asAccountId,
   asProfileId,
-  asUserId,
-  type AccountId,
   TechnicalsSignalSchema,
   type ManualOverridePayload,
   type TechnicalsBundle,
@@ -29,7 +28,7 @@ import { createTickBundleProvider } from '../../src/tick/bundle-builder.js';
 const HAS_INFRA = process.env['TESTCONTAINERS'] === '1' || Boolean(process.env['REDIS_TEST_URL']);
 const describeIfInfra = HAS_INFRA ? describe : describe.skip;
 
-const USER = asUserId('00000000-0000-0000-0000-000000000abc');
+const ACCOUNT = asAccountId('00000000-0000-0000-0000-000000000abc');
 const PROFILE = asProfileId('00000000-0000-0000-0000-000000000def');
 const SYMBOL = 'BTCUSDT';
 const INTERVAL = '1h';
@@ -41,6 +40,7 @@ const PROVIDERS = ['technicals', 'override'];
 const TV_CONFIG: TechnicalsBundleConfig = {
   useOnlyWithinMin: 2,
   ifExpires: 'do-not-buy',
+  entryConfirmReads: 1,
   intervals: [
     {
       interval: INTERVAL,
@@ -49,6 +49,7 @@ const TV_CONFIG: TechnicalsBundleConfig = {
       whenSell: false,
       whenStrongSell: false,
       whenNeutral: false,
+      mode: 'advisory',
     },
   ],
 };
@@ -85,7 +86,7 @@ describeIfInfra('tick bundle provider — Redis-backed', () => {
     await r.set(key, JSON.stringify(seeded));
     try {
       const provider = createTickBundleProvider({ redis: r, logger: pino({ level: 'silent' }) });
-      const bundle = (await provider(USER, PROFILE, SYMBOL, TV_CONFIG, PROVIDERS))
+      const bundle = (await provider(ACCOUNT, PROFILE, SYMBOL, TV_CONFIG, PROVIDERS))
         .bundle as unknown as ProviderBundle;
       expect(bundle.technicals.signals).toHaveLength(1);
       expect(bundle.technicals.signals[0]).toEqual({ interval: INTERVAL, signal: seeded });
@@ -105,7 +106,7 @@ describeIfInfra('tick bundle provider — Redis-backed', () => {
       redis,
       logger: pino({ level: 'silent' }),
     });
-    const bundle = (await provider(USER, PROFILE, SYMBOL, TV_CONFIG, PROVIDERS))
+    const bundle = (await provider(ACCOUNT, PROFILE, SYMBOL, TV_CONFIG, PROVIDERS))
       .bundle as unknown as ProviderBundle;
     expect(bundle.technicals.signals).toHaveLength(1);
     expect(bundle.technicals.signals[0]).toEqual({ interval: INTERVAL, signal: null });
@@ -117,11 +118,7 @@ describeIfInfra('tick bundle provider — Redis-backed', () => {
     // consuming DEL. The tick handler re-arms a deferred override off this value.
     if (!redis) throw new Error('fixture not ready');
     const r = redis;
-    const overrideKey = profileKey(
-      { accountId: USER as unknown as AccountId, profileId: PROFILE },
-      'override',
-      SYMBOL,
-    );
+    const overrideKey = profileKey({ accountId: ACCOUNT, profileId: PROFILE }, 'override', SYMBOL);
     await r.set(
       overrideKey,
       JSON.stringify({ kind: 'trigger-sell', overrideActionId: OVERRIDE_ACTION_ID }),
@@ -130,7 +127,7 @@ describeIfInfra('tick bundle provider — Redis-backed', () => {
     );
     try {
       const provider = createTickBundleProvider({ redis: r, logger: pino({ level: 'silent' }) });
-      const result = await provider(USER, PROFILE, SYMBOL, TV_CONFIG, PROVIDERS);
+      const result = await provider(ACCOUNT, PROFILE, SYMBOL, TV_CONFIG, PROVIDERS);
       expect((result.bundle as unknown as ProviderBundle).override).toMatchObject({
         kind: 'trigger-sell',
         overrideActionId: OVERRIDE_ACTION_ID,

--- a/apps/worker/__tests__/lib/binance-snapshot.test.ts
+++ b/apps/worker/__tests__/lib/binance-snapshot.test.ts
@@ -46,8 +46,14 @@ describe('openOrdersFromDtos', () => {
     ...overrides,
   });
 
+  const firstOrder = (input: OpenOrderDto): ReturnType<typeof openOrdersFromDtos>[number] => {
+    const order = openOrdersFromDtos([input])[0];
+    if (!order) throw new Error('expected one open order');
+    return order;
+  };
+
   it('maps DTO timestamps to *Ms fields and preserves enums', () => {
-    const [o] = openOrdersFromDtos([dto()]);
+    const o = firstOrder(dto());
     expect(o).toEqual({
       orderId: 42,
       clientOrderId: 'co-1',
@@ -69,18 +75,19 @@ describe('openOrdersFromDtos', () => {
     // Binance reports zero stop-price in several forms depending on
     // endpoint/symbol — all mean "no stop price set".
     for (const zero of ['0', '0.0', '0.00000000', '']) {
-      const [o] = openOrdersFromDtos([dto({ stopPrice: zero })]);
+      const o = firstOrder(dto({ stopPrice: zero }));
       expect(o).not.toHaveProperty('stopPrice');
     }
   });
 
   it('includes stopPrice when DTO reports a real value', () => {
-    const [o] = openOrdersFromDtos([dto({ stopPrice: '49000' })]);
+    const o = firstOrder(dto({ stopPrice: '49000' }));
     expect(o.stopPrice).toBe('49000');
   });
 
   it('omits timeInForce when DTO omits it', () => {
-    const [o] = openOrdersFromDtos([dto({ timeInForce: undefined })]);
+    const { timeInForce: _timeInForce, ...withoutTimeInForce } = dto();
+    const o = firstOrder(withoutTimeInForce);
     expect(o).not.toHaveProperty('timeInForce');
   });
 
@@ -95,9 +102,9 @@ describe('openOrdersFromDtos', () => {
     // dead-letter every tick on that symbol for as long as the order rests —
     // the position would go wholly unmanaged, which is the opposite of what
     // arming a stop was for.
-    const [o] = openOrdersFromDtos([
+    const o = firstOrder(
       dto({ type: 'STOP_LOSS', side: 'SELL', stopPrice: '0', trailingDelta: 1551 }),
-    ]);
+    );
     expect(o.type).toBe('STOP_LOSS');
     // The distance is the only field that can tell a later tick whether the
     // resting order still matches the configured stop: a trailing order has no
@@ -112,7 +119,7 @@ describe('openOrdersFromDtos', () => {
     // value is a payload we cannot read, and reading it as a distance would
     // compare a resting order against a number it does not hold.
     expect(
-      openOrdersFromDtos([dto({ trailingDelta: '1551' } as Partial<OpenOrderDto>)])[0],
+      firstOrder({ ...dto(), trailingDelta: '1551' } as unknown as OpenOrderDto),
     ).not.toHaveProperty('trailingDelta');
   });
 });

--- a/apps/worker/__tests__/lib/shutdown-teardown.test.ts
+++ b/apps/worker/__tests__/lib/shutdown-teardown.test.ts
@@ -73,6 +73,9 @@ describe('runTeardown', () => {
     const adminOrder = deps.adminServer.stop.mock.invocationCallOrder[0];
     const poolOrder = deps.pool.end.mock.invocationCallOrder[0];
     const redisOrder = deps.redis.quit.mock.invocationCallOrder[0];
+    if (adminOrder === undefined || poolOrder === undefined || redisOrder === undefined) {
+      throw new Error('expected each teardown step to run');
+    }
     expect(adminOrder).toBeLessThan(poolOrder);
     expect(poolOrder).toBeLessThan(redisOrder);
   });

--- a/apps/worker/__tests__/market-data/market-liveness-watchdog.test.ts
+++ b/apps/worker/__tests__/market-data/market-liveness-watchdog.test.ts
@@ -15,6 +15,8 @@ import {
 import type { ParsedMarketEvent } from '../../src/market-data/types.js';
 
 const silentLogger = pino({ level: 'silent' });
+type WatchdogDeps = Parameters<typeof createMarketLivenessWatchdog>[0];
+const feedSpy = () => vi.fn<WatchdogDeps['feed']>(async () => undefined);
 
 // Fresh-feed defaults: a connected socket whose last frame was just now. The
 // stall tests override msSinceLastFrame; the gap tests set isConnected false.
@@ -26,7 +28,7 @@ const freshDeps = () => ({
 describe('createMarketLivenessWatchdog', () => {
   it('is inert while the WS is connected and frames are fresh — no poll, no feed, no reconnect', async () => {
     const fetchPrice = vi.fn(async () => '100');
-    const feed = vi.fn(async () => undefined);
+    const feed = feedSpy();
     const forceReconnect = vi.fn();
     const wd = createMarketLivenessWatchdog({
       isConnected: () => true,
@@ -50,7 +52,7 @@ describe('createMarketLivenessWatchdog', () => {
     // real fetcher's synchronous flip is verified in the @app/binance suite
     // (kline-fetcher.test.ts, "forceReconnect ... flips isConnected false ...").
     let connected = true;
-    const feed = vi.fn(async () => undefined);
+    const feed = feedSpy();
     const forceReconnect = vi.fn(() => {
       connected = false;
     });
@@ -78,7 +80,7 @@ describe('createMarketLivenessWatchdog', () => {
 
   it('does NOT force a reconnect when connected with no subscribed symbols (no frames expected)', async () => {
     const forceReconnect = vi.fn();
-    const feed = vi.fn(async () => undefined);
+    const feed = feedSpy();
     const wd = createMarketLivenessWatchdog({
       isConnected: () => true,
       msSinceLastFrame: () => 999_999, // very stale, but nothing is subscribed
@@ -119,7 +121,7 @@ describe('createMarketLivenessWatchdog', () => {
 
   it('during a gap, feeds a synthetic mini-ticker per symbol carrying the polled price', async () => {
     const prices: Record<string, string> = { BTCUSDT: '64000', ETHUSDT: '3000' };
-    const feed = vi.fn(async () => undefined);
+    const feed = feedSpy();
     const wd = createMarketLivenessWatchdog({
       isConnected: () => false,
       ...freshDeps(),
@@ -147,7 +149,7 @@ describe('createMarketLivenessWatchdog', () => {
   });
 
   it('skips a symbol whose price is unavailable (null) without feeding', async () => {
-    const feed = vi.fn(async () => undefined);
+    const feed = feedSpy();
     const wd = createMarketLivenessWatchdog({
       isConnected: () => false,
       ...freshDeps(),
@@ -162,7 +164,7 @@ describe('createMarketLivenessWatchdog', () => {
   });
 
   it('swallows a per-symbol poll failure and still feeds the others', async () => {
-    const feed = vi.fn(async () => undefined);
+    const feed = feedSpy();
     const wd = createMarketLivenessWatchdog({
       isConnected: () => false,
       ...freshDeps(),

--- a/apps/worker/__tests__/market-data/subscriptions-manager.test.ts
+++ b/apps/worker/__tests__/market-data/subscriptions-manager.test.ts
@@ -292,7 +292,9 @@ describe('createMarketSubscriptionsManager', () => {
       logger: silentLogger,
     });
     await mgr.addSymbols(['BTCUSDT', 'ETHUSDT'], '1h');
-    const onResync = vi.fn(async () => undefined);
+    const onResync = vi.fn<Parameters<typeof triggerResyncForAllSubscribed>[1]>(
+      async () => undefined,
+    );
     await triggerResyncForAllSubscribed(mgr, onResync);
     expect(onResync).toHaveBeenCalledTimes(2);
     const calls = onResync.mock.calls.map((c) => c[0]).sort();

--- a/apps/worker/__tests__/notifiers/account-notify-event.test.ts
+++ b/apps/worker/__tests__/notifiers/account-notify-event.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import pino from 'pino';
-import type { NotifyProviderRegistry } from '@app/notify';
+import type { AnyNotifyProvider, NotifyProviderRegistry } from '@app/notify';
 
 const h = vi.hoisted(() => ({
   get: vi.fn(),
@@ -60,12 +60,14 @@ describe('isAccountEventEnabled', () => {
 });
 
 describe('createAccountNotifyEvent', () => {
-  const registryWith = (send: ReturnType<typeof vi.fn>): NotifyProviderRegistry =>
+  const registryWith = (
+    send: ReturnType<typeof vi.fn<AnyNotifyProvider['send']>>,
+  ): NotifyProviderRegistry =>
     ({ get: (name: string) => (name === 'slack' ? { name: 'slack', send } : undefined) }) as never;
 
   it('does not send when the category is muted', async () => {
     h.get.mockResolvedValue({ events: { 'job-failed': false } });
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     await createAccountNotifyEvent({ db, notifyProviders: registryWith(send), logger: silent })({
       category: 'job-failed',
       body: 'a job died',
@@ -80,22 +82,15 @@ describe('createAccountNotifyEvent', () => {
       // Exact duplicate transport — must be deduped to a single send.
       { provider: 'slack', config: { channel: '#a' }, secrets: { url: 'u' }, enabled: true },
     ]);
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     await createAccountNotifyEvent({ db, notifyProviders: registryWith(send), logger: silent })({
       category: 'job-failed',
       body: 'db-backup failed',
       fields: [{ label: 'Job', value: 'db-backup' }],
     });
     expect(send).toHaveBeenCalledTimes(1);
-    const arg = send.mock.calls[0]?.[0] as {
-      message: {
-        severity: string;
-        topic: string;
-        title: string;
-        body: string;
-        fields: { label: string; value: string }[];
-      };
-    };
+    const arg = send.mock.calls[0]?.[0];
+    if (!arg) throw new Error('expected one account notification');
     expect(arg.message).toMatchObject({
       severity: 'error',
       topic: 'job-failed',
@@ -108,7 +103,7 @@ describe('createAccountNotifyEvent', () => {
   it('no-ops when no notifiers are configured anywhere', async () => {
     h.get.mockResolvedValue({ events: {} });
     h.listAllEnabled.mockResolvedValue([]);
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     await createAccountNotifyEvent({ db, notifyProviders: registryWith(send), logger: silent })({
       category: 'job-failed',
       body: 'nothing to send to',
@@ -125,7 +120,7 @@ describe('createAccountNotifyEvent', () => {
     h.listEnabledForAccount.mockResolvedValue([
       { provider: 'slack', config: { channel: '#test' }, secrets: { url: 'u' }, enabled: true },
     ]);
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     const outcome = await createAccountNotifyEvent({
       db,
       notifyProviders: registryWith(send),
@@ -153,7 +148,7 @@ describe('createAccountNotifyEvent', () => {
         ? [{ provider: 'slack', config: { channel: '#a' }, secrets: { url: 'ua' }, enabled: true }]
         : [{ provider: 'slack', config: { channel: '#b' }, secrets: { url: 'ub' }, enabled: true }],
     );
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     const notify = createAccountNotifyEvent({
       db,
       notifyProviders: registryWith(send),
@@ -175,7 +170,7 @@ describe('createAccountNotifyEvent', () => {
     // retry. Collapsing them would either spam the log or drop the alert.
     h.get.mockResolvedValue({ events: {} });
     h.listEnabledForAccount.mockResolvedValue([]);
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     const outcome = await createAccountNotifyEvent({
       db,
       notifyProviders: registryWith(send),
@@ -187,7 +182,7 @@ describe('createAccountNotifyEvent', () => {
 
   it('reports muted when the operator has turned the category off', async () => {
     h.get.mockResolvedValue({ events: { 'orphan-order': false } });
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     const outcome = await createAccountNotifyEvent({
       db,
       notifyProviders: registryWith(send),
@@ -199,7 +194,9 @@ describe('createAccountNotifyEvent', () => {
 });
 
 describe('createAccountNotifyEventBatch', () => {
-  const registryWith = (send: ReturnType<typeof vi.fn>): NotifyProviderRegistry =>
+  const registryWith = (
+    send: ReturnType<typeof vi.fn<AnyNotifyProvider['send']>>,
+  ): NotifyProviderRegistry =>
     ({ get: (name: string) => (name === 'slack' ? { name: 'slack', send } : undefined) }) as never;
 
   it('reads the gate and the notifier set ONCE for the whole batch', async () => {
@@ -209,7 +206,7 @@ describe('createAccountNotifyEventBatch', () => {
     h.listEnabledForAccount.mockResolvedValue([
       { provider: 'slack', config: { channel: '#a' }, secrets: { url: 'u' }, enabled: true },
     ]);
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     const outcomes = await createAccountNotifyEventBatch({
       db,
       notifyProviders: registryWith(send),
@@ -230,7 +227,7 @@ describe('createAccountNotifyEventBatch', () => {
 
   it('reports the shared outcome for every event when the gate or the resolve settles it', async () => {
     h.get.mockResolvedValue({ events: { 'orphan-order': false } });
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     const outcomes = await createAccountNotifyEventBatch({
       db,
       notifyProviders: registryWith(send),

--- a/apps/worker/__tests__/notifiers/notify-event.test.ts
+++ b/apps/worker/__tests__/notifiers/notify-event.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import pino from 'pino';
-import type { NotifyProviderRegistry } from '@app/notify';
+import type { AnyNotifyProvider, NotifyProviderRegistry } from '@app/notify';
 
 const h = vi.hoisted(() => ({ findById: vi.fn(), listForProfile: vi.fn() }));
 vi.mock('@app/db', () => ({
@@ -52,12 +52,14 @@ describe('isProfileEventEnabled', () => {
 });
 
 describe('createNotifyEvent', () => {
-  const registryWith = (send: ReturnType<typeof vi.fn>): NotifyProviderRegistry =>
+  const registryWith = (
+    send: ReturnType<typeof vi.fn<AnyNotifyProvider['send']>>,
+  ): NotifyProviderRegistry =>
     ({ get: (name: string) => (name === 'slack' ? { name: 'slack', send } : undefined) }) as never;
 
   it('does not send when the category is muted', async () => {
     h.findById.mockResolvedValue({ notifyEvents: { 'daily-loss-halt': false } });
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     await createNotifyEvent({ db, notifyProviders: registryWith(send), logger: silent })({
       category: 'daily-loss-halt',
       operatorId: U,
@@ -73,7 +75,7 @@ describe('createNotifyEvent', () => {
     h.listForProfile.mockResolvedValue([
       { provider: 'slack', config: { channel: '#a' }, secrets: { url: 'u' }, enabled: true },
     ]);
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     await createNotifyEvent({ db, notifyProviders: registryWith(send), logger: silent })({
       category: 'edge-decay-warning',
       operatorId: U,
@@ -83,17 +85,8 @@ describe('createNotifyEvent', () => {
       fields: [{ label: 'Live profit factor', value: '0.8' }],
     });
     expect(send).toHaveBeenCalledTimes(1);
-    const arg = send.mock.calls[0]?.[0] as {
-      config: Record<string, unknown>;
-      message: {
-        severity: string;
-        topic: string;
-        title: string;
-        profile: string;
-        body: string;
-        fields: { label: string; value: string }[];
-      };
-    };
+    const arg = send.mock.calls[0]?.[0];
+    if (!arg) throw new Error('expected one profile notification');
     expect(arg.config).toMatchObject({ channel: '#a', url: 'u' });
     expect(arg.message).toMatchObject({
       severity: 'warn',

--- a/apps/worker/__tests__/profile-bindings/index.test.ts
+++ b/apps/worker/__tests__/profile-bindings/index.test.ts
@@ -144,14 +144,14 @@ describe('buildProfileBindings — null branches', () => {
     findApiKey.mockResolvedValueOnce({ key: 'k', secret: 's', last4: '0000' });
     // Environment is per-account: mode resolves via repo.accounts.binanceModeById.
     findMode.mockResolvedValueOnce('paper');
-    await expect(buildProfileBindings({ db }, userId, profileId)).rejects.toThrow(
+    await expect(buildProfileBindings({ db }, userId, accountId, profileId)).rejects.toThrow(
       /binanceMode out of range/,
     );
   });
 
   it('rethrows unknown errors from the ownership check so the worker can retry/DLQ', async () => {
     profileRepoSpy.mockRejectedValueOnce(new Error('pg pool exhausted'));
-    await expect(buildProfileBindings({ db }, userId, profileId)).rejects.toThrow(
+    await expect(buildProfileBindings({ db }, userId, accountId, profileId)).rejects.toThrow(
       'pg pool exhausted',
     );
   });

--- a/apps/worker/__tests__/profile-bindings/persistence.test.ts
+++ b/apps/worker/__tests__/profile-bindings/persistence.test.ts
@@ -272,7 +272,7 @@ describe('buildPersistence.recordNotifierGap', () => {
   });
 
   it('passes symbol=null when the gap carries no symbol', async () => {
-    const p = buildPersistence(makeRepo(), { clock: { nowMs: () => 0 } });
+    const p = buildPersistence(makeRepo(), makeAccountRepo(), { clock: { nowMs: () => 0 } });
     await p.recordNotifierGap({ topic: 'binance-weight-throttle' });
     expect(actionLogAppend.mock.calls[0]?.[0]).toMatchObject({ symbol: null });
   });

--- a/apps/worker/__tests__/profile-manager/enabled-set-reconciler.test.ts
+++ b/apps/worker/__tests__/profile-manager/enabled-set-reconciler.test.ts
@@ -9,6 +9,8 @@ const silentLogger = new Proxy({} as Logger, { get: () => () => undefined }) as 
 const rows: ProfileLoadRow[] = [
   {
     userId: 'u1' as ProfileLoadRow['userId'],
+    operatorId: 'u1' as ProfileLoadRow['operatorId'],
+    accountId: 'a1' as ProfileLoadRow['accountId'],
     profileId: 'p1' as ProfileLoadRow['profileId'],
     symbols: ['BTCUSDT'],
     candleInterval: '1h',

--- a/apps/worker/__tests__/profile-manager/profile-manager.test.ts
+++ b/apps/worker/__tests__/profile-manager/profile-manager.test.ts
@@ -1,13 +1,22 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { asProfileId, asUserId } from '@app/contracts';
+import { asAccountId, asProfileId, asUserId } from '@app/contracts';
 import {
   createProfileManager,
   type MarketSubscriberHooks,
+  type ProfileLoadRow,
   type ProfileManager,
 } from '../../src/profile-manager/profile-manager.js';
 
 const u = asUserId;
 const p = asProfileId;
+const a = asAccountId;
+
+type TestProfileRow = Omit<ProfileLoadRow, 'operatorId'>;
+
+const scoped = (row: TestProfileRow): ProfileLoadRow => ({
+  ...row,
+  operatorId: row.userId,
+});
 
 const stubMarket = (): MarketSubscriberHooks & {
   addCalls: { symbols: readonly string[]; candleInterval: string }[];
@@ -37,8 +46,12 @@ describe('ProfileManager', () => {
   // Mirror the boot back-edge wire: construct the manager, then inject the
   // market back-edge before start(). The account user-data stream is driven by
   // subscription-ownership, not the manager, so there is no stream back-edge.
-  const makePm = (deps: Parameters<typeof createProfileManager>[0]): ProfileManager => {
-    const pm = createProfileManager(deps);
+  const makePm = (deps: {
+    loadEnabledProfiles: () => Promise<readonly TestProfileRow[]>;
+  }): ProfileManager => {
+    const pm = createProfileManager({
+      loadEnabledProfiles: async () => (await deps.loadEnabledProfiles()).map(scoped),
+    });
     pm.setMarket(market);
     return pm;
   };
@@ -48,6 +61,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT', 'ETHUSDT'],
           candleInterval: '1h',
@@ -55,6 +69,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p2'),
           symbols: ['BTCUSDT'],
           candleInterval: '1h',
@@ -77,6 +92,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT', 'ETHUSDT'],
           candleInterval: '1h',
@@ -84,6 +100,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p2'),
           symbols: ['BTCUSDT'],
           candleInterval: '1h',
@@ -108,6 +125,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
           candleInterval: '5m',
@@ -115,6 +133,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p2'),
           symbols: ['BTCUSDT'],
           candleInterval: '1h',
@@ -135,6 +154,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
           candleInterval: '1h',
@@ -154,6 +174,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
           candleInterval: '5m',
@@ -177,6 +198,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
           candleInterval: '5m',
@@ -201,6 +223,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT', 'ETHUSDT'],
           candleInterval: '5m',
@@ -228,6 +251,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT', 'ETHUSDT'],
           candleInterval: '1h',
@@ -235,6 +259,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u2'),
+          accountId: a('a2'),
           profileId: p('p2'),
           symbols: ['SOLUSDT'],
           candleInterval: '5m',
@@ -248,6 +273,8 @@ describe('ProfileManager', () => {
       {
         profileId: 'p1',
         userId: 'u1',
+        operatorId: 'u1',
+        accountId: 'a1',
         candleInterval: '1h',
         symbols: ['BTCUSDT', 'ETHUSDT'],
         technicalsIntervals: [],
@@ -255,6 +282,8 @@ describe('ProfileManager', () => {
       {
         profileId: 'p2',
         userId: 'u2',
+        operatorId: 'u2',
+        accountId: 'a2',
         candleInterval: '5m',
         symbols: ['SOLUSDT'],
         technicalsIntervals: [],
@@ -267,6 +296,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
           candleInterval: '1h',
@@ -274,6 +304,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p2'),
           symbols: ['ETHUSDT'],
           candleInterval: '1h',
@@ -291,6 +322,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
           candleInterval: '1h',
@@ -319,6 +351,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
           candleInterval: '1h',
@@ -326,6 +359,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p2'),
           symbols: ['ETHUSDT'],
           candleInterval: '1h',
@@ -347,6 +381,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT', 'ETHUSDT'],
           candleInterval: '5m',
@@ -356,13 +391,16 @@ describe('ProfileManager', () => {
     });
     await pm.start();
 
-    await pm.enable({
-      userId: u('u1'),
-      profileId: p('p1'),
-      symbols: ['BTCUSDT', 'SOLUSDT'],
-      candleInterval: '1h',
-      technicalsIntervals: ['1h', '4h'],
-    });
+    await pm.enable(
+      scoped({
+        userId: u('u1'),
+        accountId: a('a1'),
+        profileId: p('p1'),
+        symbols: ['BTCUSDT', 'SOLUSDT'],
+        candleInterval: '1h',
+        technicalsIntervals: ['1h', '4h'],
+      }),
+    );
 
     // Symbol set converged: ETH dropped, SOL added, BTC retained on the new interval.
     expect([...pm.profilesUsing('BTCUSDT')]).toEqual(['p1']);
@@ -385,6 +423,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
           candleInterval: '1h',
@@ -396,13 +435,16 @@ describe('ProfileManager', () => {
     const addsAfterStart = market.addCalls.length;
     const removesAfterStart = market.removeCalls.length;
 
-    await pm.enable({
-      userId: u('u1'),
-      profileId: p('p1'),
-      symbols: ['BTCUSDT'],
-      candleInterval: '1h',
-      technicalsIntervals: ['1h', '4h', '1d'],
-    });
+    await pm.enable(
+      scoped({
+        userId: u('u1'),
+        accountId: a('a1'),
+        profileId: p('p1'),
+        symbols: ['BTCUSDT'],
+        candleInterval: '1h',
+        technicalsIntervals: ['1h', '4h', '1d'],
+      }),
+    );
 
     // No market churn: same symbol set + same interval => setSymbols is a no-op.
     expect(market.addCalls).toHaveLength(addsAfterStart);
@@ -418,24 +460,29 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [],
     });
     await expect(
-      pm.enable({
-        userId: u('u1'),
-        profileId: p('p1'),
-        symbols: ['BTCUSDT'],
-        candleInterval: '1h',
-        technicalsIntervals: [],
-      }),
+      pm.enable(
+        scoped({
+          userId: u('u1'),
+          accountId: a('a1'),
+          profileId: p('p1'),
+          symbols: ['BTCUSDT'],
+          candleInterval: '1h',
+          technicalsIntervals: [],
+        }),
+      ),
     ).rejects.toThrow(/Market hook not wired/);
   });
 
   it('reconcile() converges membership to the given enabled set (add, drop, keep)', async () => {
-    const row = (profileId: string, symbols: string[], candleInterval = '1h') => ({
-      userId: u('u1'),
-      profileId: p(profileId),
-      symbols,
-      candleInterval,
-      technicalsIntervals: [],
-    });
+    const row = (profileId: string, symbols: string[], candleInterval = '1h') =>
+      scoped({
+        userId: u('u1'),
+        accountId: a('a1'),
+        profileId: p(profileId),
+        symbols,
+        candleInterval,
+        technicalsIntervals: [],
+      });
     const pm = makePm({
       loadEnabledProfiles: async () => [row('p1', ['BTCUSDT']), row('p2', ['ETHUSDT'])],
     });
@@ -462,13 +509,14 @@ describe('ProfileManager', () => {
   });
 
   it('reconcile() with no changes makes zero market churn (single-replica no-op)', async () => {
-    const row = {
+    const row = scoped({
       userId: u('u1'),
+      accountId: a('a1'),
       profileId: p('p1'),
       symbols: ['BTCUSDT'],
       candleInterval: '1h',
       technicalsIntervals: [],
-    };
+    });
     const pm = makePm({ loadEnabledProfiles: async () => [row] });
     await pm.start();
     const addsAfterStart = market.addCalls.length;

--- a/apps/worker/__tests__/profile-manager/profile-manager.test.ts
+++ b/apps/worker/__tests__/profile-manager/profile-manager.test.ts
@@ -11,13 +11,6 @@ const u = asUserId;
 const p = asProfileId;
 const a = asAccountId;
 
-type TestProfileRow = Omit<ProfileLoadRow, 'operatorId'>;
-
-const scoped = (row: TestProfileRow): ProfileLoadRow => ({
-  ...row,
-  operatorId: row.userId,
-});
-
 const stubMarket = (): MarketSubscriberHooks & {
   addCalls: { symbols: readonly string[]; candleInterval: string }[];
   removeCalls: { symbols: readonly string[]; candleInterval: string }[];
@@ -47,11 +40,9 @@ describe('ProfileManager', () => {
   // market back-edge before start(). The account user-data stream is driven by
   // subscription-ownership, not the manager, so there is no stream back-edge.
   const makePm = (deps: {
-    loadEnabledProfiles: () => Promise<readonly TestProfileRow[]>;
+    loadEnabledProfiles: () => Promise<readonly ProfileLoadRow[]>;
   }): ProfileManager => {
-    const pm = createProfileManager({
-      loadEnabledProfiles: async () => (await deps.loadEnabledProfiles()).map(scoped),
-    });
+    const pm = createProfileManager(deps);
     pm.setMarket(market);
     return pm;
   };
@@ -61,6 +52,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT', 'ETHUSDT'],
@@ -69,6 +61,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p2'),
           symbols: ['BTCUSDT'],
@@ -92,6 +85,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT', 'ETHUSDT'],
@@ -100,6 +94,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p2'),
           symbols: ['BTCUSDT'],
@@ -125,6 +120,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
@@ -133,6 +129,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p2'),
           symbols: ['BTCUSDT'],
@@ -154,6 +151,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
@@ -174,6 +172,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
@@ -198,6 +197,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
@@ -223,6 +223,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT', 'ETHUSDT'],
@@ -251,6 +252,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT', 'ETHUSDT'],
@@ -259,6 +261,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u2'),
+          operatorId: u('o2'),
           accountId: a('a2'),
           profileId: p('p2'),
           symbols: ['SOLUSDT'],
@@ -273,7 +276,7 @@ describe('ProfileManager', () => {
       {
         profileId: 'p1',
         userId: 'u1',
-        operatorId: 'u1',
+        operatorId: 'o1',
         accountId: 'a1',
         candleInterval: '1h',
         symbols: ['BTCUSDT', 'ETHUSDT'],
@@ -282,7 +285,7 @@ describe('ProfileManager', () => {
       {
         profileId: 'p2',
         userId: 'u2',
-        operatorId: 'u2',
+        operatorId: 'o2',
         accountId: 'a2',
         candleInterval: '5m',
         symbols: ['SOLUSDT'],
@@ -296,6 +299,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
@@ -304,6 +308,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p2'),
           symbols: ['ETHUSDT'],
@@ -322,6 +327,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
@@ -351,6 +357,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
@@ -359,6 +366,7 @@ describe('ProfileManager', () => {
         },
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p2'),
           symbols: ['ETHUSDT'],
@@ -381,6 +389,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT', 'ETHUSDT'],
@@ -391,16 +400,15 @@ describe('ProfileManager', () => {
     });
     await pm.start();
 
-    await pm.enable(
-      scoped({
-        userId: u('u1'),
-        accountId: a('a1'),
-        profileId: p('p1'),
-        symbols: ['BTCUSDT', 'SOLUSDT'],
-        candleInterval: '1h',
-        technicalsIntervals: ['1h', '4h'],
-      }),
-    );
+    await pm.enable({
+      userId: u('u1'),
+      operatorId: u('o1'),
+      accountId: a('a1'),
+      profileId: p('p1'),
+      symbols: ['BTCUSDT', 'SOLUSDT'],
+      candleInterval: '1h',
+      technicalsIntervals: ['1h', '4h'],
+    });
 
     // Symbol set converged: ETH dropped, SOL added, BTC retained on the new interval.
     expect([...pm.profilesUsing('BTCUSDT')]).toEqual(['p1']);
@@ -423,6 +431,7 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('o1'),
           accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
@@ -435,16 +444,15 @@ describe('ProfileManager', () => {
     const addsAfterStart = market.addCalls.length;
     const removesAfterStart = market.removeCalls.length;
 
-    await pm.enable(
-      scoped({
-        userId: u('u1'),
-        accountId: a('a1'),
-        profileId: p('p1'),
-        symbols: ['BTCUSDT'],
-        candleInterval: '1h',
-        technicalsIntervals: ['1h', '4h', '1d'],
-      }),
-    );
+    await pm.enable({
+      userId: u('u1'),
+      operatorId: u('o1'),
+      accountId: a('a1'),
+      profileId: p('p1'),
+      symbols: ['BTCUSDT'],
+      candleInterval: '1h',
+      technicalsIntervals: ['1h', '4h', '1d'],
+    });
 
     // No market churn: same symbol set + same interval => setSymbols is a no-op.
     expect(market.addCalls).toHaveLength(addsAfterStart);
@@ -460,29 +468,28 @@ describe('ProfileManager', () => {
       loadEnabledProfiles: async () => [],
     });
     await expect(
-      pm.enable(
-        scoped({
-          userId: u('u1'),
-          accountId: a('a1'),
-          profileId: p('p1'),
-          symbols: ['BTCUSDT'],
-          candleInterval: '1h',
-          technicalsIntervals: [],
-        }),
-      ),
+      pm.enable({
+        userId: u('u1'),
+        operatorId: u('o1'),
+        accountId: a('a1'),
+        profileId: p('p1'),
+        symbols: ['BTCUSDT'],
+        candleInterval: '1h',
+        technicalsIntervals: [],
+      }),
     ).rejects.toThrow(/Market hook not wired/);
   });
 
   it('reconcile() converges membership to the given enabled set (add, drop, keep)', async () => {
-    const row = (profileId: string, symbols: string[], candleInterval = '1h') =>
-      scoped({
-        userId: u('u1'),
-        accountId: a('a1'),
-        profileId: p(profileId),
-        symbols,
-        candleInterval,
-        technicalsIntervals: [],
-      });
+    const row = (profileId: string, symbols: string[], candleInterval = '1h'): ProfileLoadRow => ({
+      userId: u('u1'),
+      operatorId: u('o1'),
+      accountId: a('a1'),
+      profileId: p(profileId),
+      symbols,
+      candleInterval,
+      technicalsIntervals: [],
+    });
     const pm = makePm({
       loadEnabledProfiles: async () => [row('p1', ['BTCUSDT']), row('p2', ['ETHUSDT'])],
     });
@@ -509,14 +516,15 @@ describe('ProfileManager', () => {
   });
 
   it('reconcile() with no changes makes zero market churn (single-replica no-op)', async () => {
-    const row = scoped({
+    const row = {
       userId: u('u1'),
+      operatorId: u('o1'),
       accountId: a('a1'),
       profileId: p('p1'),
       symbols: ['BTCUSDT'],
       candleInterval: '1h',
       technicalsIntervals: [],
-    });
+    };
     const pm = makePm({ loadEnabledProfiles: async () => [row] });
     await pm.start();
     const addsAfterStart = market.addCalls.length;

--- a/apps/worker/__tests__/profile-manager/reconfigure-interval.test.ts
+++ b/apps/worker/__tests__/profile-manager/reconfigure-interval.test.ts
@@ -10,13 +10,14 @@
 import { describe, expect, it, vi } from 'vitest';
 import pino from 'pino';
 import { createFakeMarketDataPort } from '@app/binance';
-import { asProfileId, asUserId } from '@app/contracts';
+import { asAccountId, asProfileId, asUserId } from '@app/contracts';
 
 import { createProfileManager } from '../../src/profile-manager/profile-manager.js';
 import { createMarketSubscriptionsManager } from '../../src/market-data/subscriptions-manager.js';
 
 const silentLogger = pino({ level: 'silent' });
 const u = asUserId;
+const a = asAccountId;
 const p = asProfileId;
 
 describe('ProfileManager interval change over the real subscriptions-manager', () => {
@@ -35,6 +36,8 @@ describe('ProfileManager interval change over the real subscriptions-manager', (
       loadEnabledProfiles: async () => [
         {
           userId: u('u1'),
+          operatorId: u('u1'),
+          accountId: a('a1'),
           profileId: p('p1'),
           symbols: ['BTCUSDT'],
           candleInterval: '5m',

--- a/apps/worker/__tests__/queues/advisor-worker.test.ts
+++ b/apps/worker/__tests__/queues/advisor-worker.test.ts
@@ -89,7 +89,13 @@ function harness() {
   return { queueSet, invoke };
 }
 
-const JOB: AdvisorJobData = { runId: 'r1', userId: 'u1', profileId: 'p1', variant: 'safe' };
+const JOB: AdvisorJobData = {
+  runId: 'r1',
+  userId: 'u1',
+  accountId: 'a1',
+  profileId: 'p1',
+  variant: 'safe',
+};
 
 beforeEach(() => {
   for (const m of Object.values(repoMocks)) m.mockClear();

--- a/apps/worker/__tests__/queues/backtest-worker.test.ts
+++ b/apps/worker/__tests__/queues/backtest-worker.test.ts
@@ -2,15 +2,24 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Job, Processor } from 'bullmq';
 import type { Redis } from 'ioredis';
 import pino from 'pino';
+import type { ProfileRepo } from '@app/db';
 import type { QueueSet } from '../../src/queues/queue-set.js';
 import type { BacktestJobData } from '../../src/queues/job-payloads.js';
+import type { BacktestWorkerDeps } from '../../src/queues/backtest-worker.js';
+import type { NotifyEvent } from '../../src/notifiers/notify-event.js';
+
+type BoundMethod<K extends keyof ProfileRepo['backtestRuns'], R> = (
+  ...args: Parameters<ProfileRepo['backtestRuns'][K]>
+) => Promise<R>;
 
 const repoMocks = vi.hoisted(() => ({
-  markRunning: vi.fn(async () => true),
-  updateProgress: vi.fn(async () => undefined),
-  complete: vi.fn(async () => undefined),
-  fail: vi.fn(async () => undefined),
-  get: vi.fn(async () => null as { status: string; symbols?: readonly string[] } | null),
+  markRunning: vi.fn<BoundMethod<'markRunning', boolean>>(async () => true),
+  updateProgress: vi.fn<BoundMethod<'updateProgress', void>>(async () => undefined),
+  complete: vi.fn<BoundMethod<'complete', void>>(async () => undefined),
+  fail: vi.fn<BoundMethod<'fail', void>>(async () => undefined),
+  get: vi.fn<BoundMethod<'get', { status: string; symbols?: readonly string[] } | null>>(
+    async () => null,
+  ),
   failById: vi.fn(async () => true),
   ledgerUpsert: vi.fn(async () => undefined),
   profileRepo: vi.fn(async () => ({
@@ -37,7 +46,17 @@ vi.mock('@app/db', async (importOriginal) => {
   };
 });
 
-const emitEvent = vi.hoisted(() => vi.fn(async () => undefined));
+const emitEvent = vi.hoisted(() =>
+  vi.fn<
+    (
+      deps: unknown,
+      accountId: unknown,
+      profileId: unknown,
+      topic: string,
+      payload: unknown,
+    ) => Promise<void>
+  >(async () => undefined),
+);
 vi.mock('../../src/executor/event-emitter.js', () => ({ emitEvent }));
 
 // Import after mocks are registered.
@@ -48,7 +67,7 @@ const silentLogger = pino({ level: 'silent' });
 
 // Profile-event notifier stub (Slack/Telegram/webhook fan-out); the real one
 // gates on the profile's subscription and never throws.
-const notifyEvent = vi.fn(async () => undefined);
+const notifyEvent = vi.fn<NotifyEvent>(async () => undefined);
 
 function harness() {
   let processor: Processor<BacktestJobData> | undefined;
@@ -79,7 +98,11 @@ const LEDGER_ENTRY = {
   params: {},
   outcome: { totalReturnPct: 7 },
 };
-const RUN_OUT = { result: RESULT, configFingerprint: FP, ledgerEntry: LEDGER_ENTRY } as never;
+const RUN_OUT = {
+  result: RESULT,
+  configFingerprint: FP,
+  ledgerEntry: LEDGER_ENTRY,
+} as Awaited<ReturnType<BacktestWorkerDeps['run']>>;
 
 beforeEach(() => {
   for (const m of Object.values(repoMocks)) m.mockClear();
@@ -173,12 +196,9 @@ describe('registerBacktestWorker', () => {
       publicWebUrl: 'http://localhost:5173',
     });
     await invoke(JOB);
-    const arg = notifyEvent.mock.calls[0]?.[0] as {
-      link: string;
-      fields: { label: string; value: string }[];
-    };
-    expect(arg.link).toBe('http://localhost:5173/accounts/a1/profiles/p1/backtest?run=r1');
-    expect(arg.fields).toEqual([
+    const arg = notifyEvent.mock.calls[0]?.[0];
+    expect(arg?.link).toBe('http://localhost:5173/accounts/a1/profiles/p1/backtest?run=r1');
+    expect(arg?.fields).toEqual([
       { label: 'Trades', value: '8' },
       { label: 'Profit factor', value: '1.40' },
       { label: 'vs buy-and-hold', value: '+5.00%' },

--- a/apps/worker/__tests__/queues/backtest-worker.test.ts
+++ b/apps/worker/__tests__/queues/backtest-worker.test.ts
@@ -2,24 +2,20 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Job, Processor } from 'bullmq';
 import type { Redis } from 'ioredis';
 import pino from 'pino';
-import type { ProfileRepo } from '@app/db';
+import type { BacktestRunRow, ProfileRepo } from '@app/db';
 import type { QueueSet } from '../../src/queues/queue-set.js';
 import type { BacktestJobData } from '../../src/queues/job-payloads.js';
 import type { BacktestWorkerDeps } from '../../src/queues/backtest-worker.js';
 import type { NotifyEvent } from '../../src/notifiers/notify-event.js';
 
-type BoundMethod<K extends keyof ProfileRepo['backtestRuns'], R> = (
-  ...args: Parameters<ProfileRepo['backtestRuns'][K]>
-) => Promise<R>;
+type RepoMethod<K extends keyof ProfileRepo['backtestRuns']> = ProfileRepo['backtestRuns'][K];
 
 const repoMocks = vi.hoisted(() => ({
-  markRunning: vi.fn<BoundMethod<'markRunning', boolean>>(async () => true),
-  updateProgress: vi.fn<BoundMethod<'updateProgress', void>>(async () => undefined),
-  complete: vi.fn<BoundMethod<'complete', void>>(async () => undefined),
-  fail: vi.fn<BoundMethod<'fail', void>>(async () => undefined),
-  get: vi.fn<BoundMethod<'get', { status: string; symbols?: readonly string[] } | null>>(
-    async () => null,
-  ),
+  markRunning: vi.fn<RepoMethod<'markRunning'>>(async () => true),
+  updateProgress: vi.fn<RepoMethod<'updateProgress'>>(async () => undefined),
+  complete: vi.fn<RepoMethod<'complete'>>(async () => undefined),
+  fail: vi.fn<RepoMethod<'fail'>>(async () => undefined),
+  get: vi.fn<RepoMethod<'get'>>(async () => null),
   failById: vi.fn(async () => true),
   ledgerUpsert: vi.fn(async () => undefined),
   profileRepo: vi.fn(async () => ({
@@ -46,16 +42,28 @@ vi.mock('@app/db', async (importOriginal) => {
   };
 });
 
+// `get` returns a full `BacktestRunRow`, so the mock builds one rather than a two-field shape: narrowing the mock's return would let a column the worker reads disappear from the row type without failing here.
+const runRow = (over: Partial<BacktestRunRow> = {}): BacktestRunRow => ({
+  id: '00000000-0000-0000-0000-0000000000dd',
+  profileId: '00000000-0000-0000-0000-0000000000bb',
+  symbols: ['BTCUSDT'],
+  params: {},
+  status: 'done',
+  progress: 100,
+  progressDetail: null,
+  result: null,
+  error: null,
+  configFingerprint: null,
+  backtestSignature: null,
+  parentRunId: null,
+  createdAt: new Date(0),
+  startedAt: null,
+  finishedAt: null,
+  ...over,
+});
+
 const emitEvent = vi.hoisted(() =>
-  vi.fn<
-    (
-      deps: unknown,
-      accountId: unknown,
-      profileId: unknown,
-      topic: string,
-      payload: unknown,
-    ) => Promise<void>
-  >(async () => undefined),
+  vi.fn<typeof import('../../src/executor/event-emitter.js').emitEvent>(async () => undefined),
 );
 vi.mock('../../src/executor/event-emitter.js', () => ({ emitEvent }));
 
@@ -154,7 +162,7 @@ describe('registerBacktestWorker', () => {
 
   it('notifies the operator channels when a run completes', async () => {
     // A completed run fans out to the profile's notifiers.
-    repoMocks.get.mockResolvedValue({ status: 'done', symbols: ['BTCUSDT'] });
+    repoMocks.get.mockResolvedValue(runRow());
     const { queueSet, invoke } = harness();
     const run = vi.fn(async () => RUN_OUT);
     registerBacktestWorker(queueSet, {
@@ -182,7 +190,7 @@ describe('registerBacktestWorker', () => {
   });
 
   it('includes formatted fields and a results deep link when PUBLIC_WEB_URL is set', async () => {
-    repoMocks.get.mockResolvedValue({ status: 'done', symbols: ['BTCUSDT'] });
+    repoMocks.get.mockResolvedValue(runRow());
     const { queueSet, invoke } = harness();
     const metrics = { totalTrades: 8, profitFactor: 1.4, alphaVsHoldPct: 5 };
     const run = vi.fn(async () => ({ ...RUN_OUT, result: { metrics } }) as never);
@@ -206,7 +214,7 @@ describe('registerBacktestWorker', () => {
   });
 
   it('omits the link when PUBLIC_WEB_URL is unset', async () => {
-    repoMocks.get.mockResolvedValue({ status: 'done', symbols: ['BTCUSDT'] });
+    repoMocks.get.mockResolvedValue(runRow());
     const { queueSet, invoke } = harness();
     registerBacktestWorker(queueSet, {
       db: {} as never,
@@ -226,7 +234,7 @@ describe('registerBacktestWorker', () => {
     [{ totalTrades: 8, profitFactor: null, alphaVsHoldPct: 5 }, 'profit factor n/a'],
     [{ totalTrades: 8, profitFactor: 1.4, alphaVsHoldPct: -3.2 }, 'lagged buy-and-hold by 3.20%'],
   ])('renders the completion text for %o', async (metrics, expected) => {
-    repoMocks.get.mockResolvedValue({ status: 'done', symbols: ['BTCUSDT'] });
+    repoMocks.get.mockResolvedValue(runRow());
     const { queueSet, invoke } = harness();
     const run = vi.fn(async () => ({ ...RUN_OUT, result: { metrics } }) as never);
     registerBacktestWorker(queueSet, {

--- a/apps/worker/__tests__/queues/dispose-profile.test.ts
+++ b/apps/worker/__tests__/queues/dispose-profile.test.ts
@@ -50,6 +50,7 @@ const position = (over: Record<string, unknown> = {}) => ({
   avgEntryPrice: '0.30',
   quantity: '189.87',
   overrideConfig: null,
+  reserveBaseQuantity: null,
   ...over,
 });
 
@@ -714,7 +715,7 @@ describe('handleDisposeProfile', () => {
           ]
         : [],
     );
-    const apply = vi.fn(async () => ({ ok: true }) as const);
+    const apply = vi.fn<DisposeDeps['executor']['apply']>(async () => ({ ok: true }) as const);
     const deps = mkDeps({
       executor: { apply } as unknown as DisposeDeps['executor'],
       strategies: { get: () => trailingTrade } as unknown as DisposeDeps['strategies'],
@@ -784,7 +785,9 @@ describe('handleDisposeProfile', () => {
 
   const ttDeps = (
     open: readonly Record<string, unknown>[],
-    apply = vi.fn(async () => ({ ok: true }) as const),
+    apply: DisposeDeps['executor']['apply'] = vi.fn<DisposeDeps['executor']['apply']>(
+      async () => ({ ok: true }) as const,
+    ),
     over: Partial<DisposeDeps> = {},
   ): DisposeDeps =>
     mkDeps({
@@ -809,7 +812,7 @@ describe('handleDisposeProfile', () => {
     // strip a live position of its protection.
     const repo = mkTtRepo();
     profileRepo.mockResolvedValue(repo);
-    const apply = vi.fn(async () => ({ ok: true }) as const);
+    const apply = vi.fn<DisposeDeps['executor']['apply']>(async () => ({ ok: true }) as const);
     const deps = ttDeps(
       [
         {
@@ -836,7 +839,7 @@ describe('handleDisposeProfile', () => {
     // nothing left in the system pointing at it.
     const repo = mkTtRepo();
     profileRepo.mockResolvedValue(repo);
-    const apply = vi.fn(async () => ({ ok: true }) as const);
+    const apply = vi.fn<DisposeDeps['executor']['apply']>(async () => ({ ok: true }) as const);
     const deps = ttDeps(
       [
         {
@@ -946,7 +949,7 @@ describe('handleDisposeProfile', () => {
     // id would cancel a stranger's order on the strength of OUR row.
     const repo = withSlack(mkTtRepo(trailingTrade.defaultConfig, ['ENAUSDT:8888']));
     profileRepo.mockResolvedValue(repo);
-    const apply = vi.fn(async () => ({ ok: true }) as const);
+    const apply = vi.fn<DisposeDeps['executor']['apply']>(async () => ({ ok: true }) as const);
     const deps = ttDeps(
       [
         {

--- a/apps/worker/__tests__/queues/queue-set-dlq-redaction.test.ts
+++ b/apps/worker/__tests__/queues/queue-set-dlq-redaction.test.ts
@@ -1,4 +1,5 @@
 import { repo } from '@app/db';
+import type { AnyNotifyProvider } from '@app/notify';
 import pino from 'pino';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -55,7 +56,7 @@ afterEach(() => {
 describe('exhausted-job DLQ redaction', () => {
   it('censors Drizzle bind values in the queued record and outbound notifier message', async () => {
     vi.useFakeTimers();
-    const send = vi.fn(async () => undefined);
+    const send = vi.fn<AnyNotifyProvider['send']>(async () => undefined);
     vi.spyOn(repo.opsNotifyConfig, 'get').mockResolvedValue({ events: {} } as never);
     vi.spyOn(repo.profileNotifiers, 'listAllEnabled').mockResolvedValue([
       { provider: 'test', config: {}, secrets: {}, enabled: true },
@@ -102,9 +103,8 @@ describe('exhausted-job DLQ redaction', () => {
     await vi.advanceTimersByTimeAsync(15_000);
 
     expect(send).toHaveBeenCalledTimes(1);
-    const outbound = send.mock.calls[0]?.[0] as {
-      message: { fields?: readonly { label: string; value: string }[] };
-    };
+    const outbound = send.mock.calls[0]?.[0];
+    if (!outbound) throw new Error('expected one DLQ notification');
     const errorField = outbound.message.fields?.find((field) => field.label === 'Error');
     expect(errorField?.value).toContain(SQL);
     expect.soft(errorField?.value).toContain('\nparams: [redacted]');

--- a/apps/worker/__tests__/queues/reconcile-fees.test.ts
+++ b/apps/worker/__tests__/queues/reconcile-fees.test.ts
@@ -19,7 +19,7 @@ const { handleReconcileFees } =
 const logWarn = vi.fn();
 const logger = { warn: logWarn, info: vi.fn() } as unknown as Logger;
 const warnEvents = (): string[] => logWarn.mock.calls.map((c) => c[1] as string);
-const IDS = { userId: 'u1' as never, profileId: 'p1' as never };
+const IDS = { userId: 'u1' as never, accountId: 'a1' as never, profileId: 'p1' as never };
 
 const fakeClient = (trades: unknown[], ticker = { lastPrice: '0' }): BinanceRestClient =>
   ({

--- a/apps/worker/__tests__/queues/reset-grid-trade.test.ts
+++ b/apps/worker/__tests__/queues/reset-grid-trade.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { AccountId, ProfileId, UserId } from '@app/contracts';
 import type { PositionStateAdapter, StrategyRegistry } from '@app/strategy-core';
+import type { StatePort } from '../../src/state/state-port.js';
 
 const { profileRepoSpy } = vi.hoisted(() => ({ profileRepoSpy: vi.fn() }));
 vi.mock('@app/db', async (importOriginal) => {
@@ -36,7 +37,7 @@ const repo = {
 };
 
 const applySpy = vi.fn(async () => ({ ok: true as const }));
-const mutate = vi.fn(async () => undefined);
+const mutate = vi.fn<StatePort['mutate']>(async () => undefined);
 
 // Fake position capability: `clearPosition` clears the grid index only when
 // asked (resetGridIndex), returns null for a body it does not recognise — same
@@ -103,7 +104,7 @@ describe('handleResetGridTrade', () => {
     expect(mutate).toHaveBeenCalledWith(repo, 'BTCUSDT', expect.any(Function));
     // The mutator applies the strategy's grid-reset to the body the port hands
     // it (already reconciled to the current schema).
-    const mutator = mutate.mock.calls[0]?.[2] as ((s: unknown) => unknown) | undefined;
+    const mutator = mutate.mock.calls[0]?.[2];
     expect(mutator).toBeDefined();
     expect(mutator?.({ schemaVersion: 'ok', currentGridTradeIndex: 4 })).toEqual({
       schemaVersion: 'ok',

--- a/apps/worker/__tests__/state/state-port.test.ts
+++ b/apps/worker/__tests__/state/state-port.test.ts
@@ -232,7 +232,9 @@ describe('StatePort load handle commit', () => {
 
 // A strategy that stamps a latch field via mergeConcurrent — the CAS-miss
 // reconcile the state-port dispatches on a tick commit that lost the version.
-const latchStrategy = (mergeConcurrent: ReturnType<typeof vi.fn>): SymbolStateStrategyShape => ({
+const latchStrategy = (
+  mergeConcurrent: NonNullable<SymbolStateStrategyShape['mergeConcurrent']>,
+): SymbolStateStrategyShape => ({
   name: 'trailing-trade',
   version: '1.1.0',
   initialState: () => ({ schemaVersion: '1.1.0', seeded: true }),
@@ -251,7 +253,7 @@ describe('StatePort commit CAS-miss latch merge dispatch', () => {
     // Tick commit CAS-misses (persist #1 false), so the port re-reads the winner
     // and merges; the merged write (persist #2) lands.
     const persistSymbolState = vi
-      .fn<() => Promise<boolean>>()
+      .fn<StatePortDeps['persistSymbolState']>()
       .mockResolvedValueOnce(false)
       .mockResolvedValue(true);
     const mergeConcurrent = vi.fn(({ base, latchSource }) => ({
@@ -283,7 +285,7 @@ describe('StatePort commit CAS-miss latch merge dispatch', () => {
     // genuine persist error (dropped connection). commit must still resolve — a
     // reject would DLQ + re-run the tick. The latch is dropped, tick continues.
     const persistSymbolState = vi
-      .fn<() => Promise<boolean>>()
+      .fn<StatePortDeps['persistSymbolState']>()
       .mockResolvedValueOnce(false)
       .mockRejectedValue(new Error('pg connection dropped'));
     const mergeConcurrent = vi.fn(({ base }) => ({ ...(base as object), latch: 1 }));

--- a/apps/worker/__tests__/state/version-aware-mutate.test.ts
+++ b/apps/worker/__tests__/state/version-aware-mutate.test.ts
@@ -17,6 +17,8 @@ import {
   mergeLatchFieldsOnCasMiss,
   mutateSymbolState,
   type LatchMergeStrategy,
+  type PersistSymbolState,
+  type SymbolStateStrategyShape,
 } from '../../src/state/version-aware-mutate.js';
 import type { SymbolStateRowView } from '../../src/tick/snapshot-loader.js';
 import { buildSymbolStateKey } from '../../src/executor/redis-namespace.js';
@@ -81,11 +83,11 @@ const stratWith = (
     migrateState: (input: { fromVersion: string; state: unknown }) => unknown;
     initialState: (cfg: unknown) => unknown;
   }> = {},
-) => ({
+): SymbolStateStrategyShape => ({
   name: 'trailing-trade',
   version,
   initialState: extras.initialState ?? (() => ({ schemaVersion: version })),
-  migrateState: extras.migrateState,
+  ...(extras.migrateState === undefined ? {} : { migrateState: extras.migrateState }),
 });
 
 describe('mutateSymbolState', () => {
@@ -104,7 +106,7 @@ describe('mutateSymbolState', () => {
       },
     );
 
-    const persistSymbolState = vi.fn(async () => true);
+    const persistSymbolState = vi.fn<PersistSymbolState>(async () => true);
     const registry = { get: vi.fn(() => stratWith('1.1.0', { migrateState: vi.fn() })) };
 
     await mutateSymbolState(
@@ -131,7 +133,7 @@ describe('mutateSymbolState', () => {
       { state: { schemaVersion: '1.0.0', lastBuyPrice: null }, strategyVersion: '1.0.0' },
     );
 
-    const persistSymbolState = vi.fn(async () => true);
+    const persistSymbolState = vi.fn<PersistSymbolState>(async () => true);
     const migrateState = vi.fn(({ state }) => ({
       ...(state as Record<string, unknown>),
       schemaVersion: '1.1.0',
@@ -164,7 +166,7 @@ describe('mutateSymbolState', () => {
     const { redis } = makeRedis();
     const scope = makeScope({ strategyName: 'trailing-trade', config: { foo: 'bar' } }, null);
 
-    const persistSymbolState = vi.fn(async () => true);
+    const persistSymbolState = vi.fn<PersistSymbolState>(async () => true);
     const initialState = vi.fn((cfg: unknown) => ({
       schemaVersion: '1.1.0',
       config: cfg,
@@ -214,7 +216,7 @@ describe('mutateSymbolState', () => {
       { state: { schemaVersion: '1.0.0' }, strategyVersion: '1.0.0' },
     );
 
-    const persistSymbolState = vi.fn(async () => true);
+    const persistSymbolState = vi.fn<PersistSymbolState>(async () => true);
     const migrateState = vi.fn(({ state }) => ({
       ...(state as Record<string, unknown>),
       schemaVersion: '1.1.0',
@@ -244,7 +246,7 @@ describe('mutateSymbolState', () => {
       { state: { schemaVersion: '1.1.0', lastBuyPrice: '10' }, strategyVersion: '1.1.0' },
     );
 
-    const persistSymbolState = vi.fn(async () => true);
+    const persistSymbolState = vi.fn<PersistSymbolState>(async () => true);
     const registry = { get: vi.fn(() => stratWith('1.1.0')) };
 
     await mutateSymbolState(
@@ -335,7 +337,7 @@ describe('mutateSymbolState', () => {
       },
     };
 
-    const persistSymbolState = vi.fn(async () => true);
+    const persistSymbolState = vi.fn<PersistSymbolState>(async () => true);
     const registry = { get: vi.fn(() => stratWith('1.1.0')) };
 
     await Promise.all([
@@ -509,8 +511,8 @@ describe('commitSymbolStateForTick', () => {
   it('records state_commit_persist_timeout when the persist exceeds the deadline', async () => {
     const { redis, rs } = makeRedis();
     // Resolves well after the deadline; the race resolves on the timer.
-    const persistSymbolState = vi.fn(
-      () => new Promise<void>((resolve) => setTimeout(resolve, 200)),
+    const persistSymbolState = vi.fn<PersistSymbolState>(
+      () => new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 200)),
     );
     const record = vi.fn();
 
@@ -688,7 +690,7 @@ describe('mergeLatchFieldsOnCasMiss', () => {
   it('grafts the tick latch onto the winner and CAS-writes on the winner version', async () => {
     const { redis } = makeRedis();
     const coldLoad = { loadSymbolState: vi.fn(async () => winnerRow()) };
-    const persistSymbolState = vi.fn(async () => true);
+    const persistSymbolState = vi.fn<PersistSymbolState>(async () => true);
     const metrics = { record: vi.fn(), forget: vi.fn() };
 
     const ok = await mergeLatchFieldsOnCasMiss(

--- a/apps/worker/__tests__/symbol-permission-guard.test.ts
+++ b/apps/worker/__tests__/symbol-permission-guard.test.ts
@@ -26,7 +26,7 @@ import { pino } from 'pino';
 import type { Redis } from 'ioredis';
 import type { BinanceRestClient, Ticker24hrDto } from '@app/binance';
 import type { NotifyProviderRegistry } from '@app/notify';
-import type { Decision, ExecutorContext } from '@app/strategy-core';
+import { createRegistry, type Decision, type ExecutorContext } from '@app/strategy-core';
 import { asAccountId, asProfileId, asUserId } from '@app/contracts';
 import { Decimal } from '@app/money';
 
@@ -47,7 +47,11 @@ import type { ProfilePersistence } from '../src/profile-bindings/persistence.js'
 const USER = asUserId('00000000-0000-0000-0000-0000000000aa');
 const PROFILE = asProfileId('00000000-0000-0000-0000-0000000000bb');
 const ACCOUNT = asAccountId('00000000-0000-0000-0000-0000000000cc');
-const CTX: ExecutorContext = { userId: USER, profileId: PROFILE };
+const CTX: ExecutorContext = {
+  userId: USER,
+  profileId: PROFILE,
+  clock: { nowMs: () => 1_700_000_000_000 },
+};
 
 const BLOCKED = 'CRCLBUSDT';
 
@@ -185,6 +189,8 @@ const buildBindings = (binance: BinanceRestClient): ProfileExecutorBindings =>
         { provider: 'slack', config: {}, secrets: {}, enabled: true },
       ]),
       recordNotifierGap: vi.fn(async () => undefined),
+      setKv: vi.fn(async () => undefined),
+      deleteKv: vi.fn(async () => undefined),
     },
   }) as ProfileExecutorBindings;
 
@@ -199,6 +205,7 @@ const buildDeps = (bindings: ProfileExecutorBindings, redis: Redis): DecisionDep
     notifyRegistry: registry as NotifyProviderRegistry,
     resolveProfile: async () => bindings,
     cancelLedger: createCancelLedger(),
+    strategies: createRegistry(),
   } as DecisionDeps;
 };
 

--- a/apps/worker/__tests__/tick/_frame-replay-harness.ts
+++ b/apps/worker/__tests__/tick/_frame-replay-harness.ts
@@ -34,9 +34,11 @@ import {
 } from '../../src/tick/snapshot-loader.js';
 import {
   buildAccountInfoKey,
+  buildDisableActionKey,
   buildOpenOrdersKey,
   buildKillSwitchKey,
   buildOrderRefusalKey,
+  buildOrderRearmKey,
   buildSymbolStateKey,
   buildWeightKey,
 } from '../../src/executor/redis-namespace.js';
@@ -74,8 +76,10 @@ export const makeFakeRedis = (tuple: FrameTuple): Redis => {
   const store = new Map<string, string | null>();
   store.set(buildSymbolStateKey(accountId, profileId, symbol), tuple.raw.state);
   store.set(buildAccountInfoKey(accountId, profileId), tuple.raw.accountInfo);
-  store.set(buildOpenOrdersKey(accountId, profileId, symbol), tuple.raw.openOrders);
+  store.set(buildOpenOrdersKey(accountId, symbol), tuple.raw.openOrders);
   store.set(buildKillSwitchKey(accountId, profileId), tuple.raw.killSwitch);
+  store.set(buildDisableActionKey(accountId, profileId, symbol), tuple.raw.symbolDisable);
+  store.set(buildOrderRearmKey(profileId, symbol), tuple.raw.orderRearm);
   store.set(buildOrderRefusalKey(accountId, profileId, symbol), tuple.raw.orderRefusal ?? null);
   store.set(
     buildWeightKey(accountId, profileId, minuteBucketOf(NOW_MS)),

--- a/apps/worker/__tests__/tick/_override-ticket-stub.ts
+++ b/apps/worker/__tests__/tick/_override-ticket-stub.ts
@@ -21,6 +21,9 @@ export const createRecordingOverrideTicket = (): RecordingOverrideTicket => {
       arm: (armed) => {
         arms.push(armed);
       },
+      whenClaimed: async () => true,
+      claimAt: () => null,
+      whenPickedUpStamped: async () => undefined,
       markOrderAttempted: () => undefined,
       markDeterministicAbort: () => undefined,
       markSettled: () => undefined,

--- a/apps/worker/__tests__/tick/build-tick-input.test.ts
+++ b/apps/worker/__tests__/tick/build-tick-input.test.ts
@@ -4,14 +4,18 @@ import type { Logger } from 'pino';
 import type { MarketDataPort } from '@app/binance';
 import type { AnyStrategy, Candle, SymbolInfo, TriggerEvent } from '@app/strategy-core';
 import { asAccountId, asProfileId, asUserId, type TechnicalsBundleConfig } from '@app/contracts';
-import type { ProfileScope } from '@app/db';
+import type { ProfileRepo, ProfileScope } from '@app/db';
 
 // The entry-blocker on-change writer resolves a bound repo from the scope and
 // records a condition. Mock the binding so the wrapper's write is observable
 // without a real DB; `recordSpy` captures the input. The state row and the log
 // edge are the writer's business and are covered against real Postgres in
 // packages/db; what matters here is WHETHER the tick path calls it.
-const recordSpy = vi.fn(async () => ({ changed: true as const, previousCode: null, sinceMs: 0 }));
+const recordSpy = vi.fn<ProfileRepo['conditionStates']['recordCondition']>(async () => ({
+  changed: true,
+  previousCode: null,
+  sinceMs: 0,
+}));
 vi.mock('@app/db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@app/db')>();
   return {
@@ -101,6 +105,7 @@ const baseRaw = (overrides: Partial<RawSnapshot> = {}): RawSnapshot => ({
   killSwitch: null,
   symbolDisable: null,
   weightUsed1m: 10,
+  orderRearm: null,
   orderRefusal: null,
   indicatorsByInterval: { '1h': null },
   ...overrides,
@@ -539,10 +544,10 @@ describe('buildTickInput', () => {
     // the case above it left behind. Each case takes its own symbol.
     // Every commit audits each blocker field, so a per-condition view is what
     // the de-spam claims are actually about.
-    const callsFor = (condition: string): unknown[] =>
-      recordSpy.mock.calls
-        .map((c) => c[0] as { condition: string })
-        .filter((c) => c.condition === condition);
+    const callsFor = (
+      condition: string,
+    ): Array<Parameters<ProfileRepo['conditionStates']['recordCondition']>[0]> =>
+      recordSpy.mock.calls.map((c) => c[0]).filter((c) => c.condition === condition);
 
     // Three audited fields now share one writer, so a `mockResolvedValue` set for
     // one case would answer for the other two and outlive the test that set it.

--- a/apps/worker/__tests__/tick/bundle-builder.test.ts
+++ b/apps/worker/__tests__/tick/bundle-builder.test.ts
@@ -29,11 +29,13 @@ const ALL_PROVIDERS = ['technicals', 'override'];
 const tvConfig = (interval: string = INTERVAL): TechnicalsBundleConfig => ({
   useOnlyWithinMin: 2,
   ifExpires: 'do-not-buy',
+  entryConfirmReads: 1,
   intervals: [defaultIntervalRow(interval)],
 });
 
 const defaultIntervalRow = (interval: string): TechnicalsIntervalConfig => ({
   interval,
+  mode: 'block',
   whenStrongBuy: true,
   whenBuy: true,
   whenSell: false,
@@ -179,6 +181,7 @@ describe('createTickBundleProvider', () => {
     const cfg: TechnicalsBundleConfig = {
       useOnlyWithinMin: 10,
       ifExpires: 'allow-anyway',
+      entryConfirmReads: 1,
       intervals: [defaultIntervalRow(INTERVAL)],
     };
     const bundle = (await provider(ACCOUNT, PROFILE, SYMBOL, cfg, ALL_PROVIDERS))
@@ -246,6 +249,7 @@ describe('createTickBundleProvider', () => {
     const cfg: TechnicalsBundleConfig = {
       useOnlyWithinMin: 2,
       ifExpires: 'do-not-buy',
+      entryConfirmReads: 1,
       intervals: [defaultIntervalRow('1h'), defaultIntervalRow('1d')],
     };
     const bundle = (await provider(ACCOUNT, PROFILE, SYMBOL, cfg, ALL_PROVIDERS))
@@ -264,6 +268,7 @@ describe('createTickBundleProvider', () => {
     const cfg: TechnicalsBundleConfig = {
       useOnlyWithinMin: 2,
       ifExpires: 'do-not-buy',
+      entryConfirmReads: 1,
       intervals: [],
     };
     const bundle = (await provider(ACCOUNT, PROFILE, SYMBOL, cfg, ALL_PROVIDERS))
@@ -538,6 +543,7 @@ describe('createTickBundleProvider', () => {
     const cfg: TechnicalsBundleConfig = {
       useOnlyWithinMin: 2,
       ifExpires: 'do-not-buy',
+      entryConfirmReads: 1,
       intervals: [defaultIntervalRow('1h'), defaultIntervalRow('1d')],
     };
     const bundle = (await provider(ACCOUNT, PROFILE, SYMBOL, cfg, ALL_PROVIDERS))

--- a/apps/worker/__tests__/tick/cold-load.test.ts
+++ b/apps/worker/__tests__/tick/cold-load.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, type Mock } from 'vitest';
 import pino, { type Logger } from 'pino';
 import type { Redis } from 'ioredis';
 import type { BinanceRestClient } from '@app/binance';
@@ -30,9 +30,7 @@ const stubRestClient = (overrides: Partial<BinanceRestClient> = {}): BinanceRest
     ...overrides,
   }) as unknown as BinanceRestClient;
 
-interface StubRedis extends Redis {
-  set: ReturnType<typeof vi.fn>;
-}
+type StubRedis = Redis & { set: Mock<(key: string, value: string) => Promise<'OK'>> };
 
 const stubRedis = (initial: Record<string, string> = {}): StubRedis => {
   const data = new Map<string, string>(Object.entries(initial));
@@ -131,7 +129,7 @@ describe('createProductionColdLoad.loadAccount', () => {
 describe('createProductionColdLoad.loadOpenOrders', () => {
   it('maps OpenOrderDto array to strategy-core OpenOrder via REST fallback', async () => {
     const rest = stubRestClient({
-      getOpenOrders: vi.fn(async () => [
+      getOpenOrders: vi.fn<BinanceRestClient['getOpenOrders']>(async () => [
         {
           symbol: 'BTCUSDT',
           orderId: 1,
@@ -157,7 +155,7 @@ describe('createProductionColdLoad.loadOpenOrders', () => {
       resolveBinance: async () => rest,
     });
 
-    const orders = await coldLoad.loadOpenOrders(USER_ID, PROFILE_ID, 'BTCUSDT');
+    const orders = await coldLoad.loadOpenOrders(USER_ID, ACCOUNT_ID, PROFILE_ID, 'BTCUSDT');
 
     expect(orders).toHaveLength(1);
     expect(orders[0]).toMatchObject({

--- a/apps/worker/__tests__/tick/frame-recorder.test.ts
+++ b/apps/worker/__tests__/tick/frame-recorder.test.ts
@@ -19,6 +19,7 @@ const tuple = (over: Partial<FrameTuple> = {}): FrameTuple => ({
     killSwitch: null,
     symbolDisable: null,
     weightUsed1m: 0,
+    orderRearm: null,
     orderRefusal: null,
     indicatorsByInterval: {},
   },

--- a/apps/worker/__tests__/tick/frame-replay.generate.test.ts
+++ b/apps/worker/__tests__/tick/frame-replay.generate.test.ts
@@ -79,6 +79,8 @@ const ttTuple: FrameTuple = {
     killSwitch: null,
     symbolDisable: null,
     weightUsed1m: 10,
+    orderRearm: null,
+    orderRefusal: null,
     indicatorsByInterval: { '1h': null },
   },
   livePrice: '47000.00',

--- a/apps/worker/__tests__/tick/map-event-to-trigger.test.ts
+++ b/apps/worker/__tests__/tick/map-event-to-trigger.test.ts
@@ -4,6 +4,7 @@ import type { TickJobData } from '../../src/queues/job-payloads.js';
 
 const data = (event: TickJobData['event'], payload: Record<string, unknown> = {}): TickJobData => ({
   userId: 'u',
+  accountId: 'a',
   profileId: 'p',
   symbol: 'BTCUSDT',
   event,

--- a/apps/worker/__tests__/tick/override-abort-rearm.test.ts
+++ b/apps/worker/__tests__/tick/override-abort-rearm.test.ts
@@ -38,7 +38,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.00001', stepSize: '0.00001', minNotional: '10', tickSize: '0.01' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.00001',
+    maxQty: '1000000',
+    minNotional: '10',
+    tickSize: '0.01',
+    stepSize: '0.00001',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 /** Distinguishable from an incidental setup failure, so no assertion false-passes. */
@@ -259,7 +268,7 @@ const run = async (
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/override-breadcrumb.test.ts
+++ b/apps/worker/__tests__/tick/override-breadcrumb.test.ts
@@ -43,7 +43,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.00001', stepSize: '0.00001', minNotional: '10', tickSize: '0.01' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.00001',
+    stepSize: '0.00001',
+    minNotional: '10',
+    tickSize: '0.01',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 /** ioredis stub: empty snapshot slots (cold-load), plus the tick-meta/re-arm SETs. */
@@ -206,7 +215,7 @@ const run = async (opts: RunOpts = {}): Promise<RunResult> => {
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/override-claim-gate.test.ts
+++ b/apps/worker/__tests__/tick/override-claim-gate.test.ts
@@ -81,7 +81,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.00001', stepSize: '0.00001', minNotional: '10', tickSize: '0.01' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.00001',
+    stepSize: '0.00001',
+    minNotional: '10',
+    tickSize: '0.01',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 /** ioredis stub: empty snapshot slots (cold-load), plus the tick-meta / re-arm SETs. */
@@ -287,7 +296,7 @@ const run = async (opts: RunOpts = {}): Promise<RunResult> => {
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/override-defer-rearm.test.ts
+++ b/apps/worker/__tests__/tick/override-defer-rearm.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { profileKey, type ProfileScope } from '@app/db';
 import { asAccountId, asProfileId, asUserId, type ManualOverridePayload } from '@app/contracts';
 
-import { settleOverride } from '../../src/tick/override-settlement.js';
+import { settleOverride, type SettleOverrideArgs } from '../../src/tick/override-settlement.js';
 
 const OPERATOR = asUserId('00000000-0000-0000-0000-0000000000a1');
 const ACCOUNT = asAccountId('00000000-0000-0000-0000-000000000abc');
@@ -27,6 +27,9 @@ const OVERRIDE_KEY = profileKey({ accountId: ACCOUNT, profileId: PROFILE }, 'ove
 
 /** The `processing_at` stamp a claiming tick would have written, and the release's fence. */
 const CLAIM_AT = new Date('2026-07-30T00:00:00.000Z');
+type SettleOverrideAction = NonNullable<SettleOverrideArgs['settleOverrideAction']>;
+const settleAction = (implementation: SettleOverrideAction) =>
+  vi.fn<SettleOverrideAction>(implementation);
 
 /**
  * ioredis stub recording every `set` argv. `rejectSet` forces the SET to
@@ -64,7 +67,7 @@ const buildFakeLogger = (warnings: { ctx: unknown; msg: string }[]): import('pin
 describe('settleOverride', () => {
   it('re-arms with NX+PX and does not mark consumed when deferred', async () => {
     const setCalls: unknown[][] = [];
-    const settleOverrideAction = vi.fn(async () => {});
+    const settleOverrideAction = settleAction(async () => undefined);
 
     await settleOverride({
       redis: buildFakeRedis(setCalls),
@@ -87,7 +90,7 @@ describe('settleOverride', () => {
 
   it('marks consumed and does not re-arm when the strategy applied the override', async () => {
     const setCalls: unknown[][] = [];
-    const settleOverrideAction = vi.fn(async () => {});
+    const settleOverrideAction = settleAction(async () => undefined);
 
     await settleOverride({
       redis: buildFakeRedis(setCalls),
@@ -118,7 +121,7 @@ describe('settleOverride', () => {
     await settleOverride({
       redis: buildFakeRedis(setCalls),
       logger: buildFakeLogger([]),
-      settleOverrideAction: vi.fn(async () => {}),
+      settleOverrideAction: settleAction(async () => undefined),
       scope: SCOPE,
       symbol: SYMBOL,
       override: OVERRIDE,
@@ -138,7 +141,7 @@ describe('settleOverride', () => {
   it('consumes without re-arming when remaining TTL is exhausted or unavailable', async () => {
     for (const ttlMs of [0, -1, undefined]) {
       const setCalls: unknown[][] = [];
-      const settleOverrideAction = vi.fn(async () => {});
+      const settleOverrideAction = settleAction(async () => undefined);
 
       await settleOverride({
         redis: buildFakeRedis(setCalls),
@@ -147,7 +150,7 @@ describe('settleOverride', () => {
         scope: SCOPE,
         symbol: SYMBOL,
         override: OVERRIDE,
-        ttlMs,
+        ...(ttlMs === undefined ? {} : { ttlMs }),
         deferred: true,
         supported: true,
         orderFate: { kind: 'none' },
@@ -160,7 +163,7 @@ describe('settleOverride', () => {
 
   it('consumes an unsupported kind without re-arming', async () => {
     const setCalls: unknown[][] = [];
-    const settleOverrideAction = vi.fn(async () => {});
+    const settleOverrideAction = settleAction(async () => undefined);
 
     // An override the strategy does not declare can never be applied; re-arming
     // it would loop it forever. Consume it, same as today.
@@ -191,7 +194,7 @@ describe('settleOverride', () => {
     // no view of `strategy.capabilities` must not have the NEGATIVE assertion put in
     // its mouth: the neutral wording is true whatever the capability turns out to be.
     const setCalls: unknown[][] = [];
-    const settleOverrideAction = vi.fn(async () => {});
+    const settleOverrideAction = settleAction(async () => undefined);
 
     await settleOverride({
       redis: buildFakeRedis(setCalls),
@@ -217,7 +220,7 @@ describe('settleOverride', () => {
   it('warns and completes when the re-arm SET rejects', async () => {
     const setCalls: unknown[][] = [];
     const warnings: { ctx: unknown; msg: string }[] = [];
-    const settleOverrideAction = vi.fn(async () => {});
+    const settleOverrideAction = settleAction(async () => undefined);
 
     await expect(
       settleOverride({
@@ -310,7 +313,7 @@ describe('settleOverride', () => {
   it('resolves and warns when the ambiguous-outcome notify throws synchronously', async () => {
     const warnings: { ctx: unknown; msg: string }[] = [];
     const boom = new Error('notifier exploded');
-    const settleOverrideAction = vi.fn(async () => {});
+    const settleOverrideAction = settleAction(async () => undefined);
     const notifyOverrideOutcome = vi.fn(() => {
       throw boom;
     });
@@ -360,7 +363,7 @@ describe('settleOverride', () => {
     // Postgres and outbound webhooks.
     const warnings: { ctx: unknown; msg: string }[] = [];
     const boom = new Error('notifier rejected');
-    const settleOverrideAction = vi.fn(async () => {});
+    const settleOverrideAction = settleAction(async () => undefined);
     const notifyOverrideOutcome = vi.fn(() => Promise.reject(boom));
 
     await expect(
@@ -397,7 +400,7 @@ describe('settleOverride', () => {
     // can never execute — consume it instead of leaving it pending forever.
     const setCalls: unknown[][] = [];
     const warnings: { ctx: unknown; msg: string }[] = [];
-    const settleOverrideAction = vi.fn(async () => {});
+    const settleOverrideAction = settleAction(async () => undefined);
 
     await settleOverride({
       redis: buildFakeRedis(setCalls, false, null),
@@ -422,7 +425,7 @@ describe('settleOverride', () => {
     // Mirror image of the NX-loss case: an 'OK' reply means the key is armed, so
     // the row must stay pending (nothing has executed yet).
     const setCalls: unknown[][] = [];
-    const settleOverrideAction = vi.fn(async () => {});
+    const settleOverrideAction = settleAction(async () => undefined);
 
     await settleOverride({
       redis: buildFakeRedis(setCalls, false, 'OK'),
@@ -450,7 +453,7 @@ describe('settleOverride', () => {
     await settleOverride({
       redis: buildFakeRedis(setCalls),
       logger: buildFakeLogger([]),
-      settleOverrideAction: vi.fn(async () => {}),
+      settleOverrideAction: settleAction(async () => undefined),
       scope: SCOPE,
       symbol: SYMBOL,
       override: OVERRIDE,
@@ -488,7 +491,7 @@ describe('settleOverride', () => {
           },
         } as unknown as import('ioredis').Redis,
         logger: buildFakeLogger([]),
-        settleOverrideAction: vi.fn(async () => {}),
+        settleOverrideAction: settleAction(async () => undefined),
         releaseOverrideClaim,
         claimAt: CLAIM_AT,
         scope: SCOPE,
@@ -518,7 +521,7 @@ describe('settleOverride', () => {
       await settleOverride({
         redis: buildFakeRedis(setCalls),
         logger: buildFakeLogger(warnings),
-        settleOverrideAction: vi.fn(async () => {}),
+        settleOverrideAction: settleAction(async () => undefined),
         releaseOverrideClaim: vi.fn(() => Promise.reject(new Error('postgres unreachable'))),
         claimAt: CLAIM_AT,
         scope: SCOPE,
@@ -543,7 +546,7 @@ describe('settleOverride', () => {
       await settleOverride({
         redis: buildFakeRedis(setCalls),
         logger: buildFakeLogger(warnings),
-        settleOverrideAction: vi.fn(async () => {}),
+        settleOverrideAction: settleAction(async () => undefined),
         releaseOverrideClaim: vi.fn(() => new Promise<void>(() => undefined)),
         claimAt: CLAIM_AT,
         scope: SCOPE,
@@ -568,7 +571,7 @@ describe('settleOverride', () => {
       // being claimed cannot block that: the settle carries no `processing_at`
       // predicate. Left pending, the operator watches a dead override forever.
       const setCalls: unknown[][] = [];
-      const settleOverrideAction = vi.fn(async () => {});
+      const settleOverrideAction = settleAction(async () => undefined);
       const releaseOverrideClaim = vi.fn(async () => {});
 
       await settleOverride({
@@ -602,7 +605,7 @@ describe('settleOverride', () => {
       await settleOverride({
         redis: buildFakeRedis(setCalls),
         logger: buildFakeLogger([]),
-        settleOverrideAction: vi.fn(async () => {}),
+        settleOverrideAction: settleAction(async () => undefined),
         releaseOverrideClaim,
         scope: SCOPE,
         symbol: SYMBOL,
@@ -623,7 +626,7 @@ describe('settleOverride', () => {
       // a deterministic abort, different cause. Nothing was dispatched, so the override
       // provably did not execute and the row can carry a verdict.
       const setCalls: unknown[][] = [];
-      const settleOverrideAction = vi.fn(async () => {});
+      const settleOverrideAction = settleAction(async () => undefined);
 
       await settleOverride({
         redis: buildFakeRedis(setCalls),
@@ -655,7 +658,7 @@ describe('settleOverride', () => {
       // claim does not re-arm would also pass if the abort path had stopped re-arming
       // altogether.
       const setCalls: unknown[][] = [];
-      const settleOverrideAction = vi.fn(async () => {});
+      const settleOverrideAction = settleAction(async () => undefined);
 
       await settleOverride({
         redis: buildFakeRedis(setCalls),
@@ -688,7 +691,7 @@ describe('settleOverride', () => {
       await settleOverride({
         redis: buildFakeRedis(setCalls),
         logger: buildFakeLogger([]),
-        settleOverrideAction: vi.fn(async () => {}),
+        settleOverrideAction: settleAction(async () => undefined),
         releaseOverrideClaim,
         claimAt: CLAIM_AT,
         scope: SCOPE,
@@ -707,7 +710,7 @@ describe('settleOverride', () => {
 
   it('consumes without re-arming when the tick outlived the remaining window', async () => {
     const setCalls: unknown[][] = [];
-    const settleOverrideAction = vi.fn(async () => {});
+    const settleOverrideAction = settleAction(async () => undefined);
 
     await settleOverride({
       redis: buildFakeRedis(setCalls),

--- a/apps/worker/__tests__/tick/profile-context-cache.test.ts
+++ b/apps/worker/__tests__/tick/profile-context-cache.test.ts
@@ -4,7 +4,7 @@
 // null build result is never cached so a re-created profile resolves fresh.
 
 import { describe, expect, it, vi } from 'vitest';
-import type { ProfileId, UserId } from '@app/contracts';
+import type { AccountId, ProfileId } from '@app/contracts';
 
 import {
   createProfileContextCache,
@@ -12,7 +12,7 @@ import {
 } from '../../src/tick/profile-context-cache.js';
 import type { ProfileTickContext } from '../../src/tick/build-tick-input.js';
 
-const USER = 'u-1' as UserId;
+const ACCOUNT = 'a-1' as AccountId;
 const PROFILE = 'p-1' as ProfileId;
 
 // The cache stores the context opaquely; a tagged stub is enough to assert
@@ -31,9 +31,9 @@ describe('createProfileContextCache', () => {
     const ctx = ctxStub('a');
     const build = vi.fn().mockResolvedValue(ctx);
 
-    const first = await cache.resolve(USER, PROFILE, 'BTCUSDT', build);
+    const first = await cache.resolve(ACCOUNT, PROFILE, 'BTCUSDT', build);
     clock.advance(PROFILE_CONTEXT_CACHE_TTL_MS - 1);
-    const second = await cache.resolve(USER, PROFILE, 'BTCUSDT', build);
+    const second = await cache.resolve(ACCOUNT, PROFILE, 'BTCUSDT', build);
 
     expect(first).toBe(ctx);
     expect(second).toBe(ctx);
@@ -45,9 +45,9 @@ describe('createProfileContextCache', () => {
     const cache = createProfileContextCache({ nowMs: clock.nowMs });
     const build = vi.fn().mockResolvedValueOnce(ctxStub('a')).mockResolvedValueOnce(ctxStub('b'));
 
-    await cache.resolve(USER, PROFILE, 'BTCUSDT', build);
+    await cache.resolve(ACCOUNT, PROFILE, 'BTCUSDT', build);
     clock.advance(PROFILE_CONTEXT_CACHE_TTL_MS);
-    await cache.resolve(USER, PROFILE, 'BTCUSDT', build);
+    await cache.resolve(ACCOUNT, PROFILE, 'BTCUSDT', build);
 
     expect(build).toHaveBeenCalledTimes(2);
   });
@@ -57,14 +57,14 @@ describe('createProfileContextCache', () => {
     const cache = createProfileContextCache({ nowMs: clock.nowMs });
     const build = vi.fn().mockResolvedValue(ctxStub('a'));
 
-    await cache.resolve(USER, PROFILE, 'BTCUSDT', build);
-    await cache.resolve(USER, PROFILE, 'ETHUSDT', build);
+    await cache.resolve(ACCOUNT, PROFILE, 'BTCUSDT', build);
+    await cache.resolve(ACCOUNT, PROFILE, 'ETHUSDT', build);
     expect(build).toHaveBeenCalledTimes(2); // distinct symbols → distinct keys
 
     cache.evictProfile(PROFILE);
 
-    await cache.resolve(USER, PROFILE, 'BTCUSDT', build);
-    await cache.resolve(USER, PROFILE, 'ETHUSDT', build);
+    await cache.resolve(ACCOUNT, PROFILE, 'BTCUSDT', build);
+    await cache.resolve(ACCOUNT, PROFILE, 'ETHUSDT', build);
     expect(build).toHaveBeenCalledTimes(4); // both rebuilt after eviction
   });
 
@@ -73,8 +73,8 @@ describe('createProfileContextCache', () => {
     const cache = createProfileContextCache({ nowMs: clock.nowMs });
     const build = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(ctxStub('a'));
 
-    const first = await cache.resolve(USER, PROFILE, 'BTCUSDT', build);
-    const second = await cache.resolve(USER, PROFILE, 'BTCUSDT', build);
+    const first = await cache.resolve(ACCOUNT, PROFILE, 'BTCUSDT', build);
+    const second = await cache.resolve(ACCOUNT, PROFILE, 'BTCUSDT', build);
 
     expect(first).toBeNull();
     expect(second).not.toBeNull();
@@ -86,9 +86,9 @@ describe('createProfileContextCache', () => {
     const cache = createProfileContextCache({ nowMs: clock.nowMs, ttlMs: 5_000 });
     const build = vi.fn().mockResolvedValue(ctxStub('a'));
 
-    await cache.resolve(USER, PROFILE, 'BTCUSDT', build);
+    await cache.resolve(ACCOUNT, PROFILE, 'BTCUSDT', build);
     clock.advance(5_000);
-    await cache.resolve(USER, PROFILE, 'BTCUSDT', build);
+    await cache.resolve(ACCOUNT, PROFILE, 'BTCUSDT', build);
 
     expect(build).toHaveBeenCalledTimes(2);
   });

--- a/apps/worker/__tests__/tick/symbol-info-cache.test.ts
+++ b/apps/worker/__tests__/tick/symbol-info-cache.test.ts
@@ -49,7 +49,9 @@ describe('createSymbolInfoCache', () => {
   };
 
   it('returns symbol-info from the Redis cache without calling refresh', async () => {
-    const redis = stubRedis({ [buildSymbolInfoKey('BTCUSDT')]: JSON.stringify(symbolInfo) });
+    const redis = stubRedis({
+      [buildSymbolInfoKey('BTCUSDT', 'live')]: JSON.stringify(symbolInfo),
+    });
     const refresh = vi.fn(async () => undefined);
     const cache = createSymbolInfoCache({
       redis,
@@ -67,7 +69,9 @@ describe('createSymbolInfoCache', () => {
     // Entries are cast, not schema-parsed, and no migration rewrites them: a blob
     // written before the band existed must survive the read and present the field
     // as UNKNOWN, which every consumer treats as "impose no constraint".
-    const redis = stubRedis({ [buildSymbolInfoKey('BTCUSDT')]: JSON.stringify(symbolInfo) });
+    const redis = stubRedis({
+      [buildSymbolInfoKey('BTCUSDT', 'live')]: JSON.stringify(symbolInfo),
+    });
     const cache = createSymbolInfoCache({
       redis,
       logger: silentLogger,
@@ -94,7 +98,7 @@ describe('createSymbolInfoCache', () => {
         },
       },
     };
-    const redis = stubRedis({ [buildSymbolInfoKey('BTCUSDT')]: JSON.stringify(banded) });
+    const redis = stubRedis({ [buildSymbolInfoKey('BTCUSDT', 'live')]: JSON.stringify(banded) });
     const cache = createSymbolInfoCache({
       redis,
       logger: silentLogger,
@@ -111,7 +115,7 @@ describe('createSymbolInfoCache', () => {
     const redis = stubRedis();
     const refresh = vi.fn(async () => {
       // simulate the refresher writing the key
-      redis.data.set(buildSymbolInfoKey('BTCUSDT'), JSON.stringify(symbolInfo));
+      redis.data.set(buildSymbolInfoKey('BTCUSDT', 'live'), JSON.stringify(symbolInfo));
     });
     const cache = createSymbolInfoCache({
       redis,
@@ -170,7 +174,7 @@ describe('createSymbolInfoCache', () => {
 
     it('keeps live and test entries independent — a live hit never serves a test get', async () => {
       const redis = stubRedis({
-        [buildSymbolInfoKey('BTCUSDT')]: JSON.stringify(symbolInfo),
+        [buildSymbolInfoKey('BTCUSDT', 'live')]: JSON.stringify(symbolInfo),
         [buildSymbolInfoKey('BTCUSDT', 'test')]: JSON.stringify(testnetInfo),
       });
       const refresh = vi.fn(async () => undefined);
@@ -187,7 +191,9 @@ describe('createSymbolInfoCache', () => {
     });
 
     it('defaults to the live keyspace when mode is omitted', async () => {
-      const redis = stubRedis({ [buildSymbolInfoKey('BTCUSDT')]: JSON.stringify(symbolInfo) });
+      const redis = stubRedis({
+        [buildSymbolInfoKey('BTCUSDT', 'live')]: JSON.stringify(symbolInfo),
+      });
       const cache = createSymbolInfoCache({
         redis,
         logger: silentLogger,
@@ -251,7 +257,9 @@ describe('createSymbolInfoCache', () => {
     });
 
     it('serves the second call from the in-process cache without hitting Redis', async () => {
-      const redis = stubRedis({ [buildSymbolInfoKey('BTCUSDT')]: JSON.stringify(symbolInfo) });
+      const redis = stubRedis({
+        [buildSymbolInfoKey('BTCUSDT', 'live')]: JSON.stringify(symbolInfo),
+      });
       const refresh = vi.fn(async () => undefined);
       const cache = createSymbolInfoCache({
         redis,
@@ -270,7 +278,9 @@ describe('createSymbolInfoCache', () => {
     it('refetches from Redis after the TTL elapses', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-05-28T00:00:00Z'));
-      const redis = stubRedis({ [buildSymbolInfoKey('BTCUSDT')]: JSON.stringify(symbolInfo) });
+      const redis = stubRedis({
+        [buildSymbolInfoKey('BTCUSDT', 'live')]: JSON.stringify(symbolInfo),
+      });
       const cache = createSymbolInfoCache({
         redis,
         logger: silentLogger,
@@ -292,7 +302,7 @@ describe('createSymbolInfoCache', () => {
     it('caches the refresh-path payload so the next tick is also cache-hot', async () => {
       const redis = stubRedis();
       const refresh = vi.fn(async () => {
-        redis.data.set(buildSymbolInfoKey('BTCUSDT'), JSON.stringify(symbolInfo));
+        redis.data.set(buildSymbolInfoKey('BTCUSDT', 'live'), JSON.stringify(symbolInfo));
       });
       const cache = createSymbolInfoCache({
         redis,
@@ -332,7 +342,9 @@ describe('createSymbolInfoCache', () => {
     });
 
     it('isolates the cache to one instance (worker restart re-warms)', async () => {
-      const redis = stubRedis({ [buildSymbolInfoKey('BTCUSDT')]: JSON.stringify(symbolInfo) });
+      const redis = stubRedis({
+        [buildSymbolInfoKey('BTCUSDT', 'live')]: JSON.stringify(symbolInfo),
+      });
       const refresh = vi.fn(async () => undefined);
 
       const cacheA = createSymbolInfoCache({
@@ -444,7 +456,7 @@ describe('createSymbolInfoCache', () => {
       const refresh = vi.fn(async () => {
         // Operator re-lists on Binance after the first (absent) refresh.
         if (relisted) {
-          redis.data.set(buildSymbolInfoKey('RELISTUSDT'), JSON.stringify(symbolInfo));
+          redis.data.set(buildSymbolInfoKey('RELISTUSDT', 'live'), JSON.stringify(symbolInfo));
         }
       });
       const cache = createSymbolInfoCache({

--- a/apps/worker/__tests__/tick/tick-handler-bundle-schema.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-bundle-schema.test.ts
@@ -32,7 +32,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.00001', stepSize: '0.00001', minNotional: '10', tickSize: '0.01' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.00001',
+    stepSize: '0.00001',
+    minNotional: '10',
+    tickSize: '0.01',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 /**
@@ -145,7 +154,7 @@ const run = async () => {
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/tick-handler-counters.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-counters.test.ts
@@ -45,7 +45,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.00001', stepSize: '0.00001', minNotional: '10', tickSize: '0.01' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.00001',
+    stepSize: '0.00001',
+    minNotional: '10',
+    tickSize: '0.01',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 /**
@@ -191,7 +200,7 @@ const run = async (
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/tick-handler-delisted-reap.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-delisted-reap.test.ts
@@ -131,7 +131,9 @@ const buildHarness = (opts: HarnessOpts) => {
         };
 
   const reapAutoIfFlat = vi.fn(async (): Promise<ReapOutcome> => opts.reapResult ?? 'removed');
-  const appendActionLog = vi.fn(async () => undefined);
+  const appendActionLog = vi.fn<NonNullable<TickHandlerDeps['appendActionLog']>>(
+    async () => undefined,
+  );
   // After a `removed` reap, the handler tells the WS to drop the unbound symbol by
   // enqueuing a reconfigure job. Best-effort: a throw must be swallowed, not fatal.
   const enqueueReconfigure = vi.fn(async () => {
@@ -203,7 +205,7 @@ const buildHarness = (opts: HarnessOpts) => {
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/tick-handler-multi-place.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-multi-place.test.ts
@@ -34,7 +34,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.00001', stepSize: '0.00001', minNotional: '10', tickSize: '0.01' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.00001',
+    stepSize: '0.00001',
+    minNotional: '10',
+    tickSize: '0.01',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 const place = (clientOrderId: string): Decision => ({
@@ -137,7 +146,7 @@ const drive = async (
     logger,
     // Never reached: the placement-count check throws before any handler resolves.
     resolveProfile: vi.fn(async () => ({}) as never),
-    notifierGapThrottle: { allow: async () => true },
+    notifierGapThrottle: { allow: async () => true, release: async () => undefined },
   });
 
   const deps = {
@@ -168,7 +177,7 @@ const drive = async (
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/tick-handler-not-permitted-retire.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-not-permitted-retire.test.ts
@@ -153,7 +153,7 @@ const buildHarness = (opts: HarnessOpts) => {
     if (opts.reapThrows) throw new Error('reapAutoIfFlat: transient postgres failure');
     return opts.reapResult ?? 'removed';
   });
-  const appendActionLog = vi.fn(async () => {
+  const appendActionLog = vi.fn<NonNullable<TickHandlerDeps['appendActionLog']>>(async () => {
     if (opts.appendActionLogThrows) throw new Error('appendActionLog: transient postgres failure');
   });
   const enqueueReconfigure = vi.fn(async () => {
@@ -239,7 +239,7 @@ const buildHarness = (opts: HarnessOpts) => {
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/tick-handler-order-rearm.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-order-rearm.test.ts
@@ -61,7 +61,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.00001', stepSize: '0.00001', minNotional: '10', tickSize: '0.01' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.00001',
+    stepSize: '0.00001',
+    minNotional: '10',
+    tickSize: '0.01',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 type OrderFailure = {
@@ -292,7 +301,7 @@ const run = async (opts: RunOpts) => {
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/tick-handler-order-refusal-circuit.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-order-refusal-circuit.test.ts
@@ -41,7 +41,15 @@ const SYMBOL_INFO: SymbolInfo = {
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
   status: 'TRADING',
-  filters: { minQty: '0.0001', stepSize: '0.0001', minNotional: '10', tickSize: '0.01' },
+  filters: {
+    minQty: '0.0001',
+    stepSize: '0.0001',
+    minNotional: '10',
+    tickSize: '0.01',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 const strategy = {
@@ -91,7 +99,7 @@ const job = {
     accountId: String(ACCOUNT),
     profileId: String(PROFILE),
     symbol: SYMBOL,
-    event: 'tick',
+    event: 'resync',
     enqueuedAtMs: START_MS,
     payload: {},
   } satisfies TickJobData,
@@ -194,7 +202,9 @@ const buildHarness = (options: HarnessOptions = {}) => {
     },
   };
   const commit = vi.fn(async () => undefined);
-  const recordOrderRefusalCondition = vi.fn(async () => undefined);
+  const recordOrderRefusalCondition = vi.fn<
+    NonNullable<TickHandlerDeps['recordOrderRefusalCondition']>
+  >(async () => undefined);
   const notifyOrderFailed = vi.fn(async () => undefined);
   const notifyOrderRefusalLoop = vi.fn(async () => undefined);
   const audits: AuditEntry[] = [];

--- a/apps/worker/__tests__/tick/tick-handler-override-outcome.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-override-outcome.test.ts
@@ -56,7 +56,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.00001', stepSize: '0.00001', minNotional: '10', tickSize: '0.01' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.00001',
+    stepSize: '0.00001',
+    minNotional: '10',
+    tickSize: '0.01',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 /** The failure shapes the executor reports; `phase` is what makes re-arm decidable. */
@@ -261,7 +270,7 @@ const run = async (opts: RunOpts): Promise<RunResult> => {
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/tick-handler-override-settle.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-override-settle.test.ts
@@ -35,7 +35,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.00001', stepSize: '0.00001', minNotional: '10', tickSize: '0.01' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.00001',
+    stepSize: '0.00001',
+    minNotional: '10',
+    tickSize: '0.01',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 /**
@@ -247,7 +256,7 @@ const run = async (
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/tick-handler-protective-stop-alert.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-protective-stop-alert.test.ts
@@ -64,7 +64,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'LINK',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.01', stepSize: '0.01', minNotional: '10', tickSize: '0.001' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.01',
+    stepSize: '0.01',
+    minNotional: '10',
+    tickSize: '0.001',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 const blockerState = (detail: { terminal: boolean; guarded: boolean }) => ({
@@ -211,7 +220,7 @@ const run = async (opts: RunOpts) => {
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/__tests__/tick/tick-handler-symbol-pause.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-symbol-pause.test.ts
@@ -38,7 +38,16 @@ const SYMBOL_INFO: SymbolInfo = {
   symbol: SYMBOL,
   baseAsset: 'BTC',
   quoteAsset: 'USDT',
-  filters: { minQty: '0.00001', stepSize: '0.00001', minNotional: '10', tickSize: '0.01' },
+  status: 'TRADING',
+  filters: {
+    minQty: '0.00001',
+    stepSize: '0.00001',
+    minNotional: '10',
+    tickSize: '0.01',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
 };
 
 /**
@@ -179,7 +188,7 @@ const run = async (): Promise<{
       accountId: String(ACCOUNT),
       profileId: String(PROFILE),
       symbol: SYMBOL,
-      event: 'tick',
+      event: 'resync',
       enqueuedAtMs: 0,
       payload: {},
     } satisfies TickJobData,

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -9,7 +9,7 @@
     "dev": "ROLE=worker bun --watch src/index.ts",
     "dev:study": "ROLE=study WORKER_ADMIN_PORT=9102 bun --watch src/index.ts",
     "build": "tsc -b",
-    "typecheck": "tsc -b --noEmit && tsc -p tsconfig.test-d.json --noEmit",
+    "typecheck": "tsc -b --noEmit && tsc -p tsconfig.test-d.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test": "vitest run --exclude '**/integration/**'",
     "test:integration": "vitest run __tests__/integration --no-file-parallelism --hookTimeout=180000",
     "test:frame-replay": "vitest run __tests__/tick/frame-replay.test.ts",

--- a/apps/worker/tsconfig.test.json
+++ b/apps/worker/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  // Type-checks the TEST surface, which `tsc -b` does not: the build graph covers `src/` only, so a fixture can omit a required field, satisfy `Partial<T>` at runtime, and drift from the type it claims to build. That is not theoretical — two revive tests here omitted `walletQuantity` entirely, read `undefined` where the code branches on `null`, threw inside a try/catch, and passed for the wrong reason while asserting nothing.
+  //
+  // Ordinary tests and type-level tests have separate compilers. This project checks every ordinary test, while `tsconfig.test-d.json` owns `.test-d.ts` assertions.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "isolatedDeclarations": false,
+    "incremental": false
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "exclude": ["**/*.test-d.ts"]
+}

--- a/packages/binance/__tests__/market-data/kline-fetcher.test.ts
+++ b/packages/binance/__tests__/market-data/kline-fetcher.test.ts
@@ -14,15 +14,6 @@
 //   - `shutdown` drains every subscriber, closes the WS, drops the rings.
 
 import { describe, expect, it, vi } from 'vitest';
-import type { Logger } from 'pino';
-
-// `pino` is not a binance-package dep. A no-op logger is sufficient for the
-// adapter's warn/info calls (the messages are advisory; tests assert on
-// observable state, not on log content).
-const silent = {} as Logger;
-const _silentLogger: Logger = new Proxy(silent, {
-  get: () => () => undefined,
-}) as Logger;
 
 import {
   createKlineFetcher,
@@ -33,7 +24,12 @@ import {
   type KlineFetcher,
 } from '../../src/index.js';
 
-const silentLogger = _silentLogger;
+type KlineFetcherLogger = Parameters<typeof createKlineFetcher>[0]['logger'];
+
+const silentLogger: KlineFetcherLogger = {
+  info: vi.fn<KlineFetcherLogger['info']>(),
+  warn: vi.fn<KlineFetcherLogger['warn']>(),
+};
 
 interface FakeWs extends BinanceWs {
   /** Sends recorded on this socket. */
@@ -1388,7 +1384,7 @@ describe('createKlineFetcher', () => {
     });
 
     it('forceReconnect closes the open socket, flips isConnected false, and the reconnect rebuilds it', () => {
-      let scheduled: (() => void) | null = null;
+      const scheduled: Array<() => void> = [];
       const { factory, sockets } = makeFactory();
       const fetcher = createKlineFetcher({
         wsUrl: 'wss://fake/ws',
@@ -1396,7 +1392,7 @@ describe('createKlineFetcher', () => {
         fetchRestKlines: async () => [],
         logger: silentLogger,
         schedule: (fn) => {
-          scheduled = fn;
+          scheduled.push(fn);
         },
       });
       const sub = fetcher.subscribeKlines('BTCUSDT', '1h');
@@ -1410,8 +1406,9 @@ describe('createKlineFetcher', () => {
 
       // The closed socket fires onClose → reconnect is scheduled; run it.
       sockets[0]?.triggerClose();
-      expect(scheduled).not.toBeNull();
-      scheduled?.();
+      const reconnect = scheduled[0];
+      expect(reconnect).toBeDefined();
+      reconnect?.();
       expect(sockets).toHaveLength(2);
       sockets[1]?.triggerOpen();
       expect(fetcher.isConnected()).toBe(true);

--- a/packages/binance/__tests__/market-data/ws.test.ts
+++ b/packages/binance/__tests__/market-data/ws.test.ts
@@ -32,11 +32,8 @@ class FakeWs {
     this.url = url;
   }
 
-  on(event: 'message', cb: (data: MsgData) => void): void;
-  on(event: 'open' | 'close', cb: () => void): void;
-  on(event: 'error', cb: (err: Error) => void): void;
-  on(event: 'open' | 'close' | 'error' | 'message', cb: (arg?: unknown) => void): void {
-    (this.handlers as Record<string, unknown>)[event] = cb;
+  on<K extends keyof Handlers>(event: K, cb: NonNullable<Handlers[K]>): void {
+    this.handlers[event] = cb;
   }
 
   send(payload: string): void {

--- a/packages/binance/__tests__/rate-limit/redis-weight-governor.test.ts
+++ b/packages/binance/__tests__/rate-limit/redis-weight-governor.test.ts
@@ -5,11 +5,12 @@
 // token-bucket math itself is covered by the real-Redis integration test in
 // apps/worker/__tests__/integration/redis-weight-governor.test.ts.
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, type Mock } from 'vitest';
 
 import {
   createRedisWeightGovernor,
   RedisUnavailableError,
+  type GovernorLogger,
   type RedisEvalClient,
 } from '../../src/rate-limit/redis-weight-governor.js';
 
@@ -41,7 +42,9 @@ const fakeRedis = (replies: Entry[]): RedisEvalClient & { calls: (string | numbe
   };
 };
 
-const noopLogger = (): { warn: ReturnType<typeof vi.fn> } => ({ warn: vi.fn() });
+type MockGovernorLogger = { warn: Mock<GovernorLogger['warn']> };
+
+const noopLogger = (): MockGovernorLogger => ({ warn: vi.fn<GovernorLogger['warn']>() });
 
 describe('createRedisWeightGovernor', () => {
   it('reports the configured ceiling', () => {

--- a/packages/binance/package.json
+++ b/packages/binance/package.json
@@ -8,7 +8,7 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "tsc -b",
-    "typecheck": "tsc -b --noEmit",
+    "typecheck": "tsc -b --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/binance/tsconfig.test.json
+++ b/packages/binance/tsconfig.test.json
@@ -1,4 +1,7 @@
 {
+  // Type-checks the TEST surface, which `tsc -b` does not: the build graph covers `src/` only, so a fixture can omit a required field, satisfy `Partial<T>` at runtime, and drift from the type it claims to build.
+  //
+  // Unlike `apps/worker`, this package has no `tsconfig.test-d.json`, so nothing is carved out: a `.test-d.ts` added here is checked by this project rather than by nothing.
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
@@ -9,6 +12,5 @@
     "isolatedDeclarations": false,
     "incremental": false
   },
-  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
-  "exclude": ["**/*.test-d.ts"]
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"]
 }

--- a/packages/binance/tsconfig.test.json
+++ b/packages/binance/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "isolatedDeclarations": false,
+    "incremental": false
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "exclude": ["**/*.test-d.ts"]
+}


### PR DESCRIPTION
**Stack 6/6** — base #757. Last on purpose; see below.

### The gap

`tsc -b` builds `src/` only, so **nothing ever type-checked the tests**. Fixtures drifted from the types they claimed to build and the suite stayed green.

That is not theoretical:

- Two revive tests in `apps/worker` omitted `walletQuantity` entirely, satisfied the partial at runtime, read `undefined` where the code branches on `null`, threw inside a try/catch, and **passed while asserting nothing**.
- The `SymbolInfo` fixtures had fallen behind the contract's `status`, `maxQty`, `minPrice` and `maxPrice` fields.
- Around twenty tick tests were still building `TickJobData` with `event: 'tick'`, a member `TickEvent` has not carried for some time.

### The gate

A `tsconfig.test.json` in `apps/worker` and `packages/binance` covering `src/**` plus `__tests__/**`, wired into each package's `typecheck` script. Ordinary tests and type-level tests keep separate compilers: this project owns every ordinary test, `tsconfig.test-d.json` keeps the `.test-d.ts` assertions.

### Why this is last in the stack

I originally planned it first. It cannot go there, and this was established by running it rather than by reasoning about it.

`tsconfig.test.json` includes `__tests__/**` wholesale, so it compiles **every** test file — including the ones whose fixes live in the feature commits. Arming it before them produced 100+ errors across `backfill-trade-archive`, `discovery/handler`, `reconcile-held-quantity`, `pipeline-worker`, `discovery-health.cron`, `diagnosis-worker` and `binance-rest` tests. Landing it earlier would have meant either a red gate or splitting feature test files by hunk.

### Why only these two packages

Measured, not assumed. Dropping the same 14-line project into every other workspace and compiling it surfaces **685 errors across 570 test files in 19 packages** — `apps/web` 294, `packages/strategy/trailing-trade` 137, `apps/api` 63, `packages/strategy/backtest` 38, `packages/strategy/core` 33, `packages/db` 31, `packages/contracts` 27, `packages/llm` 24, and the rest in single digits. Five are already clean and could be armed for free: `notify`, `money`, `observability`, `testcontainers`, `strategy/registry`.

`apps/server` needs a different shape — it consumes `apps/api` and `apps/worker` as project references, so a `composite: false` test project re-compiles their sources against server's `paths` and produces hundreds of spurious module-resolution errors.

### The rest

Mechanical throughout: fields added to fixtures, unions corrected, and one cast in the metrics-sink test that reproduces a JS caller now that `MetricName` is closed. **No behaviour changes.**

### Verification

Isolated worktree, fresh `bun install`: `typecheck` (with the new project confirmed to actually execute, not cache-skip), `lint`, full unit suite, and `docs:build` — 42/42 turbo tasks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111aiL6FyW3FtSSCjKsMzu3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for account-scoped data, cache isolation, snapshot merging, order handling, event routing, and resynchronization workflows.
  * Updated test scenarios to reflect current trading, profile, notification, and strategy contracts.
  * Added stronger assertions for error handling, teardown ordering, malformed data, and persistence edge cases.

* **Chores**
  * Added comprehensive type-checking for source and test code across worker and Binance packages.
  * Improved mock and fixture consistency for more reliable test validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
