### PR TITLE
test(db): let a project-owned globalSetup own the Postgres fixture

### DIFF
--- a/packages/config/turbo.json
+++ b/packages/config/turbo.json
@@ -1,14 +1,20 @@
 {
-  "$schema": "https://turborepo.com/schema.json",
+  "$schema": "https://v2-9-16.turborepo.dev/schema.json",
   "extends": ["//"],
   "tasks": {
     "test": {
       "inputs": [
         "$TURBO_EXTENDS$",
-        "$TURBO_ROOT$/scripts/ci/check-worker-integration-honesty.ts",
-        "$TURBO_ROOT$/scripts/ci/test-worker-integration.sh",
-        "$TURBO_ROOT$/scripts/ci/test-worker-integration-local.sh",
-        "$TURBO_ROOT$/apps/worker/__tests__/integration/**"
+        "$TURBO_ROOT$/README.md",
+        "$TURBO_ROOT$/docs/**/*.md",
+        "$TURBO_ROOT$/e2e/**",
+        "$TURBO_ROOT$/scripts/ci/**",
+        "$TURBO_ROOT$/apps/**/package.json",
+        "$TURBO_ROOT$/apps/**/vitest.config.ts",
+        "$TURBO_ROOT$/apps/**/src/**",
+        "$TURBO_ROOT$/apps/worker/__tests__/integration/**",
+        "$TURBO_ROOT$/packages/**/package.json",
+        "$TURBO_ROOT$/packages/**/src/**"
       ]
     }
   }

--- a/packages/config/turbo.json
+++ b/packages/config/turbo.json
@@ -14,6 +14,7 @@
         "$TURBO_ROOT$/apps/**/src/**",
         "$TURBO_ROOT$/apps/worker/__tests__/integration/**",
         "$TURBO_ROOT$/packages/**/package.json",
+        "$TURBO_ROOT$/packages/**/vitest.config.ts",
         "$TURBO_ROOT$/packages/**/src/**"
       ]
     }

--- a/packages/config/turbo.json
+++ b/packages/config/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "inputs": [
+        "$TURBO_EXTENDS$",
+        "$TURBO_ROOT$/scripts/ci/check-worker-integration-honesty.ts",
+        "$TURBO_ROOT$/scripts/ci/test-worker-integration.sh",
+        "$TURBO_ROOT$/scripts/ci/test-worker-integration-local.sh",
+        "$TURBO_ROOT$/apps/worker/__tests__/integration/**"
+      ]
+    }
+  }
+}

--- a/packages/core/__tests__/env/bootstrap.test.ts
+++ b/packages/core/__tests__/env/bootstrap.test.ts
@@ -40,8 +40,12 @@ describe('bootstrapEnv', () => {
     expect(process.env['BOOTSTRAP_TEST_REDIS']).toBe('redis://test');
   });
 
-  it('container path: no .git / no turbo.json → no-op, no throw', () => {
-    const callerUrl = callerUrlFor(join(root, 'app', 'src'));
+  it('does not load .env when the repository marker is beyond the 12-level search', () => {
+    mkdirSync(join(root, '.git'));
+    writeFileSync(join(root, '.env'), 'BOOTSTRAP_TEST_DB=postgres://outside\n');
+    const callerUrl = callerUrlFor(
+      join(root, ...Array.from({ length: 12 }, (_, depth) => `level-${depth}`)),
+    );
 
     expect(() => bootstrapEnv(callerUrl)).not.toThrow();
     expect(process.env['BOOTSTRAP_TEST_DB']).toBeUndefined();

--- a/packages/core/__tests__/env/load-env-root.test.ts
+++ b/packages/core/__tests__/env/load-env-root.test.ts
@@ -1,0 +1,27 @@
+import { existsSync } from 'node:fs';
+import { parse } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { findEnvFile, findRepoRoot } from '../../src/env/index.js';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, existsSync: vi.fn(actual.existsSync) };
+});
+
+const filesystemRoot = parse(process.cwd()).root;
+
+beforeEach(() => {
+  vi.mocked(existsSync).mockReset();
+  vi.mocked(existsSync).mockReturnValue(false);
+});
+
+describe('filesystem-root termination', () => {
+  it('returns undefined when the filesystem root has no repository marker', () => {
+    expect(findRepoRoot(filesystemRoot)).toBeUndefined();
+  });
+
+  it('returns undefined when the filesystem root has no .env', () => {
+    expect(findEnvFile(filesystemRoot)).toBeUndefined();
+  });
+});

--- a/packages/core/__tests__/env/load-env.test.ts
+++ b/packages/core/__tests__/env/load-env.test.ts
@@ -40,8 +40,9 @@ describe('findRepoRoot', () => {
     expect(findRepoRoot(nested)).toBe(root);
   });
 
-  it('returns undefined when neither marker is present anywhere up the tree', () => {
-    const nested = join(root, 'a', 'b');
+  it('returns undefined when a repository marker is immediately beyond the 12-level search', () => {
+    mkdirSync(join(root, '.git'));
+    const nested = join(root, ...Array.from({ length: 12 }, (_, depth) => `level-${depth}`));
     mkdirSync(nested, { recursive: true });
 
     expect(findRepoRoot(nested)).toBeUndefined();
@@ -68,8 +69,9 @@ describe('findEnvFile', () => {
     expect(findEnvFile(inner)).toBe(innerEnv);
   });
 
-  it('returns undefined when no .env exists above startDir', () => {
-    const nested = join(root, 'a', 'b');
+  it('returns undefined when a .env is immediately beyond the 12-level search', () => {
+    writeFileSync(join(root, '.env'), 'OUTSIDE=1\n');
+    const nested = join(root, ...Array.from({ length: 12 }, (_, depth) => `level-${depth}`));
     mkdirSync(nested, { recursive: true });
 
     expect(findEnvFile(nested)).toBeUndefined();

--- a/packages/db/__tests__/_global-setup.ts
+++ b/packages/db/__tests__/_global-setup.ts
@@ -1,0 +1,42 @@
+import type { TestProject } from 'vitest/node';
+
+const TESTCONTAINERS_SPECIFIER = ['@app', 'testcontainers'].join('/');
+
+declare module 'vitest' {
+  export interface ProvidedContext {
+    readonly databaseTestUrl: string | undefined;
+  }
+}
+
+/**
+ * Owns the database fixture for the complete project run so a shared module graph cannot attach teardown to the first importing file. Explicit container provisioning takes precedence over a caller-owned external URL, matching the repository's test-infrastructure contract.
+ *
+ * @param project - Vitest project receiving the serialisable URL exposed to test workers.
+ * @returns Global teardown when this run provisioned a container, otherwise no teardown.
+ */
+const setupDatabase = async (project: TestProject): Promise<void | (() => Promise<void>)> => {
+  if (process.env['TESTCONTAINERS'] === '1') {
+    const { withPostgres } = (await import(TESTCONTAINERS_SPECIFIER)) as {
+      readonly withPostgres: () => Promise<{
+        readonly databaseUrl: string;
+        readonly stop: () => Promise<void>;
+      }>;
+    };
+    const fixture = await withPostgres();
+    project.provide('databaseTestUrl', fixture.databaseUrl);
+    return async () => {
+      try {
+        await fixture.stop();
+      } catch (error) {
+        // Vitest reports project-teardown rejections during close without making the CLI fail, so preserve the rejection in the process outcome before rethrowing its diagnostic.
+        process.exitCode = 1;
+        throw error;
+      }
+    };
+  }
+
+  const externalUrl = process.env['DATABASE_TEST_URL'];
+  if (externalUrl) project.provide('databaseTestUrl', externalUrl);
+};
+
+export default setupDatabase;

--- a/packages/db/__tests__/_global-setup.ts
+++ b/packages/db/__tests__/_global-setup.ts
@@ -1,42 +1,38 @@
 import type { TestProject } from 'vitest/node';
 
-const TESTCONTAINERS_SPECIFIER = ['@app', 'testcontainers'].join('/');
-
 declare module 'vitest' {
   export interface ProvidedContext {
     readonly databaseTestUrl: string | undefined;
   }
 }
 
+// Two ways to get a real Postgres: `TESTCONTAINERS=1` provisions a throwaway one (Docker required), or `DATABASE_TEST_URL` names a running server. Neither, and the provisioning suites `describe.skipIf` out in the no-Docker unit lane. Declared here rather than in the worker-side helper because this file decides whether to acquire anything at all; `_infra.ts` re-exports it for the suites.
+export const HAS_INFRA =
+  process.env['TESTCONTAINERS'] === '1' || Boolean(process.env['DATABASE_TEST_URL']);
+
 /**
- * Owns the database fixture for the complete project run so a shared module graph cannot attach teardown to the first importing file. Explicit container provisioning takes precedence over a caller-owned external URL, matching the repository's test-infrastructure contract.
+ * Owns the database fixture for the complete project run so a shared module graph cannot attach teardown to the first importing file.
  *
  * @param project - Vitest project receiving the serialisable URL exposed to test workers.
- * @returns Global teardown when this run provisioned a container, otherwise no teardown.
+ * @returns Global teardown that releases whatever `withPostgres` acquired, or nothing when no infrastructure was requested.
  */
 const setupDatabase = async (project: TestProject): Promise<void | (() => Promise<void>)> => {
-  if (process.env['TESTCONTAINERS'] === '1') {
-    const { withPostgres } = (await import(TESTCONTAINERS_SPECIFIER)) as {
-      readonly withPostgres: () => Promise<{
-        readonly databaseUrl: string;
-        readonly stop: () => Promise<void>;
-      }>;
-    };
-    const fixture = await withPostgres();
-    project.provide('databaseTestUrl', fixture.databaseUrl);
-    return async () => {
-      try {
-        await fixture.stop();
-      } catch (error) {
-        // Vitest reports project-teardown rejections during close without making the CLI fail, so preserve the rejection in the process outcome before rethrowing its diagnostic.
-        process.exitCode = 1;
-        throw error;
-      }
-    };
-  }
+  if (!HAS_INFRA) return;
 
-  const externalUrl = process.env['DATABASE_TEST_URL'];
-  if (externalUrl) project.provide('databaseTestUrl', externalUrl);
+  // Which selector wins when both are set is `withPostgres`'s rule, not this file's. Re-deciding it here would leave the db lane on the old precedence the day the wrapper grows a third selector, with every test still green. Imported lazily so the no-infra lane never loads Testcontainers.
+  const { withPostgres } = await import('@app/testcontainers');
+  const fixture = await withPostgres();
+  project.provide('databaseTestUrl', fixture.databaseUrl);
+  // A no-op on the reuse branch: the wrapper hands back a `stop` that releases nothing when it did not provision.
+  return async () => {
+    try {
+      await fixture.stop();
+    } catch (error) {
+      // Vitest reports project-teardown rejections during close without making the CLI fail, so preserve the rejection in the process outcome before rethrowing its diagnostic.
+      process.exitCode = 1;
+      throw error;
+    }
+  };
 };
 
 export default setupDatabase;

--- a/packages/db/__tests__/_infra.ts
+++ b/packages/db/__tests__/_infra.ts
@@ -2,9 +2,8 @@
 
 import { inject } from 'vitest';
 
-// Two ways to get a real Postgres: `TESTCONTAINERS=1` provisions a throwaway one (Docker required), or `DATABASE_TEST_URL` names a running server. Neither, and the provisioning suites `describe.skipIf` out in the no-Docker unit lane.
-export const HAS_INFRA =
-  process.env['TESTCONTAINERS'] === '1' || Boolean(process.env['DATABASE_TEST_URL']);
+// Re-exported from the lifecycle owner so the suites keep one import site and the predicate has one definition.
+export { HAS_INFRA } from './_global-setup.js';
 
 /**
  * Returns the project-owned Postgres endpoint shared by every provisioning suite. Callers that need an empty schema create a scratch database on this endpoint rather than asking for a second container.

--- a/packages/db/__tests__/_infra.ts
+++ b/packages/db/__tests__/_infra.ts
@@ -1,46 +1,22 @@
-// One Postgres endpoint per test file, provisioned lazily and torn down by a hook this module owns.
-//
-// The migration suites here used to each resolve their own endpoint inside `beforeAll`, which put the container's only handle inside the hook that acquires it. When that hook timed out — the ordinary outcome once several suites provisioned at once — the suite's `afterAll` still ran, but the assignment it needed was still awaiting the provision, so it had nothing to stop and the container that eventually came up ran on. The handle therefore has to be reachable from outside the hook that acquires it: this module's memo holds it from the moment the provision resolves, however late that is, and the file-scope `afterAll` below stops it whether or not any suite's setup succeeded.
-//
-// Serialisation is the other half, and it lives in `vitest.config.ts` (`fileParallelism: !provisionsContainers` — serial only under `TESTCONTAINERS=1`, the one lane where this memo has a container to bound). Vitest isolates module state per test file, so the memo bounds provisioning within a file, never across them; only running one file at a time bounds it across the package. On the `DATABASE_TEST_URL` lane there is nothing to bound — every `stop` is a no-op — so the files run in parallel.
+// The project global setup owns the one Postgres endpoint and its teardown. Keeping this module to a provided-context read makes its lifetime independent of which test file imports it first when Vitest reuses the module graph.
 
-import { afterAll } from 'vitest';
+import { inject } from 'vitest';
 
-// Two ways to get a real Postgres: `TESTCONTAINERS=1` provisions a throwaway one (Docker required), or `DATABASE_TEST_URL` names a running server. Neither, and the provisioning suites `describe.skipIf` out — the no-Docker unit lane.
+// Two ways to get a real Postgres: `TESTCONTAINERS=1` provisions a throwaway one (Docker required), or `DATABASE_TEST_URL` names a running server. Neither, and the provisioning suites `describe.skipIf` out in the no-Docker unit lane.
 export const HAS_INFRA =
   process.env['TESTCONTAINERS'] === '1' || Boolean(process.env['DATABASE_TEST_URL']);
 
-/** A resolved endpoint plus the hook that releases whatever was provisioned to obtain it. */
-interface SharedInfra {
-  readonly databaseUrl: string;
-  readonly stop: () => Promise<void>;
-}
-
-let infraPromise: Promise<SharedInfra> | null = null;
-
 /**
- * The base Postgres connection string for this test file, provisioning one throwaway container on first call and returning the same endpoint thereafter. Callers that need an empty schema create a scratch database on this endpoint rather than asking for a second container.
+ * Returns the project-owned Postgres endpoint shared by every provisioning suite. Callers that need an empty schema create a scratch database on this endpoint rather than asking for a second container.
  *
- * @returns The base connection string, which addresses the wrapper's default database rather than any suite's scratch one.
+ * @returns The base connection string, which addresses the fixture's default database rather than any suite's scratch one.
  */
 export const sharedDatabaseUrl = async (): Promise<string> => {
-  // Dynamic import so the no-Docker unit lane never resolves the testcontainers dependency graph: every file here is loaded during collection, including the ones whose suites skip.
-  infraPromise ??= import('@app/testcontainers').then((module) => module.withPostgres());
-  return (await infraPromise).databaseUrl;
+  const databaseUrl = inject('databaseTestUrl');
+  if (!databaseUrl) {
+    throw new Error(
+      'Database test infrastructure was requested without a URL from the project global setup.',
+    );
+  }
+  return databaseUrl;
 };
-
-/**
- * Releases the endpoint this file provisioned, if it ever resolved. A no-op when `DATABASE_TEST_URL` supplied the endpoint, because nothing was provisioned to release.
- *
- * @returns A promise that settles once the provisioned container has stopped.
- */
-export const stopSharedInfra = async (): Promise<void> => {
-  const pending = infraPromise;
-  if (!pending) return;
-  infraPromise = null;
-  // Swallowed rather than awaited bare: a provision that never resolved leaves nothing to stop (the deadline reaper in `@app/testcontainers` owns a container that arrives late), and rethrowing here would replace the real setup failure in the report with a teardown one.
-  const infra = await pending.catch(() => null);
-  await infra?.stop();
-};
-
-afterAll(stopSharedInfra);

--- a/packages/db/__tests__/fixtures/infra-lifecycle/consumer-a.fixture.ts
+++ b/packages/db/__tests__/fixtures/infra-lifecycle/consumer-a.fixture.ts
@@ -1,0 +1,11 @@
+import { expect, it } from 'vitest';
+
+import { sharedDatabaseUrl } from '../../_infra.js';
+import { recordEvent } from './events.fixture.js';
+
+it('first suite consumes the shared database URL', async () => {
+  const databaseUrl = await sharedDatabaseUrl();
+  const databaseEnv = process.env['DATABASE_TEST_URL'] ?? '<unset>';
+  recordEvent(`consumer-a:${databaseUrl}:${databaseEnv}`);
+  expect(databaseUrl).toBe(process.env['EXPECTED_DATABASE_URL']);
+});

--- a/packages/db/__tests__/fixtures/infra-lifecycle/consumer-b.fixture.ts
+++ b/packages/db/__tests__/fixtures/infra-lifecycle/consumer-b.fixture.ts
@@ -1,0 +1,11 @@
+import { expect, it } from 'vitest';
+
+import { sharedDatabaseUrl } from '../../_infra.js';
+import { recordEvent } from './events.fixture.js';
+
+it('later suite consumes the same shared database URL', async () => {
+  const databaseUrl = await sharedDatabaseUrl();
+  const databaseEnv = process.env['DATABASE_TEST_URL'] ?? '<unset>';
+  recordEvent(`consumer-b:${databaseUrl}:${databaseEnv}`);
+  expect(databaseUrl).toBe(process.env['EXPECTED_DATABASE_URL']);
+});

--- a/packages/db/__tests__/fixtures/infra-lifecycle/events.fixture.ts
+++ b/packages/db/__tests__/fixtures/infra-lifecycle/events.fixture.ts
@@ -1,0 +1,10 @@
+import { appendFileSync } from 'node:fs';
+
+/**
+ * Persists one lifecycle event so the parent process can inspect ordering after Vitest has completed global teardown.
+ *
+ * @param event - Event name and any value observed by the fixture suite.
+ */
+export const recordEvent = (event: string): void => {
+  appendFileSync(process.env['INFRA_LIFECYCLE_LOG']!, `${event}\n`);
+};

--- a/packages/db/__tests__/fixtures/infra-lifecycle/testcontainers.fixture.ts
+++ b/packages/db/__tests__/fixtures/infra-lifecycle/testcontainers.fixture.ts
@@ -1,0 +1,24 @@
+import { recordEvent } from './events.fixture.js';
+
+/**
+ * Replaces the container boundary with deterministic lifecycle events while preserving the wrapper shape consumed by the real global setup.
+ *
+ * @returns A fixed URL and a stop function that records global teardown.
+ */
+export const withPostgres = async () => {
+  if (process.env['TESTCONTAINERS'] === '1') {
+    recordEvent('start');
+    return {
+      databaseUrl: 'postgres://fixture/shared',
+      stop: async () => {
+        recordEvent('stop');
+        const failure = process.env['INFRA_LIFECYCLE_STOP_FAILURE'];
+        if (failure) throw new Error(failure);
+      },
+    };
+  }
+  return {
+    databaseUrl: process.env['DATABASE_TEST_URL']!,
+    stop: async () => undefined,
+  };
+};

--- a/packages/db/__tests__/fixtures/infra-lifecycle/testcontainers.fixture.ts
+++ b/packages/db/__tests__/fixtures/infra-lifecycle/testcontainers.fixture.ts
@@ -3,9 +3,11 @@ import { recordEvent } from './events.fixture.js';
 /**
  * Replaces the container boundary with deterministic lifecycle events while preserving the wrapper shape consumed by the real global setup.
  *
+ * `satisfies` binds this to the real signature: aliased in at runtime, nothing else would notice a renamed `stop` or a new required option until a lifecycle test failed for the wrong reason. It does not bind behaviour, so the reuse rule itself is pinned on the wrapper, in `packages/testcontainers/__tests__/reusable-endpoint.test.ts`.
+ *
  * @returns A fixed URL and a stop function that records global teardown.
  */
-export const withPostgres = async () => {
+export const withPostgres = (async () => {
   if (process.env['TESTCONTAINERS'] === '1') {
     recordEvent('start');
     return {
@@ -21,4 +23,4 @@ export const withPostgres = async () => {
     databaseUrl: process.env['DATABASE_TEST_URL']!,
     stop: async () => undefined,
   };
-};
+}) satisfies typeof import('@app/testcontainers').withPostgres;

--- a/packages/db/__tests__/fixtures/infra-lifecycle/vitest.config.ts
+++ b/packages/db/__tests__/fixtures/infra-lifecycle/vitest.config.ts
@@ -5,7 +5,6 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 const root = fileURLToPath(new URL('.', import.meta.url));
-const testcontainersSpecifier = ['@app', 'testcontainers'].join('/');
 const globalSetup = join(root, '../../_global-setup.ts');
 // Named here rather than spread conditionally: a renamed setup would otherwise degrade to "no global setup" and surface as `_infra.ts` refusing a missing URL, which reads as a defect in the code under test instead of a stale path in this fixture.
 if (!existsSync(globalSetup)) throw new Error(`missing ${globalSetup}`);
@@ -14,7 +13,7 @@ export default defineConfig({
   root,
   resolve: {
     alias: {
-      [testcontainersSpecifier]: join(root, 'testcontainers.fixture.ts'),
+      '@app/testcontainers': join(root, 'testcontainers.fixture.ts'),
     },
   },
   test: {

--- a/packages/db/__tests__/fixtures/infra-lifecycle/vitest.config.ts
+++ b/packages/db/__tests__/fixtures/infra-lifecycle/vitest.config.ts
@@ -7,6 +7,8 @@ import { defineConfig } from 'vitest/config';
 const root = fileURLToPath(new URL('.', import.meta.url));
 const testcontainersSpecifier = ['@app', 'testcontainers'].join('/');
 const globalSetup = join(root, '../../_global-setup.ts');
+// Named here rather than spread conditionally: a renamed setup would otherwise degrade to "no global setup" and surface as `_infra.ts` refusing a missing URL, which reads as a defect in the code under test instead of a stale path in this fixture.
+if (!existsSync(globalSetup)) throw new Error(`missing ${globalSetup}`);
 
 export default defineConfig({
   root,
@@ -18,7 +20,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     fileParallelism: false,
-    ...(existsSync(globalSetup) && { globalSetup }),
+    globalSetup,
     include: ['**/consumer-*.fixture.ts'],
     isolate: false,
     reporters: ['dot'],

--- a/packages/db/__tests__/fixtures/infra-lifecycle/vitest.config.ts
+++ b/packages/db/__tests__/fixtures/infra-lifecycle/vitest.config.ts
@@ -1,0 +1,26 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+const root = fileURLToPath(new URL('.', import.meta.url));
+const testcontainersSpecifier = ['@app', 'testcontainers'].join('/');
+const globalSetup = join(root, '../../_global-setup.ts');
+
+export default defineConfig({
+  root,
+  resolve: {
+    alias: {
+      [testcontainersSpecifier]: join(root, 'testcontainers.fixture.ts'),
+    },
+  },
+  test: {
+    environment: 'node',
+    fileParallelism: false,
+    ...(existsSync(globalSetup) && { globalSetup }),
+    include: ['**/consumer-*.fixture.ts'],
+    isolate: false,
+    reporters: ['dot'],
+  },
+});

--- a/packages/db/__tests__/infra-lifecycle-config.test.ts
+++ b/packages/db/__tests__/infra-lifecycle-config.test.ts
@@ -1,4 +1,5 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -9,6 +10,8 @@ import { describe, expect, it, vi } from 'vitest';
 import config from '../vitest.config.js';
 
 const TESTS_ROOT = fileURLToPath(new URL('.', import.meta.url));
+const DB_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const LIFECYCLE_FIXTURE = join(TESTS_ROOT, 'fixtures/infra-lifecycle');
 
 // Both specifiers are assembled at runtime: this guard scans the very directory it lives in, so a literal would make the file an offender of its own scan and the sole-provisioner rule would report itself forever.
 const PROVISIONER_SPECIFIER = ['@app', 'testcontainers'].join('/');
@@ -116,26 +119,80 @@ const fileParallelismUnder = async (
   }
 };
 
+type LifecycleRun = {
+  readonly events: readonly string[];
+  readonly status: number | null;
+  readonly stderr: string;
+};
+
+/**
+ * Runs two fixture suites through the real DB helper and global setup while replacing only the Testcontainers boundary with an event logger.
+ *
+ * @param env - Infrastructure selection passed to the child Vitest process.
+ * @returns The child status, stderr, and lifecycle events persisted after global teardown.
+ */
+const runLifecycleFixture = (env: {
+  readonly testcontainers?: '1';
+  readonly databaseUrl?: string;
+  readonly stopFailure?: string;
+}): LifecycleRun => {
+  const runDir = mkdtempSync(join(LIFECYCLE_FIXTURE, '.run-'));
+  const eventLog = join(runDir, 'events.log');
+  const childEnv = { ...process.env };
+  delete childEnv['TESTCONTAINERS'];
+  delete childEnv['DATABASE_TEST_URL'];
+  delete childEnv['INFRA_LIFECYCLE_STOP_FAILURE'];
+  if (env.testcontainers) childEnv['TESTCONTAINERS'] = env.testcontainers;
+  if (env.databaseUrl) childEnv['DATABASE_TEST_URL'] = env.databaseUrl;
+  if (env.stopFailure) childEnv['INFRA_LIFECYCLE_STOP_FAILURE'] = env.stopFailure;
+  childEnv['INFRA_LIFECYCLE_LOG'] = eventLog;
+  childEnv['EXPECTED_DATABASE_URL'] = env.testcontainers
+    ? 'postgres://fixture/shared'
+    : (env.databaseUrl ?? '<unset>');
+
+  try {
+    const result = spawnSync(
+      'bunx',
+      [
+        'vitest',
+        'run',
+        '--config',
+        join(LIFECYCLE_FIXTURE, 'vitest.config.ts'),
+        join(LIFECYCLE_FIXTURE, 'consumer-a.fixture.ts'),
+        join(LIFECYCLE_FIXTURE, 'consumer-b.fixture.ts'),
+      ],
+      {
+        cwd: DB_ROOT,
+        encoding: 'utf8',
+        env: childEnv,
+        timeout: 60_000,
+      },
+    );
+    const events = existsSync(eventLog)
+      ? readFileSync(eventLog, 'utf8').split('\n').filter(Boolean)
+      : [];
+    return { events, status: result.status, stderr: result.stderr };
+  } finally {
+    rmSync(runDir, { force: true, recursive: true });
+  }
+};
+
 describe('database test hook timeouts', () => {
   it('sets the project hook timeout to 180 seconds', () => {
     expect(config.test?.hookTimeout).toBe(180_000);
   });
 
-  // The headline claim of `_infra.ts` is that teardown lives OUTSIDE the hook that acquires, so a timed-out `beforeAll` cannot orphan a container. That claim rests entirely on this one registration: delete it and every suite in the package still passes while each `TESTCONTAINERS=1` file leaks a Postgres. The api side already pins its equivalent, and the two guards should not disagree.
-  it('registers shared-infrastructure cleanup at file scope in the module that owns it', () => {
-    const source = readFileSync(join(TESTS_ROOT, SHARED_MEMO_FILE), 'utf8');
-    const owner = source.search(
-      /^export const stopSharedInfra = async \(\): Promise<void> => \{$/m,
-    );
-    const hook = source.search(/^afterAll\(stopSharedInfra\);$/m);
+  it('keeps shared-infrastructure teardown in the project lifecycle owner', () => {
+    const helperSource = readFileSync(join(TESTS_ROOT, SHARED_MEMO_FILE), 'utf8');
+    const configured = config.test?.globalSetup;
+    const setupFiles = configured === undefined ? [] : [configured].flat();
 
-    expect(owner).toBeGreaterThanOrEqual(0);
-    // After the owner and at column zero, i.e. module scope rather than nested inside any suite hook.
-    expect(hook).toBeGreaterThan(owner);
+    expect(helperSource).not.toMatch(/\bafterAll\s*\(/);
+    expect(setupFiles.some((file) => file.endsWith('/_global-setup.ts'))).toBe(true);
   });
 
   it('serialises the package only when it provisions containers', async () => {
-    // Both branches, because each failure mode is real and they are opposites. Left unarmed under TESTCONTAINERS=1, seven suites race one Docker daemon and orphan what they start. Armed unconditionally, every Docker-free lane pays roughly 3x wall clock to serialise 78 files over zero containers.
+    // Both branches, because each failure mode is real and they are opposites. Under TESTCONTAINERS=1, every provisioning suite drives the one project-global container endpoint, so the package keeps its scratch-database migration work serial. Without a provisioned container there is no shared local endpoint to protect, and serialising the package only adds wall time.
     expect(await fileParallelismUnder('1')).toBe(false);
     expect(await fileParallelismUnder(undefined)).toBe(true);
   });
@@ -168,5 +225,81 @@ describe('database infrastructure provisioning', () => {
       .filter((file) => !provisioningSuites.includes(file))
       .flatMap(provisionerReferences);
     expect(strays).toEqual([]);
+  });
+});
+
+describe('database infrastructure global lifecycle', () => {
+  it('configures one shared module graph and one project lifecycle owner', () => {
+    const configured = config.test?.globalSetup;
+    const setupFiles = configured === undefined ? [] : [configured].flat();
+
+    expect.soft(config.test?.isolate).toBe(false);
+    expect.soft(setupFiles.some((file) => file.endsWith('/_global-setup.ts'))).toBe(true);
+  });
+
+  it('provisions once, shares the URL across later suites, and stops only after both finish', () => {
+    const result = runLifecycleFixture({ testcontainers: '1' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect
+      .soft(
+        result.events.filter((event) => event === 'start'),
+        result.events.join(' -> '),
+      )
+      .toHaveLength(1);
+    const consumers = result.events.filter((event) => event.startsWith('consumer-'));
+    expect.soft(consumers).toHaveLength(2);
+    expect
+      .soft(consumers)
+      .toEqual(
+        expect.arrayContaining([
+          'consumer-a:postgres://fixture/shared:<unset>',
+          'consumer-b:postgres://fixture/shared:<unset>',
+        ]),
+      );
+    expect.soft(result.events.filter((event) => event === 'stop')).toHaveLength(1);
+    expect.soft(result.events.at(-1), result.events.join(' -> ')).toBe('stop');
+  });
+
+  it('provides an external URL without invoking or stopping Testcontainers', () => {
+    const databaseUrl = 'postgres://external/fixture';
+    const result = runLifecycleFixture({ databaseUrl });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.events).toEqual(
+      expect.arrayContaining([
+        `consumer-a:${databaseUrl}:${databaseUrl}`,
+        `consumer-b:${databaseUrl}:${databaseUrl}`,
+      ]),
+    );
+    expect(result.events.some((event) => event === 'start' || event === 'stop')).toBe(false);
+  });
+
+  it('prefers a provisioned fixture when both infrastructure selectors are present', () => {
+    const databaseUrl = 'postgres://external/fixture';
+    const result = runLifecycleFixture({ testcontainers: '1', databaseUrl });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.events).toEqual(
+      expect.arrayContaining([
+        'start',
+        `consumer-a:postgres://fixture/shared:${databaseUrl}`,
+        `consumer-b:postgres://fixture/shared:${databaseUrl}`,
+        'stop',
+      ]),
+    );
+    expect(result.events.filter((event) => event === 'start')).toHaveLength(1);
+    expect(result.events.filter((event) => event === 'stop')).toHaveLength(1);
+    expect(result.events.at(-1), result.events.join(' -> ')).toBe('stop');
+  });
+
+  it('fails the run when project-owned teardown cannot stop its container', () => {
+    const result = runLifecycleFixture({
+      testcontainers: '1',
+      stopFailure: 'fixture stop failed',
+    });
+
+    expect(result.status, result.stderr).not.toBe(0);
+    expect(result.stderr).toContain('fixture stop failed');
   });
 });

--- a/packages/db/__tests__/infra-lifecycle-config.test.ts
+++ b/packages/db/__tests__/infra-lifecycle-config.test.ts
@@ -11,7 +11,10 @@ import config from '../vitest.config.js';
 
 const TESTS_ROOT = fileURLToPath(new URL('.', import.meta.url));
 const DB_ROOT = fileURLToPath(new URL('..', import.meta.url));
-const LIFECYCLE_FIXTURE = join(TESTS_ROOT, 'fixtures/infra-lifecycle');
+const FIXTURES_ROOT = join(TESTS_ROOT, 'fixtures');
+const LIFECYCLE_FIXTURE = join(FIXTURES_ROOT, 'infra-lifecycle');
+// Contention headroom, not an expectation of how long the work takes. Idle, the four nested `vitest run` cases settle in ~460ms and the two `bun -e` config loads in ~770ms, but 79 files run with `fileParallelism: true` in the db-isolation lane and nothing here is retried, so Vitest's five-second default turns one overrun into a red pipeline with no defect behind it. `packages/config/__tests__/coverage-thresholds.test.ts` states the same budget for a cheaper spawn.
+const SPAWN_TIMEOUT_MS = 60_000;
 
 // Both specifiers are assembled at runtime: this guard scans the very directory it lives in, so a literal would make the file an offender of its own scan and the sole-provisioner rule would report itself forever.
 const PROVISIONER_SPECIFIER = ['@app', 'testcontainers'].join('/');
@@ -182,8 +185,12 @@ const runLifecycleFixture = (env: {
 };
 
 describe('database test hook timeouts', () => {
-  it('sets the project hook timeout to 180 seconds', () => {
+  it('sets the project hook and teardown timeouts to 180 seconds', () => {
     expect(config.test?.hookTimeout).toBe(180_000);
+    // The teardown budget covers `fixture.stop()` shutting down a real container, so it needs the same headroom as the hook that started it. Read through a cast because Vitest types the key as root-only and the resolved project config does not surface it, which is the same reason the config declares it through a `satisfies` variable.
+    const teardownTimeout = (config.test as { readonly teardownTimeout?: number } | undefined)
+      ?.teardownTimeout;
+    expect(teardownTimeout).toBe(180_000);
   });
 
   // Deliberately the inverse of `apps/api/__tests__/infra-lifecycle-config.test.ts`, which requires `afterAll(stopSharedInfra)` in `_helpers.ts` and forbids the global setup from naming it. The two packages own different problems: api provisions Postgres AND Redis per isolated test file and has not moved to a project-owned fixture, so its teardown still belongs to the module that acquired. This package has one endpoint for the whole project, so file-scoped teardown is exactly the hazard being removed. Moving api across is a separate change; until then a failure on either side is read against its own package's shape, not the other's.
@@ -196,11 +203,15 @@ describe('database test hook timeouts', () => {
     expect(setupFiles.some((file) => file.endsWith('/_global-setup.ts'))).toBe(true);
   });
 
-  it('serialises the package only when it provisions containers', () => {
-    // Both branches, because each failure mode is real and they are opposites. Under TESTCONTAINERS=1, every provisioning suite drives the one project-global container endpoint, so the package keeps its scratch-database migration work serial. Without a provisioned container there is no shared local endpoint to protect, and serialising the package only adds wall time.
-    expect(fileParallelismUnder('1')).toBe(false);
-    expect(fileParallelismUnder(undefined)).toBe(true);
-  });
+  it(
+    'serialises the package only when it provisions containers',
+    () => {
+      // Both branches, because each failure mode is real and they are opposites. Under TESTCONTAINERS=1, every provisioning suite drives the one project-global container endpoint, so the package keeps its scratch-database migration work serial. Without a provisioned container there is no shared local endpoint to protect, and serialising the package only adds wall time.
+      expect(fileParallelismUnder('1')).toBe(false);
+      expect(fileParallelismUnder(undefined)).toBe(true);
+    },
+    SPAWN_TIMEOUT_MS,
+  );
 
   it('reaches every provisioning suite in the directory', () => {
     expect(allFiles.length).toBeGreaterThan(0);
@@ -225,9 +236,12 @@ describe('database infrastructure provisioning', () => {
   );
 
   // The exemption tracks the file that provisions, which is the global setup, not the memo. Pointing it at `_infra.ts` would exempt a file that acquires nothing and force the real owner to obfuscate the specifier to stay green.
+  //
+  // `fixtures/` is out of scope for the same reason. Nothing there acquires anything: the nested project aliases the specifier to a fake before any of it runs, and the outer project's include never matches those files. Scanning them only made naming the wrapper, in an alias key or a `satisfies` clause, cost a runtime-assembled string, which is a trap for the next reader rather than a rule.
   it('leaves no other file under __tests__ importing the Testcontainers wrapper', () => {
     const strays = allFiles
       .filter((file) => !file.endsWith(LIFECYCLE_OWNER_FILE))
+      .filter((file) => !file.startsWith(FIXTURES_ROOT))
       .filter((file) => !provisioningSuites.includes(file))
       .flatMap(provisionerReferences);
     expect(strays).toEqual([]);
@@ -249,69 +263,86 @@ describe('database infrastructure global lifecycle', () => {
     expect.soft(setupFiles.some((file) => file.endsWith('/_global-setup.ts'))).toBe(true);
   });
 
-  it('provisions once, shares the URL across later suites, and stops only after both finish', () => {
-    const result = runLifecycleFixture({ testcontainers: '1' });
+  it(
+    'provisions once, shares the URL across later suites, and stops only after both finish',
+    () => {
+      const result = runLifecycleFixture({ testcontainers: '1' });
 
-    expect(result.status, result.stderr).toBe(0);
-    expect
-      .soft(
-        result.events.filter((event) => event === 'start'),
-        result.events.join(' -> '),
-      )
-      .toHaveLength(1);
-    const consumers = result.events.filter((event) => event.startsWith('consumer-'));
-    expect.soft(consumers).toHaveLength(2);
-    expect
-      .soft(consumers)
-      .toEqual(
+      expect(result.status, result.stderr).toBe(0);
+      expect
+        .soft(
+          result.events.filter((event) => event === 'start'),
+          result.events.join(' -> '),
+        )
+        .toHaveLength(1);
+      const consumers = result.events.filter((event) => event.startsWith('consumer-'));
+      expect.soft(consumers).toHaveLength(2);
+      expect
+        .soft(consumers)
+        .toEqual(
+          expect.arrayContaining([
+            'consumer-a:postgres://fixture/shared:<unset>',
+            'consumer-b:postgres://fixture/shared:<unset>',
+          ]),
+        );
+      expect.soft(result.events.filter((event) => event === 'stop')).toHaveLength(1);
+      expect.soft(result.events.at(-1), result.events.join(' -> ')).toBe('stop');
+    },
+    SPAWN_TIMEOUT_MS,
+  );
+
+  it(
+    'provides an external URL without provisioning or stopping a container',
+    () => {
+      const databaseUrl = 'postgres://external/fixture';
+      const result = runLifecycleFixture({ databaseUrl });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.events).toEqual(
         expect.arrayContaining([
-          'consumer-a:postgres://fixture/shared:<unset>',
-          'consumer-b:postgres://fixture/shared:<unset>',
+          `consumer-a:${databaseUrl}:${databaseUrl}`,
+          `consumer-b:${databaseUrl}:${databaseUrl}`,
         ]),
       );
-    expect.soft(result.events.filter((event) => event === 'stop')).toHaveLength(1);
-    expect.soft(result.events.at(-1), result.events.join(' -> ')).toBe('stop');
-  });
+      expect(result.events.some((event) => event === 'start' || event === 'stop')).toBe(false);
+    },
+    SPAWN_TIMEOUT_MS,
+  );
 
-  it('provides an external URL without provisioning or stopping a container', () => {
-    const databaseUrl = 'postgres://external/fixture';
-    const result = runLifecycleFixture({ databaseUrl });
+  // Named for what the fixture can show: the setup passes the wrapper's answer through without re-deciding. The rule itself, that TESTCONTAINERS=1 wins, belongs to `withPostgres` and is pinned in `packages/testcontainers/__tests__/reusable-endpoint.test.ts`; the fake aliased in here only mirrors it.
+  it(
+    'hands the suites whatever the wrapper chose when both selectors are present',
+    () => {
+      const databaseUrl = 'postgres://external/fixture';
+      const result = runLifecycleFixture({ testcontainers: '1', databaseUrl });
 
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.events).toEqual(
-      expect.arrayContaining([
-        `consumer-a:${databaseUrl}:${databaseUrl}`,
-        `consumer-b:${databaseUrl}:${databaseUrl}`,
-      ]),
-    );
-    expect(result.events.some((event) => event === 'start' || event === 'stop')).toBe(false);
-  });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.events).toEqual(
+        expect.arrayContaining([
+          'start',
+          `consumer-a:postgres://fixture/shared:${databaseUrl}`,
+          `consumer-b:postgres://fixture/shared:${databaseUrl}`,
+          'stop',
+        ]),
+      );
+      expect(result.events.filter((event) => event === 'start')).toHaveLength(1);
+      expect(result.events.filter((event) => event === 'stop')).toHaveLength(1);
+      expect(result.events.at(-1), result.events.join(' -> ')).toBe('stop');
+    },
+    SPAWN_TIMEOUT_MS,
+  );
 
-  it('prefers a provisioned fixture when both infrastructure selectors are present', () => {
-    const databaseUrl = 'postgres://external/fixture';
-    const result = runLifecycleFixture({ testcontainers: '1', databaseUrl });
+  it(
+    'fails the run when project-owned teardown cannot stop its container',
+    () => {
+      const result = runLifecycleFixture({
+        testcontainers: '1',
+        stopFailure: 'fixture stop failed',
+      });
 
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.events).toEqual(
-      expect.arrayContaining([
-        'start',
-        `consumer-a:postgres://fixture/shared:${databaseUrl}`,
-        `consumer-b:postgres://fixture/shared:${databaseUrl}`,
-        'stop',
-      ]),
-    );
-    expect(result.events.filter((event) => event === 'start')).toHaveLength(1);
-    expect(result.events.filter((event) => event === 'stop')).toHaveLength(1);
-    expect(result.events.at(-1), result.events.join(' -> ')).toBe('stop');
-  });
-
-  it('fails the run when project-owned teardown cannot stop its container', () => {
-    const result = runLifecycleFixture({
-      testcontainers: '1',
-      stopFailure: 'fixture stop failed',
-    });
-
-    expect(result.status, result.stderr).not.toBe(0);
-    expect(result.stderr).toContain('fixture stop failed');
-  });
+      expect(result.status, result.stderr).not.toBe(0);
+      expect(result.stderr).toContain('fixture stop failed');
+    },
+    SPAWN_TIMEOUT_MS,
+  );
 });

--- a/packages/db/__tests__/infra-lifecycle-config.test.ts
+++ b/packages/db/__tests__/infra-lifecycle-config.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import * as ts from 'typescript/unstable/ast';
 import { API } from 'typescript/unstable/sync';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import config from '../vitest.config.js';
 
@@ -17,6 +17,7 @@ const LIFECYCLE_FIXTURE = join(TESTS_ROOT, 'fixtures/infra-lifecycle');
 const PROVISIONER_SPECIFIER = ['@app', 'testcontainers'].join('/');
 const SHARED_MEMO_SPECIFIER = ['./_infra', 'js'].join('.');
 const SHARED_MEMO_FILE = '_infra.ts';
+const LIFECYCLE_OWNER_FILE = '_global-setup.ts';
 
 /**
  * Collects every TypeScript file under `packages/db/__tests__` so the rules below apply to whatever the directory actually holds, not to a list that silently stops covering new suites.
@@ -101,22 +102,25 @@ const beforeAllArgumentCounts = (file: string): number[] => {
 /**
  * Re-evaluates the project config under a chosen `TESTCONTAINERS` value. The setting is resolved once at import time, so reading the ambient module would pin only whichever branch the runner happened to start in and leave the other free to be inverted.
  *
+ * Evaluated in a child process, the way `packages/config/__tests__/coverage-thresholds.test.ts` loads config under a chosen lane. The alternatives both reach outside this file: the package runs under `isolate: false`, so `vi.resetModules()` would drop modules every later file in this worker reuses, and mutating `process.env` in-process would do the same to anything reading it concurrently.
+ *
  * @param testcontainers - Value to place in `TESTCONTAINERS`, or `undefined` to unset it entirely.
  * @returns The `fileParallelism` the config resolves to under that environment.
  */
-const fileParallelismUnder = async (
-  testcontainers: string | undefined,
-): Promise<boolean | undefined> => {
-  const previous = process.env['TESTCONTAINERS'];
-  if (testcontainers === undefined) delete process.env['TESTCONTAINERS'];
-  else process.env['TESTCONTAINERS'] = testcontainers;
-  try {
-    vi.resetModules();
-    return (await import('../vitest.config.js')).default.test?.fileParallelism;
-  } finally {
-    if (previous === undefined) delete process.env['TESTCONTAINERS'];
-    else process.env['TESTCONTAINERS'] = previous;
-  }
+const fileParallelismUnder = (testcontainers: string | undefined): unknown => {
+  const env = { ...process.env };
+  if (testcontainers === undefined) delete env['TESTCONTAINERS'];
+  else env['TESTCONTAINERS'] = testcontainers;
+
+  const script =
+    'const config = (await import("./vitest.config.ts")).default;' +
+    'console.log("FILE_PARALLELISM=" + JSON.stringify(config.test?.fileParallelism ?? null));';
+  const loaded = spawnSync('bun', ['-e', script], { cwd: DB_ROOT, encoding: 'utf8', env });
+
+  expect(loaded.status, loaded.stderr).toBe(0);
+  const marker = loaded.stdout.split('\n').find((line) => line.startsWith('FILE_PARALLELISM='));
+  expect(marker, loaded.stdout).toBeDefined();
+  return JSON.parse(marker!.slice('FILE_PARALLELISM='.length)) as unknown;
 };
 
 type LifecycleRun = {
@@ -182,6 +186,7 @@ describe('database test hook timeouts', () => {
     expect(config.test?.hookTimeout).toBe(180_000);
   });
 
+  // Deliberately the inverse of `apps/api/__tests__/infra-lifecycle-config.test.ts`, which requires `afterAll(stopSharedInfra)` in `_helpers.ts` and forbids the global setup from naming it. The two packages own different problems: api provisions Postgres AND Redis per isolated test file and has not moved to a project-owned fixture, so its teardown still belongs to the module that acquired. This package has one endpoint for the whole project, so file-scoped teardown is exactly the hazard being removed. Moving api across is a separate change; until then a failure on either side is read against its own package's shape, not the other's.
   it('keeps shared-infrastructure teardown in the project lifecycle owner', () => {
     const helperSource = readFileSync(join(TESTS_ROOT, SHARED_MEMO_FILE), 'utf8');
     const configured = config.test?.globalSetup;
@@ -191,10 +196,10 @@ describe('database test hook timeouts', () => {
     expect(setupFiles.some((file) => file.endsWith('/_global-setup.ts'))).toBe(true);
   });
 
-  it('serialises the package only when it provisions containers', async () => {
+  it('serialises the package only when it provisions containers', () => {
     // Both branches, because each failure mode is real and they are opposites. Under TESTCONTAINERS=1, every provisioning suite drives the one project-global container endpoint, so the package keeps its scratch-database migration work serial. Without a provisioned container there is no shared local endpoint to protect, and serialising the package only adds wall time.
-    expect(await fileParallelismUnder('1')).toBe(false);
-    expect(await fileParallelismUnder(undefined)).toBe(true);
+    expect(fileParallelismUnder('1')).toBe(false);
+    expect(fileParallelismUnder(undefined)).toBe(true);
   });
 
   it('reaches every provisioning suite in the directory', () => {
@@ -219,12 +224,19 @@ describe('database infrastructure provisioning', () => {
     },
   );
 
+  // The exemption tracks the file that provisions, which is the global setup, not the memo. Pointing it at `_infra.ts` would exempt a file that acquires nothing and force the real owner to obfuscate the specifier to stay green.
   it('leaves no other file under __tests__ importing the Testcontainers wrapper', () => {
     const strays = allFiles
-      .filter((file) => !file.endsWith(SHARED_MEMO_FILE))
+      .filter((file) => !file.endsWith(LIFECYCLE_OWNER_FILE))
       .filter((file) => !provisioningSuites.includes(file))
       .flatMap(provisionerReferences);
     expect(strays).toEqual([]);
+  });
+
+  // The negative rule above is only worth having while someone still holds the reference. Deleting the provision would otherwise satisfy every assertion in this file.
+  it('acquires infrastructure in the lifecycle owner and nowhere else', () => {
+    expect(provisionerReferences(join(TESTS_ROOT, LIFECYCLE_OWNER_FILE))).not.toEqual([]);
+    expect(provisionerReferences(join(TESTS_ROOT, SHARED_MEMO_FILE))).toEqual([]);
   });
 });
 
@@ -261,7 +273,7 @@ describe('database infrastructure global lifecycle', () => {
     expect.soft(result.events.at(-1), result.events.join(' -> ')).toBe('stop');
   });
 
-  it('provides an external URL without invoking or stopping Testcontainers', () => {
+  it('provides an external URL without provisioning or stopping a container', () => {
     const databaseUrl = 'postgres://external/fixture';
     const result = runLifecycleFixture({ databaseUrl });
 

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,12 +1,15 @@
 import { defineProject } from '../config/vitest/index.js';
 
-// Serialisation exists for one reason: to hold the one-container-at-a-time invariant while the seven migration suites provision their own Postgres, because Vitest's default fan-out started all seven against one Docker daemon at once and orphaned the containers that eventually came up.
-//
-// So it is armed only when there are containers to hold it over. With TESTCONTAINERS unset there are none: those suites either skip outright (the Docker-free unit lane) or run against a DATABASE_TEST_URL the lane already supplied, each on its own scratch database. Serialising there buys nothing and costs the package roughly 3x wall clock, measured.
+// Serialisation remains scoped to local container runs. The global setup now provisions one endpoint for the whole project, while serial execution preserves the migration suites' established Docker and database concurrency behavior.
 const provisionsContainers = process.env['TESTCONTAINERS'] === '1';
 
-export default defineProject({
-  packageName: '@app/db',
-  // 180s, not the 120s a pure provisioning budget would need. `remove-paper-trading-migration` provisions, creates a scratch database, then runs the migration set in two staged passes, and `withPostgres` may legitimately spend its full 90s PROVISION_DEADLINE_MS before the first pass starts. That suite carried an explicit 180s of its own until the shared memo took provisioning over, and `infra-lifecycle-config` now forbids a per-hook override, so the budget has to be right here or the heaviest hook regresses into the bare "beforeAll timed out" this whole path replaces.
-  test: { hookTimeout: 180_000, fileParallelism: !provisionsContainers },
-});
+// Declared separately because Vitest types `teardownTimeout` as a root-only setting even though this package config is run as the root config. The value is still consumed when `vitest run` loads this file directly.
+const test = {
+  globalSetup: './__tests__/_global-setup.ts',
+  hookTimeout: 180_000,
+  teardownTimeout: 180_000,
+  fileParallelism: !provisionsContainers,
+  isolate: false,
+};
+
+export default defineProject({ packageName: '@app/db', test });

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,9 +1,11 @@
+import type { TestProjectInlineConfiguration } from 'vitest/config';
+
 import { defineProject } from '../config/vitest/index.js';
 
 // Serialisation remains scoped to local container runs. The global setup now provisions one endpoint for the whole project, while serial execution preserves the migration suites' established Docker and database concurrency behavior.
 const provisionsContainers = process.env['TESTCONTAINERS'] === '1';
 
-// Declared separately because Vitest types `teardownTimeout` as a root-only setting even though this package config is run as the root config. The value is still consumed when `vitest run` loads this file directly.
+// Declared separately because Vitest types `teardownTimeout` as a root-only setting even though this package config is run as the root config. The value is still consumed when `vitest run` loads this file directly. `satisfies` widens exactly that one key: a bare variable would also stop TypeScript catching a typo in any of the others.
 const test = {
   globalSetup: './__tests__/_global-setup.ts',
   hookTimeout: 180_000,
@@ -13,6 +15,8 @@ const test = {
   //
   // Safe because nothing here depends on a fresh registry per file. `_infra.ts` is a provided-context read with no module-level state to leak, teardown is owned by the project global setup rather than by whichever file imported first, and no suite calls `vi.resetModules()` on the shared graph.
   isolate: false,
+} satisfies NonNullable<TestProjectInlineConfiguration['test']> & {
+  readonly teardownTimeout: number;
 };
 
 export default defineProject({ packageName: '@app/db', test });

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -9,6 +9,9 @@ const test = {
   hookTimeout: 180_000,
   teardownTimeout: 180_000,
   fileParallelism: !provisionsContainers,
+  // Measured on the no-infra lane, same 238 passed / 472 skipped either way: 3.5s wall and 15s import shared, against 7.7s wall and 52s import isolated. The 79 files re-parse the same drizzle schema and migration helpers on every fresh registry, so the saving is import cost, not test cost.
+  //
+  // Safe because nothing here depends on a fresh registry per file. `_infra.ts` is a provided-context read with no module-level state to leak, teardown is owned by the project global setup rather than by whichever file imported first, and no suite calls `vi.resetModules()` on the shared graph.
   isolate: false,
 };
 

--- a/packages/testcontainers/__tests__/reusable-endpoint.test.ts
+++ b/packages/testcontainers/__tests__/reusable-endpoint.test.ts
@@ -1,0 +1,34 @@
+// The provisioning half of this rule needs a Docker socket, which the integration lane does not have: `scripts/ci/test-integration.sh` leaves TESTCONTAINERS unset, so `wrapper.test.ts`'s Docker block never runs in CI. Testing the decision on its own is what keeps "TESTCONTAINERS=1 wins when both are set" pinned in every lane instead of only on a developer's machine.
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { reusableEndpoint } from '../src/index.js';
+
+const previous = process.env['TESTCONTAINERS'];
+
+afterEach(() => {
+  if (previous === undefined) delete process.env['TESTCONTAINERS'];
+  else process.env['TESTCONTAINERS'] = previous;
+});
+
+describe('reusableEndpoint', () => {
+  it('reuses a caller-supplied endpoint when provisioning was not requested', () => {
+    delete process.env['TESTCONTAINERS'];
+    expect(reusableEndpoint('postgres://service/db')).toBe('postgres://service/db');
+  });
+
+  it('refuses to reuse when provisioning was explicitly requested', () => {
+    process.env['TESTCONTAINERS'] = '1';
+    expect(reusableEndpoint('postgres://service/db')).toBeUndefined();
+  });
+
+  it('provisions when neither selector names an endpoint', () => {
+    delete process.env['TESTCONTAINERS'];
+    expect(reusableEndpoint(undefined)).toBeUndefined();
+  });
+
+  // The value is a switch, not a truthiness check: an exported TESTCONTAINERS=0 must not be read as a request to provision.
+  it('treats any value other than 1 as no request to provision', () => {
+    process.env['TESTCONTAINERS'] = '0';
+    expect(reusableEndpoint('postgres://service/db')).toBe('postgres://service/db');
+  });
+});

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -1,13 +1,6 @@
-// Thin wrappers around `@testcontainers/postgresql` and
-// `@testcontainers/redis` that produce a fresh container per call.
+// Thin wrappers around `@testcontainers/postgresql` and `@testcontainers/redis` that produce a fresh container per call.
 //
-// The integration suites under apps/api, apps/worker, and packages/db all
-// need a hermetic Postgres + Redis. Sharing a single long-lived instance
-// across suites is fragile — one suite's leaked rows show up in the next
-// — so each suite calls `withPostgres` / `withRedis` and tears the
-// container down on cleanup. The factories live here rather than inline
-// in each suite so the image pins, env defaults, and start-up timing are
-// owned in one place.
+// API and worker integration fixtures call these factories directly and release their containers during fixture cleanup. The database package calls `withPostgres` once from project global setup, then gives migration suites separate scratch databases on that shared endpoint. The factories live here rather than inline so image pins, environment defaults, and startup timing remain owned in one place.
 
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { RedisContainer, type StartedRedisContainer } from '@testcontainers/redis';

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -122,14 +122,25 @@ export interface PostgresFixture {
 }
 
 /**
+ * Decides whether a caller-supplied endpoint may stand in for a provisioned container. `TESTCONTAINERS=1` wins when both are set, so an explicit request to provision is never satisfied by a service URL that happens to be exported.
+ *
+ * Extracted so the rule is one expression with one test rather than a branch repeated per fixture, and so it stays pinned in lanes that have no Docker socket to observe the provisioning half.
+ *
+ * @param reuseUrl - The endpoint named by this fixture's reuse variable, if any.
+ * @returns The endpoint to reuse, or undefined when this call must provision.
+ */
+export const reusableEndpoint = (reuseUrl: string | undefined): string | undefined =>
+  process.env['TESTCONTAINERS'] === '1' ? undefined : reuseUrl;
+
+/**
  * Returns a Postgres endpoint for an integration suite. `TESTCONTAINERS=1` boots the requested pinned image, while `DATABASE_TEST_URL` reuses the service container supplied by CI. `TESTCONTAINERS=1` wins when both are set so the wrapper's smoke test exercises real provisioning.
  *
  * @param options - Per-call overrides; `startTimeoutMs` tightens the provisioning deadline for a caller with a smaller hook budget.
  * @returns The connection string, optional provisioned container, and cleanup hook owned by the caller.
  */
 export const withPostgres = async (options: ProvisionOptions = {}): Promise<PostgresFixture> => {
-  const reuseUrl = process.env['DATABASE_TEST_URL'];
-  if (process.env['TESTCONTAINERS'] !== '1' && reuseUrl) {
+  const reuseUrl = reusableEndpoint(process.env['DATABASE_TEST_URL']);
+  if (reuseUrl) {
     return { databaseUrl: reuseUrl, stop: async () => undefined };
   }
   // Deadline OUTSIDE, retry INSIDE, so all three attempts spend one budget. Nested the other way each attempt would get its own, up to 3x the deadline, which outruns the hook timeouts the deadline was sized under (packages/db 180s, apps/worker 180s) and hands the operator back the bare "beforeAll timed out" this whole path exists to replace.
@@ -185,8 +196,8 @@ export interface RedisFixture {
  * @returns The connection URL, optional provisioned container, and cleanup hook owned by the caller.
  */
 export const withRedis = async (options: ProvisionOptions = {}): Promise<RedisFixture> => {
-  const reuseUrl = process.env['REDIS_TEST_URL'];
-  if (process.env['TESTCONTAINERS'] !== '1' && reuseUrl) {
+  const reuseUrl = reusableEndpoint(process.env['REDIS_TEST_URL']);
+  if (reuseUrl) {
     return { redisUrl: reuseUrl, stop: async () => undefined };
   }
   // Same nesting as `withPostgres`, for the same reason: one budget covers the retry loop, never one budget per attempt.


### PR DESCRIPTION
## Motivation

The shared Postgres fixture used by `packages/db`'s migration suites was memoised at module scope and stopped from an `afterAll` in the helper every suite imported. Whichever suite ran that hook last decided when the container died, so a suite that imported the helper without using it could stop the fixture out from under a suite still running, and a provisioning failure surfaced as an unrelated timeout in whichever suite happened to touch it first.

## Changes

- `packages/db/__tests__/_global-setup.ts`: new Vitest `globalSetup` that acquires the shared Postgres fixture once per project run and hands the URL down via `project.provide('databaseTestUrl', ...)`. It guards once on `HAS_INFRA` and then calls `withPostgres()` unconditionally, so which selector wins when both `TESTCONTAINERS=1` and `DATABASE_TEST_URL` are set stays the wrapper's rule and is not re-derived here. It also owns `HAS_INFRA`, since it is the file that decides whether to acquire anything. Teardown sets `process.exitCode = 1` before rethrowing, because Vitest reports a project-teardown rejection without failing the CLI on its own, which would otherwise let a leaked container pass as a green run.
- `packages/db/__tests__/_infra.ts`: `sharedDatabaseUrl` now reads the URL via `inject('databaseTestUrl')` instead of owning its own memoised provision and `afterAll`; it throws if infra was requested without a provided URL. `HAS_INFRA` is re-exported from the lifecycle owner so every `describe.skipIf` import site is unchanged.
- `packages/db/vitest.config.ts`: wires `globalSetup: './__tests__/_global-setup.ts'`, adds `teardownTimeout: 180_000` alongside the existing `hookTimeout`, and adds `isolate: false`. Measured on the no-infra lane at identical results, 238 passed and 472 skipped either way: 3.5s wall and 15s import shared, against 7.7s wall and 52s import isolated. The 79 files re-parse the same drizzle schema and migration helpers on every fresh registry, so the saving is import cost rather than test cost.
- `packages/db/__tests__/fixtures/infra-lifecycle/*` (new): a nested fixture project with a fake `@app/testcontainers` that records start and stop events, used to prove the fixture is provisioned once, shared, and stopped exactly once, and that a teardown error fails the run.
- `packages/db/__tests__/infra-lifecycle-config.test.ts`: expanded to exercise the new global-setup lifecycle against the fixture project above.
- `packages/testcontainers/src/index.ts`: extracts `reusableEndpoint`, the single owner of whether a caller-supplied endpoint may stand in for a provisioned container, used by both `withPostgres` and `withRedis`. The comment above it describes the new call pattern: global setup calls `withPostgres` once and hands migration suites separate scratch databases on that shared endpoint, while API and worker integration fixtures still call the factories directly per suite.
- `packages/testcontainers/__tests__/reusable-endpoint.test.ts` (new): pins that rule with no Docker socket, so it holds in every lane. The integration lane leaves `TESTCONTAINERS` unset, so the wrapper's provisioning block never runs in CI and the precedence was previously observable only on a developer machine.
- `packages/config/turbo.json` (new): declares `test` task inputs for every root this package's suites read outside itself, `README.md`, `docs/**/*.md`, `e2e/**`, `scripts/ci/**`, `apps|packages/**/package.json`, `apps|packages/**/vitest.config.ts` and `apps|packages/**/src/**`, so Turbo cannot serve a cached green over a stale walk. The `packages/**` config glob matters most: `coverage-thresholds.test.ts` imports twenty package configs by absolute path, and without it an edit to any of them left the task hash unchanged. This makes `@app/config#test` cache-miss on most commits, which is the right trade for an infra-free suite whose whole job is to walk the repository. `$schema` matches the version the root `turbo.json` pins.
- `packages/core/__tests__/env/load-env-root.test.ts` (new), plus updates to `bootstrap.test.ts` and `load-env.test.ts`: cover `findRepoRoot` and `findEnvFile` returning `undefined` at the filesystem root when no repository marker or `.env` is present.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean
- [x] Manual: verified via `packages/db/__tests__/infra-lifecycle-config.test.ts` against the new `packages/db/__tests__/fixtures/infra-lifecycle` project, whose fake `@app/testcontainers` records start and stop events. It asserts the fixture provisions once, is shared, stops exactly once, and that a teardown rejection fails the run. `packages/core/__tests__/env/load-env-root.test.ts` covers the filesystem-root termination case for `findRepoRoot` and `findEnvFile`. The real provisioning path was also run against Docker: `TESTCONTAINERS=1 bunx vitest run` in `packages/db` is 28 files and 283 tests passed on one shared container.

## Breaking changes

None.

## Stack

This is PR 3 of a 10-PR stack. It is based on #772 and #774 is stacked on top of it. The stack must merge bottom-up, and this PR's diff will re-anchor to `main` once #772 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRceiDYdzzHo6aLFr4sZPj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded environment-loading coverage for repository search limits and filesystem-root behavior.
  - Improved database integration coverage for shared infrastructure, lifecycle handling, external database URLs, and teardown failures.
  - Added deterministic fixtures for validating database setup across test consumers.
  - Added coverage for reusable database and cache service endpoints.

- **Chores**
  - Updated test execution configuration for consistent task inputs and database test isolation.

- **Documentation**
  - Clarified container lifecycle behavior and database test infrastructure usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->