### PR TITLE
feat(worker): alert when a held position has no protective stop resting

### DIFF
--- a/apps/worker/__tests__/boot/builders/notifiers.test.ts
+++ b/apps/worker/__tests__/boot/builders/notifiers.test.ts
@@ -25,6 +25,7 @@ describe('buildNotifiers', () => {
       'orderFailedThrottle',
       'orderRefusalLoopThrottle',
       'protectiveStopBlockedThrottle',
+      'protectiveStopUnplacedThrottle',
     ]);
     expect(typeof n.accountNotify).toBe('function');
     expect(typeof n.notifyEvent).toBe('function');

--- a/apps/worker/__tests__/boot/builders/tick-handler-override-deps.test.ts
+++ b/apps/worker/__tests__/boot/builders/tick-handler-override-deps.test.ts
@@ -101,6 +101,7 @@ const buildDeps = (): TickHandlerDeps => {
     orderFailedThrottle: { allow: async () => true } as never,
     orderRefusalLoopThrottle: { allow: async () => true } as never,
     protectiveStopBlockedThrottle: { allow: async () => true } as never,
+    protectiveStopUnplacedThrottle: { allow: async () => true } as never,
     auditShipper: anyProxy(),
   });
   const deps = captured.deps;

--- a/apps/worker/__tests__/boot/builders/tick-handler.test.ts
+++ b/apps/worker/__tests__/boot/builders/tick-handler.test.ts
@@ -459,9 +459,6 @@ describe('buildTickHandler — the protective-stop-unplaced notifier', () => {
 
     await notify(unplaced({ detail: { stop: '11.5511', nativeUnavailable: true } }));
     await notify(
-      unplaced({ detail: { stop: '11.5511', nativeUnavailable: true, distancePct: 0.037 } }),
-    );
-    await notify(
       unplaced({ detail: { stop: '11.5511', nativeUnavailable: true, distancePct: 'soon' } }),
     );
 
@@ -472,6 +469,20 @@ describe('buildTickHandler — the protective-stop-unplaced notifier', () => {
       expect(JSON.stringify(event)).not.toContain('undefined');
       expect(JSON.stringify(event)).not.toContain('%');
     }
+  });
+
+  it('quotes a distance the bag carried as a JSON number, the same as the screen would', async () => {
+    // The formatter is the one `@app/strategy-core` owns, so the push alert and the symbol screen cannot accept or reject the same value differently. A number is exact at the two-decimal percent this rounds to, and dropping the clause would tell the operator less for no safety gained.
+    const { deps, events } = build();
+    const notify = deps.notifyProtectiveStopUnplaced;
+    if (!notify) throw new Error('the builder did not wire notifyProtectiveStopUnplaced');
+
+    await notify(
+      unplaced({ detail: { stop: '11.5511', nativeUnavailable: true, distancePct: 0.037 } }),
+    );
+
+    const event = events[0] as { fields: { label: string; value: string }[] };
+    expect(event.fields.find((f) => f.label === 'Why')?.value).toContain('3.7% below the high');
   });
 
   it('still reports the exposure when the detail bag did not survive the round-trip', async () => {

--- a/apps/worker/__tests__/boot/builders/tick-handler.test.ts
+++ b/apps/worker/__tests__/boot/builders/tick-handler.test.ts
@@ -34,12 +34,14 @@ interface Built {
   readonly deps: TickHandlerDeps;
   readonly events: Record<string, unknown>[];
   readonly stopKeys: string[];
+  readonly unplacedKeys: string[];
   readonly refusalKeys: string[];
 }
 
 const build = (allowStop = true, allowRefusal = true): Built => {
   const events: Record<string, unknown>[] = [];
   const stopKeys: string[] = [];
+  const unplacedKeys: string[] = [];
   const refusalKeys: string[] = [];
   const slice = buildTickHandler({
     env: ENV,
@@ -70,11 +72,17 @@ const build = (allowStop = true, allowRefusal = true): Built => {
         return allowStop;
       },
     } as never,
+    protectiveStopUnplacedThrottle: {
+      allow: async (key: string) => {
+        unplacedKeys.push(key);
+        return allowStop;
+      },
+    } as never,
     auditShipper: anyProxy(),
   });
   const deps = captured.deps;
   if (!deps) throw new Error('buildTickHandler did not construct a tick handler');
-  return { slice, deps, events, stopKeys, refusalKeys };
+  return { slice, deps, events, stopKeys, unplacedKeys, refusalKeys };
 };
 
 const BAND = {
@@ -352,5 +360,146 @@ describe('notifyOrderFailed wording', () => {
 
     expect(event.body).toContain('could not cancel an order');
     expect(event.fields).toContainEqual({ label: 'Action', value: 'Cancel order' });
+  });
+});
+
+describe('buildTickHandler — the protective-stop-unplaced notifier', () => {
+  const unplaced = (over: Record<string, unknown> = {}) => ({
+    operatorId: OPERATOR,
+    accountId: ACCOUNT,
+    profileId: PROFILE,
+    symbol: SYMBOL,
+    sinceMs: Date.now() - 2 * 3_600_000,
+    detail: { stop: '11.5511' },
+    ...over,
+  });
+
+  it('keys the throttle on the coin alone, with no escalation level to split', async () => {
+    // Unlike the band refusal there is one thing to say here — nothing is guarding this position — so a second key segment would only split one message into two alerts an hour apart.
+    const { deps, unplacedKeys } = build();
+    const notify = deps.notifyProtectiveStopUnplaced;
+    if (!notify) throw new Error('the builder did not wire notifyProtectiveStopUnplaced');
+
+    await notify(unplaced());
+
+    expect(unplacedKeys).toEqual([`${PROFILE}:${SYMBOL}`]);
+  });
+
+  it('sends nothing when the throttle window is already open', async () => {
+    const { deps, events } = build(false);
+    const notify = deps.notifyProtectiveStopUnplaced;
+    if (!notify) throw new Error('the builder did not wire notifyProtectiveStopUnplaced');
+
+    await notify(unplaced());
+
+    expect(events).toEqual([]);
+  });
+
+  it('files under order-failed, which already covers a stop that never reached the exchange', async () => {
+    // That category is severity error and defaults ON, so the alert about an unguarded position is not behind a switch the operator has to find first.
+    const { deps, events } = build();
+    const notify = deps.notifyProtectiveStopUnplaced;
+    if (!notify) throw new Error('the builder did not wire notifyProtectiveStopUnplaced');
+
+    await notify(unplaced());
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ category: 'order-failed', symbol: SYMBOL });
+  });
+
+  it('leads with the exposure and how long it has run, then what to check', async () => {
+    const { deps, events } = build();
+    const notify = deps.notifyProtectiveStopUnplaced;
+    if (!notify) throw new Error('the builder did not wire notifyProtectiveStopUnplaced');
+
+    await notify(unplaced());
+
+    const event = events[0] as { body: string; fields: { label: string; value: string }[] };
+    expect(event.body).toContain('no protective stop on Binance for 2 hours');
+    expect(event.body).toContain('Nothing on the exchange will sell it if the price falls');
+    expect(event.body).toContain('another order is holding the coins');
+    expect(event.fields).toContainEqual({ label: 'Unprotected for', value: '2 hours' });
+    expect(event.fields).toContainEqual({ label: 'Wanted stop', value: '11.5511' });
+  });
+
+  it('omits the wanted stop when the strategy could not price one', async () => {
+    // The strategy publishes `stop: null` when it could not derive a level at all, and a field reading "null" tells the operator nothing while implying a number exists.
+    const { deps, events } = build();
+    const notify = deps.notifyProtectiveStopUnplaced;
+    if (!notify) throw new Error('the builder did not wire notifyProtectiveStopUnplaced');
+
+    await notify(unplaced({ detail: { stop: null } }));
+
+    const event = events[0] as { fields: { label: string }[] };
+    expect(event.fields.map((f) => f.label)).not.toContain('Wanted stop');
+  });
+
+  it('names the trailing-stop refusal and the distance Binance would not take', async () => {
+    // The cause this alert exists for: a native-trail profile on a symbol whose trailingDelta filter has no step for the wanted distance never places anything, and no price move clears that. The distance is quoted in the percent the settings screen shows, not the fraction the strategy records.
+    const { deps, events } = build();
+    const notify = deps.notifyProtectiveStopUnplaced;
+    if (!notify) throw new Error('the builder did not wire notifyProtectiveStopUnplaced');
+
+    await notify(
+      unplaced({ detail: { stop: '11.5511', nativeUnavailable: true, distancePct: '0.037' } }),
+    );
+
+    const event = events[0] as { fields: { label: string; value: string }[] };
+    const why = event.fields.find((f) => f.label === 'Why');
+    expect(why?.value).toContain('3.7% below the high');
+    expect(why?.value).toContain('follows the price up');
+    expect(why?.value).toContain("Switch this profile's protective stop mode to priced");
+  });
+
+  it('drops the distance from the refusal rather than quote one it cannot read', async () => {
+    // `distancePct` is null whenever the strategy could not derive the distance at all, and the bag has crossed a JSON round-trip besides. The lever still has to be named, so the clause loses the number and keeps the advice.
+    const { deps, events } = build();
+    const notify = deps.notifyProtectiveStopUnplaced;
+    if (!notify) throw new Error('the builder did not wire notifyProtectiveStopUnplaced');
+
+    await notify(unplaced({ detail: { stop: '11.5511', nativeUnavailable: true } }));
+    await notify(
+      unplaced({ detail: { stop: '11.5511', nativeUnavailable: true, distancePct: 0.037 } }),
+    );
+    await notify(
+      unplaced({ detail: { stop: '11.5511', nativeUnavailable: true, distancePct: 'soon' } }),
+    );
+
+    for (const raw of events) {
+      const event = raw as { fields: { label: string; value: string }[] };
+      const why = event.fields.find((f) => f.label === 'Why');
+      expect(why?.value).toContain('at the distance your settings ask for');
+      expect(JSON.stringify(event)).not.toContain('undefined');
+      expect(JSON.stringify(event)).not.toContain('%');
+    }
+  });
+
+  it('still reports the exposure when the detail bag did not survive the round-trip', async () => {
+    // The duration is the whole signal and it comes off the input, not the bag, so a bag that arrived as null must cost the operator its optional fields and nothing else.
+    const { deps, events } = build();
+    const notify = deps.notifyProtectiveStopUnplaced;
+    if (!notify) throw new Error('the builder did not wire notifyProtectiveStopUnplaced');
+
+    await notify(unplaced({ detail: null }) as never);
+
+    const event = events[0] as { body: string; fields: { label: string }[] };
+    expect(event.body).toContain('no protective stop on Binance for 2 hours');
+    expect(event.fields).toEqual([{ label: 'Unprotected for', value: '2 hours' }]);
+  });
+
+  it('says nothing about trailing stops when that is not what blocked this one', async () => {
+    // The ordinary unplaced case has no named cause, and inventing one would send an operator to a setting that is not theirs: a priced-mode profile has no trail distance to change.
+    const { deps, events } = build();
+    const notify = deps.notifyProtectiveStopUnplaced;
+    if (!notify) throw new Error('the builder did not wire notifyProtectiveStopUnplaced');
+
+    await notify(unplaced());
+
+    const event = events[0] as { fields: { label: string; value: string }[] };
+    expect(event.fields.map((f) => f.label)).not.toContain('Why');
+    expect(event.fields).toEqual([
+      { label: 'Unprotected for', value: '2 hours' },
+      { label: 'Wanted stop', value: '11.5511' },
+    ]);
   });
 });

--- a/apps/worker/__tests__/executor/fill-adopter-detached-terminal.test.ts
+++ b/apps/worker/__tests__/executor/fill-adopter-detached-terminal.test.ts
@@ -139,6 +139,33 @@ describe('reconcileDetachedFill — terminal-status vocabulary', () => {
     expect(repoMocks.ordersCloseByBinanceOrderId).not.toHaveBeenCalled();
   });
 
+  // The terminal gate case-folds and the FILLED routing test does not, so an off-case spelling used to pass the first and fail the second, taking the plain close: terminal, but with the execution totals never merged. Binance sends these upper, so this pins the two comparisons to one reading rather than a bug anyone has seen.
+  it.each(['filled', 'Filled'])('routes %s the same way as FILLED, totals and all', async (raw) => {
+    await makeAdopter().reconcileDetachedFill({
+      ...eventWith(raw),
+      cumQty: '12',
+      cumQuoteQty: '340',
+    });
+
+    expect(repoMocks.ordersMarkFilledByBinanceOrderId).toHaveBeenCalledWith(
+      BigInt(ORDER_ID),
+      { executedQty: '12', cummulativeQuoteQty: '340' },
+      1_735_000_000_000,
+    );
+    expect(repoMocks.ordersCloseByBinanceOrderId).not.toHaveBeenCalled();
+  });
+
+  it('still writes the exchange’s own spelling to the row it plainly closes', async () => {
+    // The fold decides the ROUTE, never what is recorded: a row stamped `CANCELED` when Binance said `canceled` would misquote the exchange in the one place the operator goes to find out why the order left the book.
+    await makeAdopter().reconcileDetachedFill(eventWith('canceled'));
+
+    expect(repoMocks.ordersCloseByBinanceOrderId).toHaveBeenCalledWith(
+      BigInt(ORDER_ID),
+      'canceled',
+      1_735_000_000_000,
+    );
+  });
+
   it.each(['NEW', 'PARTIALLY_FILLED', 'PENDING_CANCEL', 'SOME_STATUS_BINANCE_ADDS_TOMORROW'])(
     'leaves the row open on %s — a still-live commitment SHOULD keep counting toward exposure',
     async (status) => {

--- a/apps/worker/__tests__/executor/fill-adopter-detached-terminal.test.ts
+++ b/apps/worker/__tests__/executor/fill-adopter-detached-terminal.test.ts
@@ -107,9 +107,55 @@ describe('reconcileDetachedFill — terminal-status vocabulary', () => {
       BigInt(ORDER_ID),
       'EXPIRED_IN_MATCH',
       1_735_000_000_000,
+      undefined,
     );
     // The exchange's own status is what lands on the row, so the ledger records WHY the order left the book.
     expect(repoMocks.ordersMarkFilledByBinanceOrderId).not.toHaveBeenCalled();
+  });
+
+  // `EXPIRED_IN_MATCH` is the mid-match status, so it is the one most likely to carry a partial fill: under STP a taker can match unrelated makers before meeting its own order and having the remainder expired. The plain close writes only status and closed_at, and the detached path never sees the PARTIALLY_FILLED reports that would have refreshed `raw`, so without this the row records nothing moving on an order that moved coins.
+  it.each(['EXPIRED_IN_MATCH', 'CANCELED'])(
+    'carries the observed totals onto a %s that had partly filled',
+    async (status) => {
+      repoMocks.ordersFindByBinanceOrderId.mockResolvedValue({
+        profileId: null,
+        raw: { clientOrderId: 'x-1', transactTime: 1, executedQty: '0' },
+      });
+
+      await makeAdopter().reconcileDetachedFill({
+        ...eventWith(status),
+        cumQty: '3',
+        cumQuoteQty: '90',
+      });
+
+      expect(repoMocks.ordersCloseByBinanceOrderId).toHaveBeenCalledWith(
+        BigInt(ORDER_ID),
+        status,
+        1_735_000_000_000,
+        // Spread over the placement-time bag rather than replacing it: `clientOrderId` and `transactTime` are what tie the row back to the request, and the repo's `raw` parameter overwrites.
+        {
+          clientOrderId: 'x-1',
+          transactTime: 1,
+          status,
+          executedQty: '3',
+          cummulativeQuoteQty: '90',
+        },
+      );
+      // The row is NOT forced to FILLED: the order expired, and claiming it filled would be a worse lie than the stale totals were.
+      expect(repoMocks.ordersMarkFilledByBinanceOrderId).not.toHaveBeenCalled();
+    },
+  );
+
+  it('leaves `raw` alone on a zero-fill terminator', async () => {
+    // Nothing executed, so there is nothing to correct, and rewriting the bag would churn a row for no change.
+    await makeAdopter().reconcileDetachedFill(eventWith('CANCELED'));
+
+    expect(repoMocks.ordersCloseByBinanceOrderId).toHaveBeenCalledWith(
+      BigInt(ORDER_ID),
+      'CANCELED',
+      1_735_000_000_000,
+      undefined,
+    );
   });
 
   it.each(['CANCELED', 'EXPIRED', 'REJECTED'])('closes the row on %s', async (status) => {
@@ -120,6 +166,7 @@ describe('reconcileDetachedFill — terminal-status vocabulary', () => {
       BigInt(ORDER_ID),
       status,
       1_735_000_000_000,
+      undefined,
     );
   });
 
@@ -163,6 +210,7 @@ describe('reconcileDetachedFill — terminal-status vocabulary', () => {
       BigInt(ORDER_ID),
       'canceled',
       1_735_000_000_000,
+      undefined,
     );
   });
 

--- a/apps/worker/__tests__/executor/fill-adopter-detached-terminal.test.ts
+++ b/apps/worker/__tests__/executor/fill-adopter-detached-terminal.test.ts
@@ -1,0 +1,160 @@
+// Which statuses close a DETACHED order's ledger row.
+//
+// `reconcileDetachedFill` is the only thing that ever stamps `closed_at` on an order whose profile was deleted. A status it does not recognise as terminal leaves the row open forever: it keeps its `orders_one_live_per_intent` live slot and keeps counting toward the account's open exposure, which backs the delete-account guard. So the set of statuses it accepts is a contract, and it must be the SHARED one — the same predicate the open-orders cache eviction and the boot reaper read. `EXPIRED_IN_MATCH` is the status that proves it: Binance stamps it when self-trade prevention kills an order, which on a shared account wallet is exactly what a sibling profile's BUY crossing our resting SELL produces.
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Logger } from 'pino';
+import type { Queue } from 'bullmq';
+
+import { asAccountId, asUserId } from '@app/contracts';
+
+import { createFillAdopter, type DetachedOrderEvent } from '../../src/executor/fill-adopter.js';
+import { createChainByKey } from '../../src/lib/chain-by-key.js';
+import type { StatePort } from '../../src/state/state-port.js';
+import type { SymbolInfoCache } from '../../src/tick/symbol-info-cache.js';
+
+const OPERATOR_ID = asUserId('00000000-0000-0000-0000-0000000705a1');
+const ACCOUNT_ID = asAccountId('00000000-0000-0000-0000-0000000705c1');
+const SYMBOL = 'XPLUSDT';
+// Above 2^32 so a lossy number/bigint hop surfaces as a miss rather than a pass.
+const ORDER_ID = 8_700_000_705;
+
+const repoMocks = vi.hoisted(() => ({
+  ordersFindByBinanceOrderId: vi.fn(),
+  ordersCloseByBinanceOrderId: vi.fn(async () => 1),
+  ordersMarkFilledByBinanceOrderId: vi.fn(async () => 1),
+}));
+
+const accountScope = { db: undefined as unknown, operatorId: OPERATOR_ID, accountId: ACCOUNT_ID };
+
+vi.mock('@app/db', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('@app/db')>();
+  return {
+    ...orig,
+    scopeAccount: vi.fn(async () => accountScope),
+    accountRepoFromScope: vi.fn(() => ({
+      orders: {
+        findByBinanceOrderId: repoMocks.ordersFindByBinanceOrderId,
+        closeByBinanceOrderId: repoMocks.ordersCloseByBinanceOrderId,
+        markFilledByBinanceOrderId: repoMocks.ordersMarkFilledByBinanceOrderId,
+      },
+    })),
+  };
+});
+
+const noopLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  debug: () => undefined,
+} as unknown as Logger;
+
+/**
+ * The production adopter with its position-side deps rigged to THROW. The detached path is the ledger half of adoption with the strategy half deliberately absent, so a regression that starts seeding cost basis or strategy state here fails loudly instead of quietly handing a deleted profile's position to a stranger.
+ */
+const makeAdopter = () =>
+  createFillAdopter({
+    db: {} as never,
+    chain: createChainByKey(),
+    logger: noopLogger,
+    statePort: {
+      mutate: () => {
+        throw new Error('detached reconcile must not touch strategy state');
+      },
+    } as unknown as StatePort,
+    registry: {
+      get: () => {
+        throw new Error('detached reconcile must not resolve a strategy');
+      },
+    },
+    pipelineQueue: {
+      add: () => {
+        throw new Error('detached reconcile must not enqueue an archive');
+      },
+    } as unknown as Queue,
+    symbolInfo: {
+      get: () => {
+        throw new Error('detached reconcile must not read symbol info');
+      },
+    } as unknown as SymbolInfoCache,
+  });
+
+const eventWith = (orderStatus: string): DetachedOrderEvent => ({
+  operatorId: OPERATOR_ID,
+  accountId: ACCOUNT_ID,
+  symbol: SYMBOL,
+  orderId: ORDER_ID,
+  orderStatus,
+  cumQty: '0',
+  cumQuoteQty: '0',
+  eventTimeMs: 1_735_000_000_000,
+});
+
+describe('reconcileDetachedFill — terminal-status vocabulary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // A detached row: present, and `profileId` null is what makes it ours to close.
+    repoMocks.ordersFindByBinanceOrderId.mockResolvedValue({ profileId: null });
+    repoMocks.ordersCloseByBinanceOrderId.mockResolvedValue(1);
+    repoMocks.ordersMarkFilledByBinanceOrderId.mockResolvedValue(1);
+  });
+
+  it('closes the row on EXPIRED_IN_MATCH, the self-trade-prevention terminator', async () => {
+    await makeAdopter().reconcileDetachedFill(eventWith('EXPIRED_IN_MATCH'));
+
+    expect(repoMocks.ordersCloseByBinanceOrderId).toHaveBeenCalledTimes(1);
+    expect(repoMocks.ordersCloseByBinanceOrderId).toHaveBeenCalledWith(
+      BigInt(ORDER_ID),
+      'EXPIRED_IN_MATCH',
+      1_735_000_000_000,
+    );
+    // The exchange's own status is what lands on the row, so the ledger records WHY the order left the book.
+    expect(repoMocks.ordersMarkFilledByBinanceOrderId).not.toHaveBeenCalled();
+  });
+
+  it.each(['CANCELED', 'EXPIRED', 'REJECTED'])('closes the row on %s', async (status) => {
+    await makeAdopter().reconcileDetachedFill(eventWith(status));
+
+    expect(repoMocks.ordersCloseByBinanceOrderId).toHaveBeenCalledTimes(1);
+    expect(repoMocks.ordersCloseByBinanceOrderId).toHaveBeenCalledWith(
+      BigInt(ORDER_ID),
+      status,
+      1_735_000_000_000,
+    );
+  });
+
+  it('routes FILLED to the totals-merging close, not the plain one', async () => {
+    await makeAdopter().reconcileDetachedFill({
+      ...eventWith('FILLED'),
+      cumQty: '12',
+      cumQuoteQty: '340',
+    });
+
+    expect(repoMocks.ordersMarkFilledByBinanceOrderId).toHaveBeenCalledTimes(1);
+    expect(repoMocks.ordersMarkFilledByBinanceOrderId).toHaveBeenCalledWith(
+      BigInt(ORDER_ID),
+      { executedQty: '12', cummulativeQuoteQty: '340' },
+      1_735_000_000_000,
+    );
+    expect(repoMocks.ordersCloseByBinanceOrderId).not.toHaveBeenCalled();
+  });
+
+  it.each(['NEW', 'PARTIALLY_FILLED', 'PENDING_CANCEL', 'SOME_STATUS_BINANCE_ADDS_TOMORROW'])(
+    'leaves the row open on %s — a still-live commitment SHOULD keep counting toward exposure',
+    async (status) => {
+      await makeAdopter().reconcileDetachedFill(eventWith(status));
+
+      expect(repoMocks.ordersFindByBinanceOrderId).not.toHaveBeenCalled();
+      expect(repoMocks.ordersCloseByBinanceOrderId).not.toHaveBeenCalled();
+      expect(repoMocks.ordersMarkFilledByBinanceOrderId).not.toHaveBeenCalled();
+    },
+  );
+
+  it('refuses to close a row that still has a profile, whatever the status says', async () => {
+    repoMocks.ordersFindByBinanceOrderId.mockResolvedValue({ profileId: 'still-owned' });
+
+    await makeAdopter().reconcileDetachedFill(eventWith('EXPIRED_IN_MATCH'));
+
+    expect(repoMocks.ordersCloseByBinanceOrderId).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/__tests__/executor/notifier-gap-throttle.test.ts
+++ b/apps/worker/__tests__/executor/notifier-gap-throttle.test.ts
@@ -7,16 +7,19 @@ import {
   createOrderFailedThrottle,
   createOrderRefusalLoopThrottle,
   createProtectiveStopBlockedThrottle,
+  createProtectiveStopUnplacedThrottle,
   DEFAULT_NOTIFIER_GAP_WINDOW_MS,
   createSymbolNotPermittedThrottle,
   DEFAULT_ORDER_FAILED_WINDOW_MS,
   DEFAULT_ORDER_REFUSAL_LOOP_WINDOW_MS,
   DEFAULT_PROTECTIVE_STOP_BLOCKED_WINDOW_MS,
+  DEFAULT_PROTECTIVE_STOP_UNPLACED_WINDOW_MS,
   DEFAULT_SYMBOL_NOT_PERMITTED_WINDOW_MS,
   ORDER_FAILED_KEY_PREFIX,
   ORDER_REFUSAL_LOOP_KEY_PREFIX,
   ORDER_UNFUNDABLE_KEY_PREFIX,
   PROTECTIVE_STOP_BLOCKED_KEY_PREFIX,
+  PROTECTIVE_STOP_UNPLACED_KEY_PREFIX,
   SYMBOL_NOT_PERMITTED_KEY_PREFIX,
 } from '../../src/executor/notifier-gap-throttle.js';
 import * as throttles from '../../src/executor/notifier-gap-throttle.js';
@@ -267,6 +270,31 @@ describe('createProtectiveStopBlockedThrottle', () => {
   });
 });
 
+describe('createProtectiveStopUnplacedThrottle', () => {
+  it('raises under its own key namespace on a one-hour window', async () => {
+    const set = vi.fn<Redis['set']>().mockResolvedValue('OK');
+    const redis = { set } as unknown as Redis;
+    const t = createProtectiveStopUnplacedThrottle({ redis, logger: fakeLogger() });
+
+    expect(await t.allow('p-1:LINKUSDT')).toBe(true);
+
+    expect(set).toHaveBeenCalledWith(
+      `${PROTECTIVE_STOP_UNPLACED_KEY_PREFIX}p-1:LINKUSDT`,
+      '1',
+      'PX',
+      DEFAULT_PROTECTIVE_STOP_UNPLACED_WINDOW_MS,
+      'NX',
+    );
+    expect(DEFAULT_PROTECTIVE_STOP_UNPLACED_WINDOW_MS).toBe(3_600_000);
+    expect(PROTECTIVE_STOP_UNPLACED_KEY_PREFIX).toBe('protective-stop-unplaced-throttle:');
+  });
+
+  it('does not share the band refusal namespace', () => {
+    // The two overlap exactly where it matters most: a coin whose stop the band refuses is also a coin with nothing resting. One shared key would let whichever fired first mute the other for the whole hour, and which one that is depends on tick order.
+    expect(PROTECTIVE_STOP_UNPLACED_KEY_PREFIX).not.toBe(PROTECTIVE_STOP_BLOCKED_KEY_PREFIX);
+  });
+});
+
 describe('per-(profile, symbol) throttle namespaces', () => {
   it('gives every (profile, symbol) window its own prefix', () => {
     // Every window here is keyed on `${profileId}:${symbol}`, some with a further
@@ -286,7 +314,7 @@ describe('per-(profile, symbol) throttle namespaces', () => {
       .flatMap((m) => Object.values(m))
       .filter((v): v is string => typeof v === 'string' && /^[a-z0-9-]+-throttle:$/.test(v));
     // A walk that finds nothing would pass the set-size assertion vacuously.
-    expect(prefixes.length).toBeGreaterThanOrEqual(8);
+    expect(prefixes.length).toBeGreaterThanOrEqual(10);
     expect(new Set(prefixes).size).toBe(prefixes.length);
   });
 });

--- a/apps/worker/__tests__/tick/build-tick-input.test.ts
+++ b/apps/worker/__tests__/tick/build-tick-input.test.ts
@@ -552,6 +552,22 @@ describe('buildTickInput', () => {
       },
     });
 
+    const baseMinimumBlocker = (resting: string | null) => ({
+      protectiveStopBlocker: {
+        reason: 'base-below-exchange-minimum',
+        detail: {
+          symbol: 'ETHUSDT',
+          required: '1',
+          free: '0.5',
+          available: '0.5',
+          held: '2',
+          stop: '100',
+          skip: 'min-notional',
+          resting,
+        },
+      },
+    });
+
     it('records the condition ONCE when the entry-blocker reason changes', async () => {
       recordSpy.mockClear();
       const stubs = makeStubs();
@@ -853,6 +869,39 @@ describe('buildTickInput', () => {
         bandBlocker({ price: '11.386' }),
         bandBlocker({ price: '11.401' }),
       );
+
+      const keys = callsFor('protective-stop-blocked').map(
+        (c) => (c as { changeKey?: string }).changeKey,
+      );
+      expect(keys).toHaveLength(2);
+      expect(keys[1]).toBe(keys[0]);
+    });
+
+    it('C1: moves the changeKey when a base-minimum blocker loses its resting stop', async () => {
+      // A resting stop covers the position even when the next arm is below Binance's minimum, so its cancellation must reach the activity feed.
+      recordSpy.mockClear();
+      const stubs = makeStubs();
+      await builtCommit(stubs, 'RESTINGFLIPUSDT', baseMinimumBlocker('2'), baseMinimumBlocker('2'));
+      await builtCommit(
+        stubs,
+        'RESTINGFLIPUSDT',
+        baseMinimumBlocker('2'),
+        baseMinimumBlocker(null),
+      );
+
+      const keys = callsFor('protective-stop-blocked').map(
+        (c) => (c as { changeKey?: string }).changeKey,
+      );
+      expect(keys).toHaveLength(2);
+      expect(keys[1]).not.toBe(keys[0]);
+    });
+
+    it('C1: holds the changeKey steady while a resting stop partially fills', async () => {
+      // The quantity changes as the stop fills, but presence is unchanged, so keying on quantity would create write amplification on every fill.
+      recordSpy.mockClear();
+      const stubs = makeStubs();
+      await builtCommit(stubs, 'PARTIALFILLUSDT', baseMinimumBlocker('2'), baseMinimumBlocker('2'));
+      await builtCommit(stubs, 'PARTIALFILLUSDT', baseMinimumBlocker('2'), baseMinimumBlocker('1'));
 
       const keys = callsFor('protective-stop-blocked').map(
         (c) => (c as { changeKey?: string }).changeKey,

--- a/apps/worker/__tests__/tick/tick-handler-protective-stop-unplaced-alert.test.ts
+++ b/apps/worker/__tests__/tick/tick-handler-protective-stop-unplaced-alert.test.ts
@@ -1,0 +1,304 @@
+// A held position with no protective stop resting on Binance produces nothing to alert on: no order was rejected, no exit was refused, and the strategy reports it as an ordinary exit blocker on every tick.
+//
+// One tick of that is normal — the stop goes on next tick. The SAME span still open a quarter of an hour later means every arm has been refused since, and the position has been sitting with nothing under it that whole time. Only the duration separates the two, so only the duration can decide whether the operator's phone rings.
+//
+// The span start comes from the `exit-blocked` condition row, which keeps `since` while the code is unchanged and restarts it when the code changes. That makes it an exact persistence clock, and the only one the tick can read.
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Job } from 'bullmq';
+import type { MarketDataPort } from '@app/binance';
+import { createRegistry, type Strategy, type SymbolInfo } from '@app/strategy-core';
+import { z } from 'zod';
+import {
+  asAccountId,
+  asProfileId,
+  asUserId,
+  PROTECTIVE_STOP_UNPLACED_PERSISTENCE_MS,
+} from '@app/contracts';
+
+// The audit wrapper resolves its condition writer off the scope, and the span start it reports back is what the persistence window is measured from. Mock the binding so each test can hand the tick a span of a chosen age, or a swallowed write, without a real Postgres.
+const recordSpy = vi.fn(async (_input: { condition: string }) => ({
+  changed: true as const,
+  previousCode: null,
+  sinceMs: 0,
+}));
+vi.mock('@app/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@app/db')>();
+  return {
+    ...actual,
+    profileRepoFromScope: () => ({ conditionStates: { recordCondition: recordSpy } }),
+  };
+});
+
+import { createChainByKey } from '../../src/lib/chain-by-key.js';
+import { createTickHandler, type TickHandlerDeps } from '../../src/tick/tick-handler.js';
+import type { ProfileTickContext } from '../../src/tick/build-tick-input.js';
+import type { TickJobData } from '../../src/queues/job-payloads.js';
+
+const OPERATOR = asUserId('11111111-1111-4111-8111-111111111111');
+const ACCOUNT = asAccountId('33333333-3333-4333-8333-333333333333');
+const PROFILE = asProfileId('22222222-2222-4222-8222-222222222222');
+const SYMBOL = 'LINKUSDT';
+const NOW_MS = 1_770_000_000_000;
+// How long a position may sit with no resting protective stop before the state stops being the tick after a fresh entry and becomes a naked position.
+const UNPLACED_PERSIST_MS = PROTECTIVE_STOP_UNPLACED_PERSISTENCE_MS;
+// Distinctive so an assertion proves the payload came from the state this tick computed. The stored condition row's `detail` froze at the moment the span opened, so on a span this old it names a stop price the strategy has long since moved past.
+const WANTED_STOP = '11.5511';
+
+const SYMBOL_INFO: SymbolInfo = {
+  symbol: SYMBOL,
+  baseAsset: 'LINK',
+  quoteAsset: 'USDT',
+  status: 'TRADING',
+  filters: {
+    minQty: '0.01',
+    stepSize: '0.01',
+    minNotional: '10',
+    tickSize: '0.001',
+    maxQty: '1000000',
+    minPrice: '0.00000001',
+    maxPrice: '100000000',
+  },
+};
+
+const unplacedState = () => ({
+  schemaVersion: '1.0.0',
+  exitBlocker: {
+    reason: 'protective-stop-unplaced',
+    changeKey: 'unplaced',
+    detail: { stop: WANTED_STOP },
+  },
+});
+
+const buildStubStrategy = (nextState: unknown): Strategy =>
+  ({
+    name: 'stub-protective-stop-unplaced',
+    version: '1.0.0',
+    displayName: 'stub',
+    description: 'stub',
+    capabilities: {
+      candleIntervals: ['1h'],
+      needsUserDataStream: false,
+      needsMiniTicker: false,
+      bundleProviders: [],
+      operatorActions: [],
+    },
+    bundleSchema: z.object({}),
+    initialState: () => ({ schemaVersion: '1.0.0' }),
+    // No decisions: the whole point is that nothing is placed, so nothing fails and no existing alert path can fire.
+    tick: () => ({ nextState, decisions: [], logs: [], metrics: [] }),
+  }) as unknown as Strategy;
+
+// What the alert has to carry for the operator to act without opening the dashboard: which coin, how long it has been naked, and the stop the strategy wanted. Derived from the shipped dep rather than restated, because the whole deps object is cast to `TickHandlerDeps` and a hand-written copy is checked against nothing: this file exists to prove the alert never fires on an undated span, and a local `sinceMs: number | null` would quietly assert a wider contract than the one that ships.
+type NotifyProtectiveStopUnplacedInput = Parameters<
+  NonNullable<TickHandlerDeps['notifyProtectiveStopUnplaced']>
+>[0];
+
+interface RunOpts {
+  readonly nextState: unknown;
+  /** When the `exit-blocked` span this tick's blocker belongs to opened. `null` = the write was lost. */
+  readonly sinceMs: number | null;
+}
+
+const run = async (opts: RunOpts) => {
+  recordSpy.mockReset();
+  // Keyed on the condition: the tick audits three blockers per pass, and only the `exit-blocked` row dates the span this alert measures.
+  recordSpy.mockImplementation(async (input: { condition: string }) =>
+    input.condition === 'exit-blocked' && opts.sinceMs === null
+      ? Promise.reject(new Error('write timeout'))
+      : { changed: true as const, previousCode: null, sinceMs: opts.sinceMs ?? 0 },
+  );
+
+  // Not async: an async wrapper would turn a synchronous throw in the real dep into a rejection, hiding the one shape the fire-and-forget guard must catch.
+  const notifyProtectiveStopUnplaced = vi.fn((_input: NotifyProtectiveStopUnplacedInput) =>
+    Promise.resolve(undefined),
+  );
+  // The sibling alert, wired on every run so the suppression cases can read whether it went out rather than inferring it from the state they passed in.
+  const notifyProtectiveStopBlocked = vi.fn((_input: unknown) => Promise.resolve(undefined));
+
+  const makeChain = (keys: string[]) => {
+    const chain = {
+      get(key: string) {
+        keys.push(key);
+        return chain;
+      },
+      exec: async () => keys.map(() => [null, null] as const),
+    };
+    return chain;
+  };
+  const redis = {
+    pipeline: () => makeChain([]),
+    exists: async () => 0,
+    set: async () => 'OK',
+    del: async () => 1,
+  } as unknown as import('ioredis').Redis;
+
+  const registry = createRegistry();
+  registry.register(buildStubStrategy(opts.nextState));
+
+  const profile = {
+    operatorId: OPERATOR,
+    accountId: ACCOUNT,
+    profileId: PROFILE,
+    scope: { operatorId: OPERATOR, accountId: ACCOUNT, profileId: PROFILE },
+    symbol: SYMBOL,
+    strategyName: 'stub-protective-stop-unplaced',
+    strategyVersion: '1.0.0',
+    config: {},
+    bundleProvider: async () => ({ bundle: {} }),
+    binanceMode: 'test',
+    quoteAsset: 'USDT',
+    weightLimit1m: 1200,
+    candleInterval: '1h',
+    technicalsConfig: { useOnlyWithinMin: 2, ifExpires: 'do-not-buy', intervals: [] },
+    needsAccountDeployedQuote: false,
+  } as unknown as ProfileTickContext;
+
+  const deps = {
+    redis,
+    registry,
+    executor: { applyAll: async () => [] },
+    chain: createChainByKey(),
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    coldLoad: {
+      loadAccount: async () => ({ balances: {} }),
+      loadAccountDeployedQuote: async () => '0',
+      loadOpenOrders: async () => [],
+      loadSymbolState: async () => null,
+    },
+    symbolInfoCache: { get: async () => SYMBOL_INFO },
+    statePort: {
+      loadForTick: async () => ({
+        state: { schemaVersion: '1.0.0' },
+        commit: async () => undefined,
+      }),
+    },
+    marketDataPort: { loadWindow: async () => [] } as unknown as MarketDataPort,
+    resolveProfile: async () => profile,
+    auditShipper: { publish: async () => undefined },
+    clock: { nowMs: () => NOW_MS },
+    notifyProtectiveStopUnplaced,
+    notifyProtectiveStopBlocked,
+  } as unknown as TickHandlerDeps;
+
+  const job = {
+    data: {
+      userId: String(OPERATOR),
+      accountId: String(ACCOUNT),
+      profileId: String(PROFILE),
+      symbol: SYMBOL,
+      event: 'resync',
+      enqueuedAtMs: 0,
+      payload: {},
+    } satisfies TickJobData,
+  } as unknown as Job<TickJobData>;
+
+  await createTickHandler(deps)(job);
+  // The notify is fire-and-forget, so a bare `not.toHaveBeenCalled()` would pass before the call it is meant to catch had a chance to land. Drain the microtask+macrotask queues first and every assertion below reads a settled state, whether it expects a call or the absence of one.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return { notifyProtectiveStopUnplaced, notifyProtectiveStopBlocked };
+};
+
+/** The band refusal the sibling alert covers, carried alongside the unplaced exit blocker: one coin, both records, which is the ordinary shape when the band is what keeps the stop from landing. */
+const bandBlocker = (guarded: boolean) => ({
+  reason: 'price-outside-exchange-band',
+  detail: {
+    symbol: SYMBOL,
+    stopPrice: WANTED_STOP,
+    price: '11.386',
+    reference: '12.7',
+    floor: '11.43',
+    ceiling: '25.4',
+    bound: 'floor',
+    terminal: false,
+    guarded,
+  },
+});
+
+describe('tick handler — a position left with no protective stop reaches the operator', () => {
+  it('raises once the coin has held the whole window with nothing resting under it', async () => {
+    // Exactly at the boundary, because the gate is inclusive: the alternative is a strict comparison that a span landing on the window silently falls through.
+    const { notifyProtectiveStopUnplaced } = await run({
+      nextState: unplacedState(),
+      sinceMs: NOW_MS - UNPLACED_PERSIST_MS,
+    });
+
+    // Pinned to the literal, not to the constant, so a shipped threshold that drifts fails here rather than silently moving every case in this file with it.
+    expect(PROTECTIVE_STOP_UNPLACED_PERSISTENCE_MS).toBe(900_000);
+    expect(notifyProtectiveStopUnplaced).toHaveBeenCalledTimes(1);
+    expect(notifyProtectiveStopUnplaced).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operatorId: OPERATOR,
+        accountId: ACCOUNT,
+        profileId: PROFILE,
+        symbol: SYMBOL,
+        sinceMs: NOW_MS - UNPLACED_PERSIST_MS,
+        detail: expect.objectContaining({ stop: WANTED_STOP }),
+      }),
+    );
+  });
+
+  it('stays silent on the tick right after an entry, before the window has run', async () => {
+    // The noise guard. One millisecond short of the window is the ordinary case the strategy reports on every fresh entry, and paging on it would make the channel unreadable long before the naked case arrives.
+    const { notifyProtectiveStopUnplaced } = await run({
+      nextState: unplacedState(),
+      sinceMs: NOW_MS - (UNPLACED_PERSIST_MS - 1),
+    });
+
+    expect(notifyProtectiveStopUnplaced).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the span start is unknown', async () => {
+    // Fails CLOSED, unlike the terminal band refusal that fires on an unknown age. The whole premise here is that the state has already outlasted the window, and a lost condition write is no evidence of that: firing anyway would page on a first-tick entry every time Postgres hiccups.
+    const { notifyProtectiveStopUnplaced } = await run({
+      nextState: unplacedState(),
+      sinceMs: null,
+    });
+
+    expect(notifyProtectiveStopUnplaced).not.toHaveBeenCalled();
+  });
+
+  it('stays silent on an exit blocker that is not the unplaced stop, however long it has held', async () => {
+    // A resting priced stop is the healthy steady state and never ends, so a handler keyed on `exit-blocked` alone rather than on the code would alert forever on every guarded position.
+    const { notifyProtectiveStopUnplaced } = await run({
+      nextState: {
+        schemaVersion: '1.0.0',
+        exitBlocker: {
+          reason: 'priced-stop-resting',
+          changeKey: `priced|stop=${WANTED_STOP}`,
+          detail: { stop: WANTED_STOP },
+        },
+      },
+      sinceMs: NOW_MS - UNPLACED_PERSIST_MS * 10,
+    });
+
+    expect(notifyProtectiveStopUnplaced).not.toHaveBeenCalled();
+  });
+
+  it('pages once, not twice, when the band alert already went out this tick', async () => {
+    // Both records describe one unguarded coin. The band alert names the cause and carries the more specific instruction, so it is the one that survives; a second alert about the same position would train the operator to skim the channel.
+    const { notifyProtectiveStopUnplaced, notifyProtectiveStopBlocked } = await run({
+      nextState: { ...unplacedState(), protectiveStopBlocker: bandBlocker(false) },
+      sinceMs: NOW_MS - UNPLACED_PERSIST_MS,
+    });
+
+    expect(notifyProtectiveStopBlocked).toHaveBeenCalledTimes(1);
+    expect(notifyProtectiveStopUnplaced).not.toHaveBeenCalled();
+  });
+
+  it('still raises when a band record exists but its own gate did not pass', async () => {
+    // Suppression has to key on the band alert having FIRED, not on a band record existing. A guarded refusal is one the sibling alert deliberately stays silent on, and reading the record alone would let it mute this one on a coin nobody was ever told about.
+    const { notifyProtectiveStopUnplaced, notifyProtectiveStopBlocked } = await run({
+      nextState: { ...unplacedState(), protectiveStopBlocker: bandBlocker(true) },
+      sinceMs: NOW_MS - UNPLACED_PERSIST_MS,
+    });
+
+    expect(notifyProtectiveStopBlocked).not.toHaveBeenCalled();
+    expect(notifyProtectiveStopUnplaced).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/worker/src/boot/boot-context.ts
+++ b/apps/worker/src/boot/boot-context.ts
@@ -273,6 +273,7 @@ export const buildBootContext = async (env: BootEnv): Promise<BootContext> => {
     orderFailedThrottle,
     orderRefusalLoopThrottle,
     protectiveStopBlockedThrottle,
+    protectiveStopUnplacedThrottle,
     notifyEvent,
   } = buildNotifiers({ db, redis, logger, liveDemo, queueSet });
 
@@ -389,6 +390,7 @@ export const buildBootContext = async (env: BootEnv): Promise<BootContext> => {
     orderFailedThrottle,
     orderRefusalLoopThrottle,
     protectiveStopBlockedThrottle,
+    protectiveStopUnplacedThrottle,
     auditShipper,
   });
 

--- a/apps/worker/src/boot/builders/notifiers.ts
+++ b/apps/worker/src/boot/builders/notifiers.ts
@@ -17,6 +17,7 @@ import {
   createOrderFailedThrottle,
   createOrderRefusalLoopThrottle,
   createProtectiveStopBlockedThrottle,
+  createProtectiveStopUnplacedThrottle,
   type NotifierGapThrottle,
 } from 'executor/notifier-gap-throttle.js';
 import {
@@ -42,6 +43,7 @@ export interface Notifiers {
   readonly orderFailedThrottle: ReturnType<typeof createOrderFailedThrottle>;
   readonly orderRefusalLoopThrottle: ReturnType<typeof createOrderRefusalLoopThrottle>;
   readonly protectiveStopBlockedThrottle: ReturnType<typeof createProtectiveStopBlockedThrottle>;
+  readonly protectiveStopUnplacedThrottle: ReturnType<typeof createProtectiveStopUnplacedThrottle>;
   readonly notifyEvent: NotifyEvent;
 }
 
@@ -78,6 +80,8 @@ export const buildNotifiers = ({
   // so it raises no placement failure, and sharing that key would let one cause
   // mute the other for the whole window.
   const protectiveStopBlockedThrottle = createProtectiveStopBlockedThrottle({ redis, logger });
+  // A fourth namespace, and specifically not the one above: the two alerts are keyed identically, so one shared key would let a band refusal mute the naked-position alert for the whole hour, or the reverse.
+  const protectiveStopUnplacedThrottle = createProtectiveStopUnplacedThrottle({ redis, logger });
   const notifyEvent = createNotifyEvent({
     db,
     notifyProviders: notifyProvidersRegistry,
@@ -147,6 +151,7 @@ export const buildNotifiers = ({
     orderFailedThrottle,
     orderRefusalLoopThrottle,
     protectiveStopBlockedThrottle,
+    protectiveStopUnplacedThrottle,
     notifyEvent,
   };
 };

--- a/apps/worker/src/boot/builders/tick-handler.ts
+++ b/apps/worker/src/boot/builders/tick-handler.ts
@@ -10,8 +10,7 @@ import type { Redis } from 'ioredis';
 
 import { humanizeDuration } from '@app/contracts';
 import { GLOBAL_KEYS, profileRepoFromScope, type Database } from '@app/db';
-import { Decimal } from '@app/money';
-import { explainProtectiveStopBandRefusal } from '@app/strategy-core';
+import { asPercent, explainProtectiveStopBandRefusal } from '@app/strategy-core';
 
 import { strategies as strategiesRegistry } from 'strategies.js';
 import {
@@ -45,24 +44,6 @@ const ORDER_ACTION_LABEL: Record<'place-order' | 'cancel-order' | 'replace-order
   'place-order': 'Place order',
   'cancel-order': 'Cancel order',
   'replace-order': 'Replace order',
-};
-
-/**
- * Render a strategy's fractional distance as the percent the operator's own settings screen shows, or null when it is not a usable number.
- *
- * The strategies store these as fractions and the settings form displays percent, so quoting the stored value verbatim would name a number the operator cannot find on any screen. Total by construction: the bag it reads survives a JSON round-trip, and this feeds operator copy, where a throw is worse than a missing clause and the string `undefined` is worse than both.
- *
- * @param raw - A fraction of 1 as the strategy recorded it, typically a decimal string, but untrusted.
- * @returns The same distance in percent, two places and never exponential, or null when the input is absent, not a string, or unparseable.
- */
-const asPercent = (raw: unknown): string | null => {
-  if (typeof raw !== 'string') return null;
-  try {
-    const value = new Decimal(raw);
-    return value.isFinite() ? `${value.mul(100).toDecimalPlaces(2).toFixed()}%` : null;
-  } catch {
-    return null;
-  }
 };
 
 export interface TickHandlerDeps {

--- a/apps/worker/src/boot/builders/tick-handler.ts
+++ b/apps/worker/src/boot/builders/tick-handler.ts
@@ -10,6 +10,7 @@ import type { Redis } from 'ioredis';
 
 import { humanizeDuration } from '@app/contracts';
 import { GLOBAL_KEYS, profileRepoFromScope, type Database } from '@app/db';
+import { Decimal } from '@app/money';
 import { explainProtectiveStopBandRefusal } from '@app/strategy-core';
 
 import { strategies as strategiesRegistry } from 'strategies.js';
@@ -39,6 +40,31 @@ import type { MetricsSink } from 'metrics/catalog.js';
 import type { Notifiers } from './notifiers.js';
 import type { Audit } from './audit.js';
 
+/** Operator-facing name of the order decision an `order-failed` alert is about. */
+const ORDER_ACTION_LABEL: Record<'place-order' | 'cancel-order' | 'replace-order', string> = {
+  'place-order': 'Place order',
+  'cancel-order': 'Cancel order',
+  'replace-order': 'Replace order',
+};
+
+/**
+ * Render a strategy's fractional distance as the percent the operator's own settings screen shows, or null when it is not a usable number.
+ *
+ * The strategies store these as fractions and the settings form displays percent, so quoting the stored value verbatim would name a number the operator cannot find on any screen. Total by construction: the bag it reads survives a JSON round-trip, and this feeds operator copy, where a throw is worse than a missing clause and the string `undefined` is worse than both.
+ *
+ * @param raw - A fraction of 1 as the strategy recorded it, typically a decimal string, but untrusted.
+ * @returns The same distance in percent, two places and never exponential, or null when the input is absent, not a string, or unparseable.
+ */
+const asPercent = (raw: unknown): string | null => {
+  if (typeof raw !== 'string') return null;
+  try {
+    const value = new Decimal(raw);
+    return value.isFinite() ? `${value.mul(100).toDecimalPlaces(2).toFixed()}%` : null;
+  } catch {
+    return null;
+  }
+};
+
 export interface TickHandlerDeps {
   readonly env: BootEnv;
   readonly db: Database;
@@ -56,6 +82,7 @@ export interface TickHandlerDeps {
   readonly orderFailedThrottle: Notifiers['orderFailedThrottle'];
   readonly orderRefusalLoopThrottle: Notifiers['orderRefusalLoopThrottle'];
   readonly protectiveStopBlockedThrottle: Notifiers['protectiveStopBlockedThrottle'];
+  readonly protectiveStopUnplacedThrottle: Notifiers['protectiveStopUnplacedThrottle'];
   readonly auditShipper: Audit['auditShipper'];
 }
 
@@ -81,6 +108,7 @@ export const buildTickHandler = ({
   orderFailedThrottle,
   orderRefusalLoopThrottle,
   protectiveStopBlockedThrottle,
+  protectiveStopUnplacedThrottle,
   auditShipper,
 }: TickHandlerDeps): TickHandlerSlice => {
   const bundleProvider = createTickBundleProvider({ redis, logger });
@@ -196,15 +224,7 @@ export const buildTickHandler = ({
         // A repeated structural refusal moves to the dedicated once-per-minute probe.
         body,
         fields: [
-          {
-            label: 'Action',
-            value:
-              input.decisionType === 'place-order'
-                ? 'Place order'
-                : input.decisionType === 'replace-order'
-                  ? 'Replace order'
-                  : 'Cancel order',
-          },
+          { label: 'Action', value: ORDER_ACTION_LABEL[input.decisionType] },
           { label: 'Reason', value: input.result.reason },
         ],
       });
@@ -237,6 +257,13 @@ export const buildTickHandler = ({
     // burning every tick on an order it knows will be refused. The position can
     // therefore sit with nothing under it while every screen looks normal.
     notifyProtectiveStopBlocked: async (input) => {
+      // The words come from the strategy package that owns the refusal, and the
+      // symbol screen reads the same ones. An operator who checks the phone alert
+      // and then the app must not find two explanations of one block, and copy
+      // maintained in two files is how that happened.
+      //
+      // Built BEFORE the window is opened: a `detail` this builder cannot read would otherwise throw after the throttle key is already set, losing the alert AND suppressing every later one for the rest of the hour. Consume the window only once there is a message to consume it for.
+      const copy = explainProtectiveStopBandRefusal(input.detail);
       // The escalation level is part of the key, same split as the order-failed
       // retry/final levels: "wait for the price to come back" and "no price ever
       // arms this stop" are different instructions, and the recoverable one
@@ -245,11 +272,6 @@ export const buildTickHandler = ({
         `${input.profileId}:${input.symbol}:${input.terminal ? 'terminal' : 'persistent'}`,
       );
       if (!allowed) return;
-      // The words come from the strategy package that owns the refusal, and the
-      // symbol screen reads the same ones. An operator who checks the phone alert
-      // and then the app must not find two explanations of one block, and copy
-      // maintained in two files is how that happened.
-      const copy = explainProtectiveStopBandRefusal(input.detail);
       await notifyEvent({
         category: 'order-failed',
         operatorId: input.operatorId,
@@ -284,6 +306,45 @@ export const buildTickHandler = ({
           ...(input.sinceMs === null
             ? []
             : [{ label: 'Blocked for', value: humanizeDuration(Date.now() - input.sinceMs) }]),
+        ],
+      });
+    },
+    // The outcome rather than a cause: whatever has been stopping the stop from landing, this position has had nothing on the exchange under it for long enough that it cannot be the moment after an entry any more. `order-failed` already describes exactly this — a protective stop that never reached the exchange, leaving the position unguarded — is severity `error`, and is on by default, so the alert the operator most needs is not behind a switch they have to find first.
+    notifyProtectiveStopUnplaced: async (input) => {
+      // The bag crossed a JSON round-trip to get here, so its declared shape is a claim rather than a guarantee; substituting once keeps every read below total, including the ones inside the send.
+      const detail = input.detail ?? {};
+      // Whether the trail distance can be quoted is decided BEFORE the window opens, because parsing it is the one step in this alert that reads a value it did not compute. Nothing between the throttle and the send may throw: a throw under an already-consumed key loses this alert and mutes the next hour of them too.
+      const refusedTrail =
+        detail['nativeUnavailable'] === true ? asPercent(detail['distancePct']) : null;
+      // No escalation dimension in the key, unlike the band alert: there is one thing to say here and one hour to say it in, per coin.
+      const allowed = await protectiveStopUnplacedThrottle.allow(
+        `${input.profileId}:${input.symbol}`,
+      );
+      if (!allowed) return;
+      const unprotectedFor = humanizeDuration(Date.now() - input.sinceMs);
+      await notifyEvent({
+        category: 'order-failed',
+        operatorId: input.operatorId,
+        accountId: input.accountId,
+        profileId: input.profileId,
+        symbol: input.symbol,
+        // Says what is true right now before it says what to do: an operator reading this on a phone has to know within one line whether money is exposed.
+        body: `This position has had no protective stop on Binance for ${unprotectedFor}. Nothing on the exchange will sell it if the price falls. Check whether another order is holding the coins, and whether Binance will accept a stop at the price your settings ask for.`,
+        fields: [
+          { label: 'Unprotected for', value: unprotectedFor },
+          // The stop the strategy wanted this tick, quoted from its own live record: it is the number the operator compares against the symbol's price band when working out why nothing lands.
+          ...(typeof detail['stop'] === 'string'
+            ? [{ label: 'Wanted stop', value: detail['stop'] }]
+            : []),
+          // The one cause the body cannot guess at. A profile trailing its stop on Binance itself is refused outright when the symbol's own filter has no step matching the distance asked for, and no price move ever clears that — so the generic "check whether Binance will accept a stop at your price" sends this operator hunting in the wrong place. Named here with both levers, because either one alone resolves it.
+          ...(detail['nativeUnavailable'] === true
+            ? [
+                {
+                  label: 'Why',
+                  value: `Binance will not accept a trailing stop — one that follows the price up and sells when it drops back — ${refusedTrail === null ? 'at the distance your settings ask for' : `${refusedTrail} below the high`} on this coin. Switch this profile's protective stop mode to priced, or change the distance.`,
+                },
+              ]
+            : []),
         ],
       });
     },

--- a/apps/worker/src/executor/fill-adopter.ts
+++ b/apps/worker/src/executor/fill-adopter.ts
@@ -69,6 +69,7 @@ import {
 } from '@app/db';
 import {
   asDecimalString,
+  isTerminalOrderStatus,
   unwrapId,
   type AccountId,
   type ProfileId,
@@ -198,10 +199,6 @@ export interface DetachedOrderEvent {
   readonly cumQuoteQty: string;
   readonly eventTimeMs: number;
 }
-
-// Binance states that mean the order has left the book for good. Only these close
-// the row: a PARTIALLY_FILLED / NEW report says the order is still live.
-const TERMINAL_STATUSES = new Set(['FILLED', 'CANCELED', 'EXPIRED', 'REJECTED']);
 
 export const createFillAdopter = (deps: FillAdopterDeps): FillAdopter => {
   const adopt = async (event: FillEvent): Promise<void> => {
@@ -500,7 +497,8 @@ export const createFillAdopter = (deps: FillAdopterDeps): FillAdopter => {
   };
 
   const reconcileDetachedFill = async (event: DetachedOrderEvent): Promise<void> => {
-    if (!TERMINAL_STATUSES.has(event.orderStatus)) return;
+    // The shared `@app/contracts` predicate, never a local copy: this row's `closed_at` stamp, the open-orders cache eviction and the boot reaper all answer "has the order left the book?" and must answer it the same way. A four-member local set omitted `EXPIRED_IN_MATCH` — the status Binance stamps when self-trade prevention kills an order, which on a shared account wallet is what a sibling profile's BUY crossing our resting SELL produces — so an STP-terminated detached row was never closed: it held its live intent slot and counted toward the account's open exposure forever. A still-resting report (NEW / PARTIALLY_FILLED) passes through untouched, and an unrecognised status fails closed the same way.
+    if (!isTerminalOrderStatus(event.orderStatus)) return;
     // Account scope, not profile scope: a detached row is reachable only by
     // account, and `scopeAccount` proves the operator owns it.
     const orders = accountRepoFromScope(

--- a/apps/worker/src/executor/fill-adopter.ts
+++ b/apps/worker/src/executor/fill-adopter.ts
@@ -87,6 +87,7 @@ import type { ChainByKey } from 'lib/chain-by-key.js';
 import type { StatePort } from 'state/state-port.js';
 import type { SymbolInfoCache } from 'tick/symbol-info-cache.js';
 import type { NotifyEvent } from 'notifiers/notify-event.js';
+import { executedSomething } from './decisions/cancel-order.js';
 
 /**
  * Minimal registry view: resolves the position-mutation capability for a
@@ -528,10 +529,21 @@ export const createFillAdopter = (deps: FillAdopterDeps): FillAdopter => {
             { executedQty: event.cumQty, cummulativeQuoteQty: event.cumQuoteQty },
             event.eventTimeMs,
           )
-        : await orders.closeByBinanceOrderId(
+        : // A terminal status other than FILLED is not proof nothing executed. Under self-trade prevention Binance can match part of an order against unrelated makers and expire the remainder as `EXPIRED_IN_MATCH`, and a cancel can land on a partly-filled order the same way, so `cumQty` may be above zero here. The plain close writes only `status` and `closed_at`, and the detached path never sees the `PARTIALLY_FILLED` reports that would have refreshed `raw` (they return at the terminal gate above), so the row would keep whatever placement wrote, `executedQty: '0'` for a resting stop. That records no coins moving on an order that moved coins.
+          //
+          // Merged here rather than in the repo: `closeByBinanceOrderId` OVERWRITES `raw`, which is what its only other caller wants (it supplies a full fresh snapshot from `getOrder`), and this event carries two fields rather than a snapshot. Reading the row we already fetched and spreading over it keeps `clientOrderId` / `transactTime` / `fills`. The read-modify-write is safe because the write is guarded by `closed_at IS NULL`, so exactly one of the N-active-profiles fan-out lands, and every one of them carries the same totals.
+          await orders.closeByBinanceOrderId(
             BigInt(event.orderId),
             event.orderStatus,
             event.eventTimeMs,
+            executedSomething(event.cumQty)
+              ? {
+                  ...(typeof row.raw === 'object' && row.raw !== null ? row.raw : {}),
+                  status: event.orderStatus,
+                  executedQty: event.cumQty,
+                  cummulativeQuoteQty: event.cumQuoteQty,
+                }
+              : undefined,
           );
 
     // No realised-P/L stamp: the cost basis lived on the deleted profile's ledger,

--- a/apps/worker/src/executor/fill-adopter.ts
+++ b/apps/worker/src/executor/fill-adopter.ts
@@ -498,7 +498,10 @@ export const createFillAdopter = (deps: FillAdopterDeps): FillAdopter => {
 
   const reconcileDetachedFill = async (event: DetachedOrderEvent): Promise<void> => {
     // The shared `@app/contracts` predicate, never a local copy: this row's `closed_at` stamp, the open-orders cache eviction and the boot reaper all answer "has the order left the book?" and must answer it the same way. A four-member local set omitted `EXPIRED_IN_MATCH` — the status Binance stamps when self-trade prevention kills an order, which on a shared account wallet is what a sibling profile's BUY crossing our resting SELL produces — so an STP-terminated detached row was never closed: it held its live intent slot and counted toward the account's open exposure forever. A still-resting report (NEW / PARTIALLY_FILLED) passes through untouched, and an unrecognised status fails closed the same way.
-    if (!isTerminalOrderStatus(event.orderStatus)) return;
+    //
+    // Folded once, here, because the two decisions below have to agree: `isTerminalOrderStatus` case-folds and the `FILLED` routing test is a strict compare, so an off-case spelling would pass the gate and then take the plain close, which does not merge the execution totals into `raw` and would leave the row's executedQty wrong. Both producers pass Binance's own string through with `orderStatus` typed as `string`, and Binance has always sent these upper, so this is the asymmetry closed rather than a reachable defect. The exchange's original spelling is what still lands on the row.
+    const status = event.orderStatus.toUpperCase();
+    if (!isTerminalOrderStatus(status)) return;
     // Account scope, not profile scope: a detached row is reachable only by
     // account, and `scopeAccount` proves the operator owns it.
     const orders = accountRepoFromScope(
@@ -516,7 +519,7 @@ export const createFillAdopter = (deps: FillAdopterDeps): FillAdopter => {
     if (!row || row.profileId !== null) return;
 
     const closed =
-      event.orderStatus === 'FILLED'
+      status === 'FILLED'
         ? // FILLED gets the exchange's true totals merged into `raw` so the row's
           // executedQty is honest, exactly as an adopted fill would. Idempotent
           // (`status <> 'FILLED'`), so the N-active-profiles fan-out settles once.

--- a/apps/worker/src/executor/notifier-gap-throttle.ts
+++ b/apps/worker/src/executor/notifier-gap-throttle.ts
@@ -241,6 +241,28 @@ export const createProtectiveStopBlockedThrottle = (
   });
 
 /**
+ * Suppression window for the `protective-stop-unplaced` alert. The position is held, nothing is resting on the exchange to sell it, and the strategy re-reports that on every tick, so the repeat shape is the same one the windows above exist for. Keyed `(profile, symbol)` with no escalation dimension: unlike the band refusal there is only one thing to say here — nothing is guarding this coin — and only one remedy path, so a second level would split one message in half.
+ *
+ * The key carries no identity for the SPAN either, and that is accepted rather than overlooked: if a stop lands and the coin goes naked again inside the hour, the second span stays silent for the rest of the window. Per-coin hourly is exactly what that means. The second alert would say the same sentence about the same coin and ask for the same check, differing only in a smaller "unprotected for" number, so keying on the span would page the operator a second time about something they were told within the hour.
+ *
+ * Deliberately NOT {@link PROTECTIVE_STOP_BLOCKED_KEY_PREFIX}. Both windows are keyed `(profile, symbol)`, so sharing a prefix would make them one Redis key, and the two causes overlap in exactly the situation that matters most: a band refusal on a coin that has nothing resting is also a coin with nothing resting. Whichever fired first would mute the other for the whole hour, and the one that gets muted is unpredictable. The tick suppresses the second alert on the tick where both fire; that is a decision taken with both facts in hand, which a shared key cannot be.
+ */
+export const DEFAULT_PROTECTIVE_STOP_UNPLACED_WINDOW_MS = 3_600_000;
+
+export const PROTECTIVE_STOP_UNPLACED_KEY_PREFIX = 'protective-stop-unplaced-throttle:';
+
+export const createProtectiveStopUnplacedThrottle = (
+  deps: NotifierGapThrottleDeps,
+): NotifierGapThrottle =>
+  createRedisWindowThrottle({
+    redis: deps.redis,
+    logger: deps.logger,
+    prefix: PROTECTIVE_STOP_UNPLACED_KEY_PREFIX,
+    windowMs: deps.windowMs ?? DEFAULT_PROTECTIVE_STOP_UNPLACED_WINDOW_MS,
+    ...(deps.setTimeoutMs === undefined ? {} : { setTimeoutMs: deps.setTimeoutMs }),
+  });
+
+/**
  * The two tick-boundary self-heal records. Named here, beside the executor's
  * prefixes, because that adjacency is what makes a collision visible: these
  * windows are all keyed `(profile, symbol)`, so two sharing a prefix would share

--- a/apps/worker/src/tick/build-tick-input.ts
+++ b/apps/worker/src/tick/build-tick-input.ts
@@ -239,6 +239,7 @@ const readStateBlocker = (state: unknown, field: string): BlockerShape | null =>
  * amplification and feed spam, not a lost span: `recordCondition` restarts
  * `since` only when the CODE changes, so a moving key under one unchanged reason
  * always carries the span over.
+ * For the resting stop, the key carries presence rather than its quantity, because partial fills would otherwise create write amplification on every tick.
  *
  * The key is still load-bearing. Without it the writer compares codes alone, so
  * a `guarded` → naked flip under the same reason is dropped as a no-op: `detail`
@@ -257,7 +258,8 @@ const protectiveStopChangeKey = (blocker: BlockerShape): string => {
   const detail: Readonly<Record<string, unknown>> = blocker.detail ?? {};
   const flag = (name: string) => (detail[name] === true ? name : `not-${name}`);
   const bound = typeof detail['bound'] === 'string' ? detail['bound'] : 'unknown';
-  return [blocker.reason, bound, flag('guarded'), flag('terminal')].join('|');
+  const resting = typeof detail['resting'] === 'string' ? 'resting' : 'naked';
+  return [blocker.reason, bound, flag('guarded'), flag('terminal'), resting].join('|');
 };
 
 /**

--- a/apps/worker/src/tick/tick-handler.ts
+++ b/apps/worker/src/tick/tick-handler.ts
@@ -24,6 +24,8 @@ import {
   asProfileId,
   asUserId,
   ENTRY_HALT_REASONS,
+  PROTECTIVE_STOP_UNPLACED_CODE,
+  PROTECTIVE_STOP_UNPLACED_PERSISTENCE_MS,
   type ManualOverridePayload,
 } from '@app/contracts';
 import { entryHaltKeys } from '@app/db';
@@ -132,6 +134,24 @@ const readProtectiveStopBlocker = (state: unknown): ProtectiveStopBlockerView | 
     terminal: detail['terminal'] === true,
     guarded: detail['guarded'] === true,
   };
+};
+
+/**
+ * The exit blocker's live detail off the state this tick just committed, read for the same reason the protective-stop view above is: the stored condition row's `detail` froze when the span opened, so on the aged span this alert waits for it names a stop price the strategy has long since moved past.
+ *
+ * The reason is deliberately not returned. The condition row written from this same state carries it, and that row is what the alert gates on, so re-testing it here would be a second comparison the first one has already decided.
+ *
+ * Only the `detail` check decides anything at the call site: reaching it needs an `exit-blocked` row whose code is the unplaced one, and that code was read off THIS same object by the condition writer, which yields a code only when the state and its `exitBlocker` are both shaped objects. The two checks above it restate that proof rather than make it, and they stay because the helper is exercised on its own and because a strategy that publishes a blocker with no `detail` is a real shape this must answer `{}` for.
+ *
+ * @param state - The `nextState` this tick produced, untyped because the handler is strategy-agnostic and only this one field concerns it.
+ * @returns The blocker's detail record, empty when the strategy reported no exit blocker or no detail for it.
+ */
+const readExitBlockerDetail = (state: unknown): Readonly<Record<string, unknown>> => {
+  if (typeof state !== 'object' || state === null) return {};
+  const raw = (state as Record<string, unknown>)['exitBlocker'];
+  if (typeof raw !== 'object' || raw === null) return {};
+  const detail = (raw as Record<string, unknown>)['detail'];
+  return typeof detail === 'object' && detail !== null ? (detail as Record<string, unknown>) : {};
 };
 
 export const createTickHandler = (
@@ -498,10 +518,11 @@ export const createTickHandler = (
         // Past this line an order may be on the wire, so an abort can no longer
         // re-arm the override: the next tick would place a second one under a fresh
         // clientOrderId, which Binance's open-order dedup does not catch. Coarse on
-        // purpose (any place-order, not just the override's) — the same fail-safe the
-        // defer path applies, and for the same reason: no plugin is trusted to have
-        // stamped the override id on the order it emitted. `cancel-order` alone does
-        // not trip it, matching that same scoping: nothing can be left resting.
+        // purpose (any placement — a `place-order` or a `replace-order`, not just the
+        // override's) — the same fail-safe the defer path applies, and for the same
+        // reason: no plugin is trusted to have stamped the override id on the order it
+        // emitted. `cancel-order` alone does not trip it, matching that same scoping:
+        // nothing can be left resting.
         if (placementDecision !== undefined && !refusalGate.defer) {
           overrideTicket.markOrderAttempted();
         }
@@ -544,10 +565,12 @@ export const createTickHandler = (
         // Whether it is SAFE to commit turns on THE PLACEMENT, and on its `phase`
         // ALONE. Two separate traps here:
         //
-        //  - Not on the FIRST failed order. Momentum's exit emits [cancel(stop),
-        //    MARKET SELL] with a FLAT nextState. A cancel that dies on a transport
-        //    error returns `ambiguous`; the chain breaks and the SELL is stamped
-        //    SKIPPED — never transmitted. Reading the CANCEL's phase would say
+        //  - Not on the FIRST failed order. A batch shaped [cancel(stop), MARKET
+        //    SELL] with a FLAT nextState — a contract the executor must still handle,
+        //    though both strategies now fuse that pair into one `replace-order` — is
+        //    the case that bites. A cancel that dies on a transport error returns
+        //    `ambiguous`; the chain breaks and the SELL is stamped SKIPPED — never
+        //    transmitted. Reading the CANCEL's phase would say
         //    "accepted/ambiguous ⇒ commit", and the bot would record itself flat while
         //    the coin is still in the wallet and its stop may still be resting. The
         //    question `nextState` hangs on is whether the ORDER IT ASSUMED WAS PLACED
@@ -869,14 +892,9 @@ export const createTickHandler = (
         // problem and would train them to ignore the naked case. Fire-and-forget
         // for the same reasons as the order-failed alert above.
         //
-        // Scoped to the BAND refusal, and only that one. The message below tells
-        // the operator to widen the stop offset, which is the wrong instruction
-        // for a base-sizing refusal — and only the band classifier publishes
-        // `guarded` / `terminal` at all, so on the three sizing reasons both read
-        // false: an absent `guarded` would be taken as "nothing is protecting
-        // this", while the sizing branch explicitly leaves any resting stop in
-        // place. The CONDITION row stays generic for all four reasons; it is the
-        // notification, whose copy tells one story, that is narrowed here.
+        // Scoped to the BAND refusal, and only that one. The message below tells the operator to widen the stop offset, which is the wrong instruction for a base-sizing refusal. `terminal` is published by the band classifier alone, and `guarded` by the band classifier and the full-size refusal (which leaves any resting stop in place and reports whether it still covers the holding); the foreign-lock and partial-size refusals publish neither, so an absent `guarded` there would be taken as "nothing is protecting this". The CONDITION row stays generic for all four reasons; it is the notification, whose copy tells one story, that is narrowed here, and the sizing reasons still owe an alert of their own.
+        // Whether the band alert below passed its TICK-SIDE gate, which is not the same as a band blocker existing: most of them are guarded, sub-window, or a reason that alert does not cover. It is not proof of delivery either — the send is fire-and-forget and the notifier's own hourly window can still drop it — but that window is the same hour and keyed on the same coin as the unplaced one below, so a dropped band send means the operator has already been told about this coin inside the hour. Suppressing on the gate rather than on delivery is therefore what keeps the unplaced alert from being a second page about one position.
+        let bandAlertFired = false;
         const stopBlocker = readProtectiveStopBlocker(output.nextState);
         if (
           stopBlocker !== null &&
@@ -893,6 +911,7 @@ export const createTickHandler = (
           const heldLongEnough =
             sinceMs !== null && clock.nowMs() - sinceMs >= PROTECTIVE_STOP_BLOCKED_PERSISTENCE_MS;
           if (stopBlocker.terminal || heldLongEnough) {
+            bandAlertFired = true;
             const notify = deps.notifyProtectiveStopBlocked;
             void callAsync(() =>
               notify({
@@ -912,6 +931,40 @@ export const createTickHandler = (
               );
             });
           }
+        }
+
+        // The block above reports one named CAUSE — the exchange's price band refuses the stop. This one reports the OUTCOME: whatever the cause, the position is held and nothing is resting on the exchange that would sell it. That covers every refusal the band classifier never sees, and it is the state the strategy re-reports on every tick without anything ever escalating it.
+        //
+        // Only the duration separates it from an entry that opened a second ago, so the span is the whole signal — which makes picking the row that dates it the whole job. The CODE is the gate, not the condition: `AUDITED_BLOCKERS` writes exactly one `exit-blocked` row per symbol per tick whatever the reason is, so matching on the condition alone would hand this the span of a `priced-stop-resting` row and page the operator about a fully guarded position. Reading the code off the row rather than re-testing the live state keeps one comparison: the row that dates the span is the row that has to be about this state, and a second test against the state would be a guard the first one already decided.
+        const unplacedSinceMs = writtenConditions.find(
+          (w) => w.condition === 'exit-blocked' && w.code === PROTECTIVE_STOP_UNPLACED_CODE,
+        )?.sinceMs;
+        // Fails CLOSED on an undated span, unlike the band alert above. That one has `terminal`, an independent span-free signal that something is permanently wrong, so it can fire without an age. There is no such signal here: without the span this is indistinguishable from the tick right after an entry, and firing anyway would page on every new position each time `recordCondition` threw and `createBlockerAudit` swallowed it. The row is re-read next tick, so a lost write costs one tick of delay, not the alert.
+        //
+        // Suppressed when the band alert already went out this tick: both describe the same unguarded coin, and the band one carries the more specific instruction.
+        if (
+          unplacedSinceMs !== null &&
+          unplacedSinceMs !== undefined &&
+          !bandAlertFired &&
+          clock.nowMs() - unplacedSinceMs >= PROTECTIVE_STOP_UNPLACED_PERSISTENCE_MS &&
+          deps.notifyProtectiveStopUnplaced
+        ) {
+          const notify = deps.notifyProtectiveStopUnplaced;
+          void callAsync(() =>
+            notify({
+              operatorId,
+              accountId,
+              profileId,
+              symbol,
+              sinceMs: unplacedSinceMs,
+              detail: readExitBlockerDetail(output.nextState),
+            }),
+          ).catch((err: unknown) => {
+            deps.logger.warn(
+              { profileId, symbol, err: err },
+              'tick-handler: could not notify the operator that a position has no protective stop resting',
+            );
+          });
         }
 
         // Audit batch. The payload is what the raw tick trace serves verbatim,

--- a/apps/worker/src/tick/tick-types.ts
+++ b/apps/worker/src/tick/tick-types.ts
@@ -223,6 +223,21 @@ export interface TickHandlerDeps {
     readonly sinceMs: number | null;
   }) => Promise<void>;
   /**
+   * Tells the operator a held position has NO protective stop resting on the exchange, whatever the cause. The outcome to {@link notifyProtectiveStopBlocked}'s one named cause: that one fires when the exchange's price band refuses the stop, this one covers every other way a stop fails to reach Binance, including the ones no classifier sees.
+   *
+   * Only the duration separates this state from an entry that opened a second ago, so `sinceMs` is the whole signal and the tick declines to fire without it. Owns its own repeat suppression on a key separate from the band alert's, so the two cannot mute each other on exactly the coin where both matter; the tick fires it and does not wait.
+   */
+  readonly notifyProtectiveStopUnplaced?: (input: {
+    readonly operatorId: UserId;
+    readonly accountId: AccountId;
+    readonly profileId: ProfileId;
+    readonly symbol: string;
+    /** When the position was first seen unguarded, off the dated condition row. Never null: the tick withholds the alert rather than page without an age. */
+    readonly sinceMs: number;
+    /** The strategy's own `exitBlocker.detail`, or `{}` when the bag did not survive the round-trip. Every field it may carry is optional to the copy. */
+    readonly detail: Readonly<Record<string, unknown>>;
+  }) => Promise<void>;
+  /**
    * Reap a (profile, symbol) binding that can never trade again — Binance no
    * longer lists the symbol, or the account holds no permission for it — but
    * ONLY when it is safe to abandon: UNPINNED and flat.

--- a/packages/strategy/core/src/index.ts
+++ b/packages/strategy/core/src/index.ts
@@ -101,7 +101,7 @@ export {
 export type { EntryStopFloor, SizeFilters } from './sizing.js';
 export { log, metric } from './emit.js';
 export { MAX_CANDLE_WINDOW, resolveCandleWindow } from './window.js';
-export { explainProtectiveStopBandRefusal } from './protective-stop-gloss.js';
+export { asPercent, explainProtectiveStopBandRefusal } from './protective-stop-gloss.js';
 export type { ProtectiveStopBandExplanation } from './protective-stop-gloss.js';
 export {
   PROTECTIVE_STOP_BLOCKER_REASONS,

--- a/packages/strategy/core/src/protective-stop-gloss.ts
+++ b/packages/strategy/core/src/protective-stop-gloss.ts
@@ -12,12 +12,21 @@ import { decOrNull } from './balances.js';
 // SPA reads it back off a JSON projection, so every field is untrusted and a
 // missing one must drop its clause rather than leak `undefined` into a sentence.
 
-/** Percent for an operator: two places, never exponential, or null when the input is not a usable number. */
-const asPercent = (raw: unknown): string | null => {
+/**
+ * Render a stored fraction as the percent the operator's own settings screen shows, or null when it is not a usable number.
+ *
+ * The strategies store these as fractions and the settings form displays percent, so quoting the stored value verbatim would name a number the operator cannot find on any screen. Exported because the push alert and the screen both format one, and a private copy on either side is how the two came to disagree about the same value before.
+ *
+ * Total by construction: every caller reads a sparse bag that has crossed a JSON round-trip, and this feeds operator copy, where a throw is worse than a missing clause and the string `undefined` is worse than both. `toFixed` rather than `toString` because decimal.js switches `toString` to exponential past its `toExpPos` decade, and `1e+23%` in a settings-shaped field reads as corruption.
+ *
+ * @param raw - A fraction of 1 as the strategy recorded it, normally a decimal string, but untrusted; a JSON number is accepted because the rounding below makes it exact at this scale and dropping the clause would tell the operator less for no safety gained.
+ * @returns The same value in percent, two places and never exponential, or null when the input is absent, not a number or string, or unparseable.
+ */
+export const asPercent = (raw: unknown): string | null => {
   if (typeof raw !== 'string' && typeof raw !== 'number') return null;
   try {
     const value = new Decimal(raw);
-    return value.isFinite() ? `${value.mul(100).toDecimalPlaces(2).toString()}%` : null;
+    return value.isFinite() ? `${value.mul(100).toDecimalPlaces(2).toFixed()}%` : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Motivation

The existing protective-stop alert only fires for one cause: the exchange's price band refusing the stop. Every other way a stop fails to reach the exchange left an `exit-blocked` condition row that the strategy re-reported every tick, with nothing ever escalating it, so a position could sit unguarded indefinitely without the operator being told.

Separately, the detached-fill reconciler's own terminal-status set was missing `EXPIRED_IN_MATCH`, the status Binance stamps when self-trade prevention kills an order, so on a shared account wallet an STP-terminated detached row never closed, holding its live intent slot and open exposure forever.

## Changes

- Add the `protective-stop-unplaced` alert (`apps/worker/src/tick/tick-handler.ts`): fires off the `exit-blocked` condition row carrying the unplaced code, gated on that row's age (`PROTECTIVE_STOP_UNPLACED_PERSISTENCE_MS`) so it cannot page about a position that opened moments ago. It fails closed on an undated span, unlike the band alert, since it has no independent span-free signal for a permanent fault.
- Suppress the new alert on any tick the band alert already fired (`bandAlertFired`), since both describe the same unguarded coin and the band one carries the more specific instruction. Give it its own throttle key (`createProtectiveStopUnplacedThrottle`, `PROTECTIVE_STOP_UNPLACED_KEY_PREFIX`) so the two alerts cannot mute each other on exactly the coin where both matter.
- Wire `protectiveStopUnplacedThrottle` through `apps/worker/src/boot/builders/notifiers.ts` and `apps/worker/src/boot/boot-context.ts`.
- Reorder the band alert's explanation parsing to happen before its throttle window opens, so a detail it cannot parse no longer throws after the key is already set, which previously lost that alert and muted the next hour of them.
- `apps/worker/src/tick/build-tick-input.ts`: the protective-stop change key now carries whether a stop is resting, presence only, not quantity, so a guarded to naked flip under the same reason is no longer dropped as a no-op.
- `apps/worker/src/executor/fill-adopter.ts`: replace the local four-member terminal-status set with the shared `isTerminalOrderStatus` predicate from `@app/contracts`, closing the `EXPIRED_IN_MATCH` leak.
- Add `apps/worker/__tests__/executor/fill-adopter-detached-terminal.test.ts` and `apps/worker/__tests__/tick/tick-handler-protective-stop-unplaced-alert.test.ts`; extend `builders/tick-handler.test.ts`, `notifier-gap-throttle.test.ts`, and `build-tick-input.test.ts` for the new alert and key.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` clean
- [x] Manual: verified via the added unit tests, including `tick-handler-protective-stop-unplaced-alert.test.ts` (alert gating on row age, suppression when the band alert fired, own throttle key) and `fill-adopter-detached-terminal.test.ts` (`EXPIRED_IN_MATCH` now closes a detached row).

## Breaking changes

None.

## Stack

This is PR 8 of a 10-PR stack. #777 has merged, so this now targets `main` directly; #779 is stacked on top of it. The stack must merge bottom-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRceiDYdzzHo6aLFr4sZPj



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added protective-stop-unplaced alerts when a position remains without a protective stop for at least 15 minutes.
  - Alerts include timing and available diagnostic details, with hourly notification throttling.
  - Protective-stop and band-refusal alerts now use separate cooldowns.

- **Bug Fixes**
  - Improved detached-order reconciliation for terminal and case-variant statuses.
  - Preserved accurate filled-order totals during reconciliation.
  - Improved protective-stop condition tracking when stops become unplaced.
  - Improved percentage formatting in protective-stop messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->